### PR TITLE
Fix ESLint flat config compatibility for Next.js

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,18 +1,26 @@
-import nextVitals from "eslint-config-next/core-web-vitals.js";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { FlatCompat } from "@eslint/eslintrc";
 
-const config = [
-  ...nextVitals,
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+export default [
+  ...compat.extends("next/core-web-vitals", "next/typescript"),
   {
     ignores: [
       ".next/**",
       "node_modules/**",
-      "coverage/**",
       "dist/**",
       "build/**",
+      "coverage/**",
+      "generated/**",
       "public/uploads/**",
-      "prisma/generated/**",
+      "prisma/migrations/**",
     ],
   },
 ];
-
-export default config;

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "eslint": "^9.22.0",
-    "eslint-config-next": "^15.3.3"
+    "eslint-config-next": "^15.3.3",
+    "@eslint/eslintrc": "^3.3.1"
   }
 }


### PR DESCRIPTION
## Summary
- replaced the broken direct `eslint-config-next` flat import approach
- switched to `FlatCompat` for `next/core-web-vitals` and `next/typescript`
- added `@eslint/eslintrc` explicitly
- kept lint and lint:fix scripts in package.json

## Why this matters
The previous ESLint config failed at runtime because the imported Next config was not iterable. This update uses a more reliable compatibility approach for ESLint 9 flat config.

## Testing
- [ ] run `npm install`
- [ ] run `npm run lint`
- [ ] confirm GitHub Actions lint workflow starts successfully