### PR TITLE
Fix document type mismatch and repo hygiene

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,17 +1,14 @@
-name: Typecheck & Prisma Validate
+name: Lint
 
 on:
-  push:
-    branches: ["main", "**"]
   pull_request:
+    branches: ["main"]
+  push:
     branches: ["main"]
 
 jobs:
-  validate-and-typecheck:
+  lint:
     runs-on: ubuntu-latest
-    env:
-      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/phr_companion?schema=public
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -25,8 +22,5 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Validate Prisma schema
-        run: npm run db:validate:ci
-
-      - name: Type check
-        run: npm run typecheck
+      - name: Run ESLint
+        run: npm run lint

--- a/README.md
+++ b/README.md
@@ -1,553 +1,157 @@
 # VitaVault
 
-![Next.js](https://img.shields.io/badge/Next.js-15-black?style=for-the-badge&logo=next.js)
-![React](https://img.shields.io/badge/React-19-149eca?style=for-the-badge&logo=react)
-![TypeScript](https://img.shields.io/badge/TypeScript-5.8-blue?style=for-the-badge&logo=typescript)
-![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-3.4-38bdf8?style=for-the-badge&logo=tailwind-css)
-![Prisma](https://img.shields.io/badge/Prisma-6.x-2D3748?style=for-the-badge&logo=prisma)
-![PostgreSQL](https://img.shields.io/badge/PostgreSQL-16-336791?style=for-the-badge&logo=postgresql)
-![Auth.js](https://img.shields.io/badge/Auth.js-5-black?style=for-the-badge)
-![BullMQ](https://img.shields.io/badge/BullMQ-Redis-red?style=for-the-badge)
-![License](https://img.shields.io/badge/License-MIT-green?style=for-the-badge)
+**VitaVault** is a business-focused personal health record platform built to feel like a real product, not a classroom CRUD app. It combines structured medical record management, AI-assisted summaries, care collaboration, alerts, reminders, exports, and background job processing into one polished health workspace.
 
-A full-stack personal health record platform for structured health tracking, shared care access, AI summaries, alert workflows, and mobile/device ingestion foundations.
+<p align="center">
+  <img src=".mkdir/Landing-Page.jpg" alt="VitaVault Landing Page" width="100%" />
+</p>
 
----
+## Product Positioning
 
-## Overview
+VitaVault is designed around a simple idea: health records should be **organized, reviewable, shareable, and operationally useful**.
 
-VitaVault is a Next.js healthcare workspace that brings personal record management, collaboration controls, and operational backend infrastructure into one authenticated app.
+Instead of scattering information across notes, messages, PDFs, and memory, VitaVault brings everything into a single system with:
+- patient-facing record management
+- care-team sharing foundations
+- reminder and alert workflows
+- AI-assisted record summaries
+- background jobs for asynchronous processing
+- exportable clinical data views
+- operational visibility for product/admin workflows
 
-It is built around a few core ideas:
+## Core Highlights
 
-- keep personal health records organized in one place
-- support collaboration through care-team invites and scoped access
-- turn passive record storage into actionable workflows with alerts and background jobs
-- prepare the data model for device sync and mobile ingestion
+### Unified Health Record Workspace
+- Health profile and baseline patient context
+- Medications and adherence tracking
+- Appointments and care follow-ups
+- Lab result tracking
+- Vitals trend logging
+- Symptom journaling
+- Vaccination records
+- Document upload and organization
+- Doctor directory and linked care context
 
-Users can manage:
+### Collaboration and Review
+- Care-team invite flows
+- Shared access foundations
+- Review queue concepts for triage-style workflows
+- Timeline-style activity and record linking
 
-- health profile and baseline medical context
-- medications, schedules, and adherence logs
-- appointments, doctors, labs, vitals, symptoms, vaccinations, and documents
-- AI-generated health insights
-- care-team invites and shared access
-- alert events and monitoring rules
-- device connections, sync jobs, and reading ingestion foundations
+### Intelligence and Monitoring
+- AI-generated health summaries and insight surfaces
+- Alert rules and alert event tracking foundations
+- Reminder center for due and overdue actions
+- Device connection and sync foundations
 
----
+### Operational Foundations
+- BullMQ + Redis background jobs
+- Job runs and queue visibility
+- Export workflows
+- Audit-minded data modeling
+- Prisma-backed schema for a serious product surface
+
+## Feature Surface
+
+| Area | What VitaVault Covers |
+|---|---|
+| Authentication | Secure sign-in and protected app access |
+| Patient Records | Health profile, medications, labs, vitals, symptoms, vaccinations, documents |
+| Care Collaboration | Invite workflows and shared access foundations |
+| AI Layer | Insight generation and summary experiences |
+| Alerts & Reminders | Rule-driven alerting foundation and task tracking |
+| Exports | Structured exports for selected record areas |
+| Device / Mobile | Device connection, mobile auth, and reading sync groundwork |
+| Jobs & Ops | Worker queues, job dispatch, logs, and operational visibility |
 
 ## Architecture Snapshot
 
 ### Frontend
-- Next.js App Router
+- Next.js 15 App Router
 - React 19
 - TypeScript
 - Tailwind CSS
-- shadcn/ui-style component stack
-- lucide-react icons
-- Recharts for charting
-- Framer Motion included in the dependency stack
+- Framer Motion
+- Lucide icons
 
-### Backend
-- Server Components and Server Actions
-- Auth.js / NextAuth authentication
+### Backend / Platform
+- Auth.js / NextAuth
 - Prisma ORM
 - PostgreSQL
-- Zod validation
-- protected route and ownership checks
-- export routes and internal API routes
-
-### Jobs & Workers
-- BullMQ queues
-- Redis-backed worker connection
-- dedicated worker runtime
-- job dispatch endpoints
-- persisted job runs and job logs
-- alert scanning support
-
-### Data Layer
-The current domain model covers:
-
-- `User`
-- `HealthProfile`
-- `Medication`
-- `MedicationSchedule`
-- `MedicationLog`
-- `Appointment`
-- `Doctor`
-- `LabResult`
-- `VitalRecord`
-- `SymptomEntry`
-- `VaccinationRecord`
-- `MedicalDocument`
-- `Reminder`
-- `CareAccess`
-- `CareInvite`
-- `AccessAuditLog`
-- `AiInsight`
-- `DeviceConnection`
-- `DeviceReading`
-- `MobileSessionToken`
-- `SyncJob`
-- `JobRun`
-- `JobRunLog`
-- `AlertRule`
-- `AlertEvent`
-- `AlertAuditLog`
-
----
-
-## Key Product Areas
-
-### 1. Health Record Management
-- Health profile with allergies, chronic conditions, blood type, height, weight, and emergency contact details
-- Medication plans with schedules and adherence logging
-- Appointment tracking with follow-up context
-- Doctor and clinic directory
-- Lab result logging
-- Vitals history
-- Symptom journal
-- Vaccination records
-- Medical document storage
-- Summary and export flows
-
-### 2. Care Collaboration
-- Care-team invite flow
-- permission-based shared access
-- patient sharing foundation
-- access audit trail support
-- shared-care visibility considerations for alerts
-
-### 3. Alerting & Monitoring
-- threshold-based alert engine foundation
-- alert categories for vitals, medication adherence, symptom severity, and sync health
-- severity levels and lifecycle states
-- source-linked alert events
-- alert audit trail
-- worker-backed evaluation and scheduled scans
-
-### 4. Mobile & Device Readiness
-- device connection tracking
-- sync job tracking
-- reading ingestion foundation
-- mirrored supported readings into `VitalRecord`
-- mobile token authentication foundation
-- reading source modeling for manual and connected inputs
-
-### 5. AI & Summaries
-- AI-generated health summaries
-- stored insight records
-- follow-up and summary-oriented workflow positioning
-
----
-
-## Engineering Features
-
-### Authentication & Access Control
-- credential-based authentication
-- protected app routes
-- secure password hashing
-- ownership enforcement on user-scoped data
-- shared-access permission checks
-- mobile bearer-token foundation for sync flows
-
-### Validation & Data Safety
-- Zod-backed server validation
-- route-level ownership checks
-- cross-user access prevention
-- audit logging for access and alerts
-- file/document handling foundation
-
-### Alert Engine
-- alert rules with configurable conditions
-- cooldown-based duplicate suppression
-- status transitions: open, acknowledged, resolved, dismissed
-- source references back to triggering records
-- alert event audit logging
-- care-team visibility controls
-
-### Queue / Worker System
-- BullMQ-based queue layer
-- Redis-backed queue connection
-- dedicated worker entrypoint
-- job metadata persistence
-- job logs for operational visibility
-- queue dashboard support
-
-### Device / Sync Pipeline
-- device connection records
-- sync job lifecycle tracking
-- ingestion support for:
-  - heart rate
-  - blood pressure
-  - blood glucose
-  - oxygen saturation
-  - temperature
-  - weight
-- normalized mirroring into `VitalRecord`
-
----
-
-## Feature Set
-
-### Authentication
-- sign up
-- login
-- logout
-- protected routes
-- demo seed support
-- secure password hashing
-- mobile auth foundation
-
-### Dashboard
-- command-center style layout
-- profile completion visibility
-- alert visibility
-- reminders panel
-- next medication summary
-- vitals summary
-- appointment summary
-- quick navigation workspace
-
-### Health Records
-- health profile management
-- medication schedules
-- adherence logging with Taken / Missed / Skipped
-- duplicate same-day medication logging protection
-- appointments
-- labs
-- vitals
-- symptoms
-- vaccinations
-- documents
-- doctors
-- summary page
-- export routes
-
-### Collaboration & AI
-- AI insight generation
-- care-team invite creation and acceptance
-- shared workspace foundation
-- permission-aware collaboration
-- audit logging for access and alerts
-
-### Jobs & Infrastructure
-- jobs dashboard
-- internal dispatch routes
-- worker runtime
-- job persistence and logs
-- alert scan script
-
-### Mobile & Device Readiness
-- device connection page
-- sync job support
-- reading ingestion foundation
-- mirrored readings into vitals
-- Android-oriented backend readiness
-
----
-
-### Core Experience
-
-| Dashboard | Health Profile |
-|---|---|
-| <img src=".mkdir/Dashboard.jpg" alt="Dashboard" width="100%"> | <img src=".mkdir/Health-Profile.jpg" alt="Health Profile" width="100%"> |
-
-| Medications | Appointments |
-|---|---|
-| <img src=".mkdir/Medications.jpg" alt="Medications" width="100%"> | <img src=".mkdir/Appointments.jpg" alt="Appointments" width="100%"> |
-
-| Labs | Exports |
-|---|---|
-| <img src=".mkdir/Lab-Results.jpg" alt="Lab Results" width="100%"> | <img src=".mkdir/Exports-Page.jpg" alt="Exports Page" width="100%"> |
-
-### Collaboration & Intelligence
-
-| AI Insights | Care Team |
-|---|---|
-| <img src=".mkdir/AI-Insights.jpg" alt="AI Insights" width="100%"> | <img src=".mkdir/Care-Team.jpg" alt="Care Team" width="100%"> |
-
-| Alert Center | Device Connections |
-|---|---|
-| <img src=".mkdir/Alert-Center.jpg" alt="Alert Center" width="100%"> | <img src=".mkdir/Device-Connections.jpg" alt="Device Connections" width="100%"> |
-
-### Clinical Records
-
-| Vaccinations | Doctors |
-|---|---|
-| <img src=".mkdir/Vaccinations.jpg" alt="Vaccinations" width="100%"> | <img src=".mkdir/Doctors.jpg" alt="Doctors" width="100%"> |
-
-| Summary | Vitals |
-|---|---|
-| <img src=".mkdir/Summary.jpg" alt="Summary" width="100%"> | <img src=".mkdir/Vitals.jpg" alt="Vitals" width="100%"> |
-
-| Symptoms | Documents |
-|---|---|
-| <img src=".mkdir/Symptoms.jpg" alt="Symptoms" width="100%"> | <img src=".mkdir/Documents.jpg" alt="Documents" width="100%"> |
-
-### Entry Screens
-
-| Landing Page | Login Page |
-|---|---|
-| <img src=".mkdir/Landing-Page.jpg" alt="Landing Page" width="100%"> | <img src=".mkdir/Login-Page.jpg" alt="Login Page" width="100%"> |
-
----
-
-## Tech Stack
-
-- **Next.js 15**
-- **React 19**
-- **TypeScript**
-- **Tailwind CSS**
-- **Prisma ORM**
-- **PostgreSQL**
-- **Auth.js / NextAuth**
-- **Zod**
-- **BullMQ**
-- **Redis**
-- **Recharts**
-- **lucide-react**
-- **Framer Motion**
-
----
-
-## Repository Structure
-
-```text
-personal-health-record-companion/
-├── .github/
-│   ├── ISSUE_TEMPLATE/
-│   ├── workflows/
-│   └── pull_request_template.md
-├── app/
-│   ├── (auth)/
-│   ├── ai-insights/
-│   ├── alerts/
-│   ├── api/
-│   │   ├── internal/
-│   │   └── mobile/
-│   ├── appointments/
-│   ├── care-team/
-│   ├── dashboard/
-│   ├── device-connections/
-│   ├── doctors/
-│   ├── documents/
-│   ├── exports/
-│   ├── health-profile/
-│   ├── invite/
-│   ├── jobs/
-│   ├── labs/
-│   ├── medications/
-│   ├── signup/
-│   ├── summary/
-│   ├── symptoms/
-│   ├── vaccinations/
-│   ├── vitals/
-│   ├── actions.ts
-│   ├── globals.css
-│   ├── layout.tsx
-│   └── page.tsx
-├── components/
-│   ├── alerts/
-│   └── ...
-├── lib/
-│   ├── alerts/
-│   ├── jobs/
-│   └── ...
-├── prisma/
-│   ├── migrations/
-│   ├── schema.prisma
-│   └── seed.ts
-├── scripts/
-├── worker/
-│   └── processors/
-├── public/uploads/
-├── types/
-├── .env.example
-├── middleware.ts
-├── package.json
-├── tailwind.config.ts
-├── tsconfig.json
-└── README.md
-```
-
----
-
-## Main Routes
-
-- `/`
-- `/login`
-- `/signup`
-- `/dashboard`
-- `/ai-insights`
-- `/care-team`
-- `/alerts`
-- `/device-connections`
-- `/health-profile`
-- `/medications`
-- `/appointments`
-- `/labs`
-- `/vitals`
-- `/symptoms`
-- `/vaccinations`
-- `/documents`
-- `/doctors`
-- `/summary`
-- `/exports`
-- `/jobs`
-
----
-
-## Demo User
-
-```text
-Email: demo@health.local
-Password: demo12345
-```
-
----
-
-## Local Setup
-
-### 1. Install dependencies
-
-```bash
-npm install
-```
-
-### 2. Create `.env`
-
-```env
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/phr_companion?schema=public"
-AUTH_SECRET="your-long-random-secret"
-AUTH_TRUST_HOST="true"
-NEXTAUTH_URL="http://localhost:3000"
-OPENAI_API_KEY="your-openai-key"
-OPENAI_MODEL="gpt-4.1-mini"
-REDIS_URL="redis://localhost:6379"
-```
-
-### 3. Prepare database
-
-```bash
-npm run db:push
-```
-
-### 4. Seed demo data
-
-```bash
-npm run seed
-```
-
-### 5. Run the app
-
-```bash
-npm run dev
-```
-
-### 6. Run the worker
-
-```bash
-npm run worker
-```
-
-### 7. Optional checks
-
-```bash
-npm run typecheck
-npm run build
-```
-
----
-
-## Useful Scripts
-
-```bash
-npm run dev
-npm run build
-npm run start
-npm run seed
-npm run db:push
-npm run db:migrate
-npm run typecheck
-npm run worker
-```
-
----
-
-## Export Routes
-
-- `/exports/appointments`
-- `/exports/medications`
-- `/exports/labs`
-- `/exports/vitals`
-
----
-
-## Why This Repo Reads Well
-
-- It goes beyond single-module CRUD and models a broader healthcare workspace.
-- It combines product UI, collaboration rules, alert flows, AI summaries, and sync foundations.
-- It includes background job infrastructure instead of only synchronous page logic.
-- It shows both user-facing product work and backend systems thinking.
-- It is a strong pinned project because it demonstrates domain modeling, authorization, jobs, and applied product design in one repo.
-
----
-
-## Future Work
-
-- fuller edit/delete coverage across all modules
-- notification delivery channels
-- production-grade Health Connect sync
-- Apple Health and wearable integrations
-- better document categorization and search
-- expanded activity logs and audit views
-- object storage for uploads
-- OCR-assisted data extraction
-- richer AI longitudinal summaries
-- offline/PWA workflows
-- interoperability / FHIR direction
-
----
+- BullMQ
+- Redis
+- Zod validations
+
+### Product Design Goals
+- premium SaaS-style UI
+- health-record-first workflows
+- extensible data model
+- portfolio-quality structure with business use potential
+- scalable foundation for reminders, alerts, exports, and collaboration
+
+## Gallery
+
+<p align="center">
+  <img src=".mkdir/Dashboard.jpg" alt="Dashboard" width="48%" />
+  <img src=".mkdir/Health-Profile.jpg" alt="Health Profile" width="48%" />
+</p>
+<p align="center">
+  <img src=".mkdir/Medications.jpg" alt="Medications" width="48%" />
+  <img src=".mkdir/Lab-Results.jpg" alt="Lab Results" width="48%" />
+</p>
+<p align="center">
+  <img src=".mkdir/Vitals.jpg" alt="Vitals" width="48%" />
+  <img src=".mkdir/Documents.jpg" alt="Documents" width="48%" />
+</p>
+<p align="center">
+  <img src=".mkdir/Care-Team.jpg" alt="Care Team" width="48%" />
+  <img src=".mkdir/Alert-Center.jpg" alt="Alert Center" width="48%" />
+</p>
+<p align="center">
+  <img src=".mkdir/AI-Insights.jpg" alt="AI Insights" width="48%" />
+  <img src=".mkdir/Exports-Page.jpg" alt="Exports" width="48%" />
+</p>
+
+## Why This Repo Stands Out
+
+VitaVault is not just a UI concept. The repo already includes:
+- a real Prisma domain model
+- modular route structure across many health workflows
+- background worker scaffolding
+- queue/job visibility
+- care-access modeling
+- upload handling
+- AI integration foundations
+- export/report surfaces
+
+That gives it stronger product depth than a typical demo health tracker.
+
+## Current Product Direction
+
+The project is moving toward a more complete business-ready platform with focus on:
+- stronger record integrity
+- cleaner collaboration flows
+- deeper reporting and exports
+- hardened internal APIs
+- improved operational health tooling
+- better test and CI confidence
+
+## Repository Standards
+
+The repo includes GitHub-first hygiene to support iterative PR-based development:
+- pull request template
+- issue templates
+- CI for Prisma validation, typecheck, and linting
+- dedicated lint workflow for fast PR signal
+
+## Suggested PR Theme for This Phase
+
+**Phase 01 — Data Integrity and Repo Hygiene**
+- fix document type mismatch in the Documents module
+- align device connection route references
+- upgrade repository presentation in README
+- add lint automation for pull requests
 
 ## License
 
-MIT
-
-
-## Local Prisma setup
-
-1. Copy `.env.example` to `.env`
-2. Replace `DATABASE_URL` with your real PostgreSQL connection string
-3. Run:
-
-```bash
-npm install
-npm run db:validate
-npx prisma generate
-npm run typecheck
-```
-
-If `npm run db:validate` fails with `Environment variable not found: DATABASE_URL`, your `.env` file is missing or `DATABASE_URL` is not set yet.
-
----
-
-## Action Layer Safety Checks
-
-Before pushing changes that touch `app/actions.ts` or any page importing from it, run:
-
-```bash
-npm run actions:check
-npm run actions:imports
-npm run actions:shadow
-npm run typecheck
-```
-
-What these do:
-
-- `actions:check` verifies the expected action export contract still exists.
-- `actions:imports` scans page imports from `@/app/actions` and confirms every imported symbol is actually exported.
-- `actions:shadow` catches temp files, backup files, and patch leftovers that can confuse future maintenance.
-
-This is meant to stop regressions where a later patch accidentally replaces `app/actions.ts` and drops older exports that existing pages still rely on.
+This project is released under the MIT License.

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -83,9 +83,9 @@ export default async function DocumentsPage({
                     <Select name="type" defaultValue="OTHER">
                       <option value="LAB_RESULT">Lab Result</option>
                       <option value="PRESCRIPTION">Prescription</option>
-                      <option value="IMAGING">Imaging</option>
+                      <option value="SCAN">Imaging / Scan</option>
                       <option value="DISCHARGE_SUMMARY">Discharge Summary</option>
-                      <option value="CONSULT_NOTE">Consult Note</option>
+                      <option value="CERTIFICATE">Consult / Medical Certificate</option>
                       <option value="OTHER">Other</option>
                     </Select>
                   </div>
@@ -182,9 +182,9 @@ export default async function DocumentsPage({
                                 <Select name="type" defaultValue={document.type}>
                                   <option value="LAB_RESULT">Lab Result</option>
                                   <option value="PRESCRIPTION">Prescription</option>
-                                  <option value="IMAGING">Imaging</option>
+                                  <option value="SCAN">Imaging / Scan</option>
                                   <option value="DISCHARGE_SUMMARY">Discharge Summary</option>
-                                  <option value="CONSULT_NOTE">Consult Note</option>
+                                  <option value="CERTIFICATE">Consult / Medical Certificate</option>
                                   <option value="OTHER">Other</option>
                                 </Select>
                               </div>

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -151,7 +151,7 @@ export function AppShell({ children }: AppShellProps) {
       "/ai-insights",
       "/care-team",
       "/alerts",
-      "/device-connections",
+      "/device-connection",
     ]);
 
     const records = primaryRoutes.filter(
@@ -161,7 +161,7 @@ export function AppShell({ children }: AppShellProps) {
           "/ai-insights",
           "/care-team",
           "/alerts",
-          "/device-connections",
+          "/device-connection",
           "/summary",
         ].includes(r.href)
     ) as AppRouteItem[];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,18 @@
+import nextVitals from "eslint-config-next/core-web-vitals";
+
+const config = [
+  ...nextVitals,
+  {
+    ignores: [
+      ".next/**",
+      "node_modules/**",
+      "coverage/**",
+      "dist/**",
+      "build/**",
+      "public/uploads/**",
+      "prisma/generated/**",
+    ],
+  },
+];
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -10,17 +10,18 @@
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate dev",
     "typecheck": "tsc --noEmit",
+    "lint": "next lint",
     "worker": "tsx --env-file=.env worker/index.ts",
     "worker:dev": "tsx watch --env-file=.env worker/index.ts",
     "postinstall": "prisma generate",
     "reminders:scan": "tsx scripts/scan-reminders.ts",
     "db:validate": "node scripts/prisma-validate.cjs",
     "db:validate:ci": "prisma validate",
-    "check": "npm run db:validate && npm run typecheck",
+    "check": "npm run db:validate && npm run lint && npm run typecheck",
     "actions:check": "node scripts/check-action-exports.cjs",
     "actions:imports": "node scripts/check-page-action-imports.cjs",
     "actions:shadow": "node scripts/check-shadow-action-files.cjs",
-    "verify": "npm run actions:check && npm run actions:imports && npm run actions:shadow && npm run typecheck"
+    "verify": "npm run actions:check && npm run actions:imports && npm run actions:shadow && npm run lint && npm run typecheck"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.10.0",


### PR DESCRIPTION
## Summary
- fixed invalid document enum values used by the Documents page
- aligned Device Connections route references in navigation grouping
- rewrote README to present VitaVault as a product showcase
- added ESLint config
- added dedicated lint workflow
- cleaned up CI naming

## Why this matters
This removes a real app-level mismatch that could break document saves/edits, improves repo credibility, and gives future PRs faster quality feedback.

## Testing
- [ ] Open Documents page
- [ ] Create a new document
- [ ] Edit an existing document
- [ ] Confirm sidebar grouping still works
- [ ] Confirm GitHub Actions runs on PR