### PR TITLE
Fix ESLint flat config import path

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,4 @@
-import nextVitals from "eslint-config-next/core-web-vitals";
+import nextVitals from "eslint-config-next/core-web-vitals.js";
 
 const config = [
   ...nextVitals,


### PR DESCRIPTION
## Summary
- fixed the ESLint flat config import path for `eslint-config-next`

## Why this matters
The previous config used a module path that failed to resolve in this environment, causing `npm run lint` to fail before linting could even start.

## Testing
- [ ] run `npm run lint`
- [ ] confirm ESLint starts successfully