### PR TITLE
Harden internal alert routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,4 @@ JOB_DASHBOARD_LIMIT="20"
 # Optional, but AI insight features will be disabled without these.
 OPENAI_API_KEY=""
 OPENAI_MODEL="gpt-5-mini"
+INTERNAL_API_SECRET=

--- a/app/api/internal/alerts/evaluate/route.ts
+++ b/app/api/internal/alerts/evaluate/route.ts
@@ -1,13 +1,67 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { enqueueAlertEvaluation } from "@/lib/jobs/enqueue";
+import {
+  authenticateInternalRequest,
+  canEvaluateAlertsForUser,
+} from "@/lib/internal-api-auth";
+
+const evaluateBodySchema = z.object({
+  userId: z.string().trim().min(1, "userId is required."),
+  sourceType: z
+    .enum([
+      "VITAL_RECORD",
+      "MEDICATION_LOG",
+      "SYMPTOM_ENTRY",
+      "SYNC_JOB",
+      "DEVICE_READING",
+      "SCHEDULED_SCAN",
+    ])
+    .nullable()
+    .optional(),
+  sourceId: z.string().trim().min(1).nullable().optional(),
+  sourceRecordedAt: z.string().trim().min(1).nullable().optional(),
+  initiatedBy: z
+    .enum(["record_create", "scheduled_scan", "manual_scan", "sync_finish"])
+    .optional(),
+});
 
 export async function POST(request: Request) {
-  const body = await request.json().catch(() => ({}));
+  const actor = await authenticateInternalRequest(request);
 
-  if (!body?.userId) {
+  if (!actor.ok) {
     return NextResponse.json(
-      { error: "userId is required." },
+      { error: "Unauthorized internal request." },
+      { status: 401 }
+    );
+  }
+
+  const parsed = evaluateBodySchema.safeParse(
+    await request.json().catch(() => ({}))
+  );
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: parsed.error.issues[0]?.message ?? "Invalid request body.",
+      },
       { status: 400 }
+    );
+  }
+
+  const body = parsed.data;
+
+  if (
+    actor.kind === "session" &&
+    !canEvaluateAlertsForUser({
+      actorId: actor.user.id,
+      actorRole: actor.user.role,
+      targetUserId: body.userId,
+    })
+  ) {
+    return NextResponse.json(
+      { error: "Forbidden for the requested user." },
+      { status: 403 }
     );
   }
 

--- a/app/api/internal/alerts/scan/route.ts
+++ b/app/api/internal/alerts/scan/route.ts
@@ -1,8 +1,31 @@
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { enqueueAlertScheduledScan } from "@/lib/jobs/enqueue";
+import {
+  authenticateInternalRequest,
+  canManageAllAlertScans,
+} from "@/lib/internal-api-auth";
 
-export async function POST() {
+export async function POST(request: Request) {
+  const actor = await authenticateInternalRequest(request);
+
+  if (!actor.ok) {
+    return NextResponse.json(
+      { error: "Unauthorized internal request." },
+      { status: 401 }
+    );
+  }
+
+  if (
+    actor.kind === "session" &&
+    !canManageAllAlertScans(actor.user.role)
+  ) {
+    return NextResponse.json(
+      { error: "Only admins can trigger a full alert scan." },
+      { status: 403 }
+    );
+  }
+
   const users = await db.user.findMany({
     select: { id: true },
   });

--- a/lib/internal-api-auth.ts
+++ b/lib/internal-api-auth.ts
@@ -1,0 +1,86 @@
+import { AppRole } from "@prisma/client";
+import { auth } from "@/lib/auth";
+
+type AuthenticatedRequestContext =
+  | {
+      ok: true;
+      kind: "session";
+      user: {
+        id: string;
+        role: AppRole;
+        email?: string | null;
+        name?: string | null;
+      };
+    }
+  | {
+      ok: true;
+      kind: "token";
+    }
+  | {
+      ok: false;
+    };
+
+function getBearerToken(request: Request) {
+  const authorization = request.headers.get("authorization") ?? "";
+  const directHeader = request.headers.get("x-internal-api-key") ?? "";
+
+  if (directHeader.trim()) {
+    return directHeader.trim();
+  }
+
+  if (authorization.toLowerCase().startsWith("bearer ")) {
+    return authorization.slice(7).trim();
+  }
+
+  return "";
+}
+
+export async function authenticateInternalRequest(
+  request: Request
+): Promise<AuthenticatedRequestContext> {
+  const session = await auth();
+
+  if (session?.user?.id) {
+    return {
+      ok: true,
+      kind: "session",
+      user: {
+        id: session.user.id,
+        role: session.user.role,
+        email: session.user.email,
+        name: session.user.name,
+      },
+    };
+  }
+
+  const configuredSecret = process.env.INTERNAL_API_SECRET?.trim();
+  const providedSecret = getBearerToken(request);
+
+  if (
+    configuredSecret &&
+    providedSecret &&
+    configuredSecret === providedSecret
+  ) {
+    return {
+      ok: true,
+      kind: "token",
+    };
+  }
+
+  return { ok: false };
+}
+
+export function canManageAllAlertScans(role: AppRole) {
+  return role === AppRole.ADMIN;
+}
+
+export function canEvaluateAlertsForUser(params: {
+  actorId: string;
+  actorRole: AppRole;
+  targetUserId: string;
+}) {
+  return (
+    params.actorId === params.targetUserId ||
+    params.actorRole === AppRole.ADMIN
+  );
+}


### PR DESCRIPTION
## Summary
- added shared auth helper for internal API requests
- restricted alert evaluation to self or admin when session-based
- restricted full alert scans to admin or internal secret
- added payload validation for alert evaluation
- documented INTERNAL_API_SECRET in env example

## Why this matters
This closes a real security gap in internal job dispatch behavior and makes alert triggering safer for production-style use.

## Testing
- [ ] logged-in user can evaluate alerts for own account
- [ ] logged-in non-admin cannot evaluate alerts for another user
- [ ] logged-in non-admin cannot trigger full alert scan
- [ ] admin can trigger full alert scan
- [ ] bearer secret works for internal calls when 