### PR TITLE
Clean Prisma enum typing and lint issues

### DIFF
--- a/app/alerts/actions.ts
+++ b/app/alerts/actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { AlertRuleCategory, AlertSeverity, AlertSourceType, AlertStatus, ThresholdOperator } from "@prisma/client";
+import { AlertRuleCategory, AlertSeverity, AlertSourceType, AlertStatus, SymptomSeverity, ThresholdOperator } from "@prisma/client";
 import { db } from "@/lib/db";
 import { requireUser } from "@/lib/session";
 import { createAlertAuditLog } from "@/lib/alerts/audit";
@@ -83,7 +83,7 @@ export async function createAlertRule(formData: FormData) {
       thresholdOperator: thresholdOperatorValue ? (thresholdOperatorValue as ThresholdOperator) : null,
       thresholdValue: toOptionalNumber(formData.get("thresholdValue")),
       thresholdValueSecondary: toOptionalNumber(formData.get("thresholdValueSecondary")),
-      symptomSeverity: toOptionalString(formData.get("symptomSeverity")) as any,
+      symptomSeverity: toOptionalString(formData.get("symptomSeverity")) as SymptomSeverity | null,
       medicationMissedCount: toOptionalNumber(formData.get("medicationMissedCount")),
       syncStaleHours: toOptionalNumber(formData.get("syncStaleHours")),
       metadataJson: null,
@@ -126,7 +126,7 @@ export async function updateAlertRule(formData: FormData) {
       thresholdOperator: thresholdOperatorValue ? (thresholdOperatorValue as ThresholdOperator) : null,
       thresholdValue: toOptionalNumber(formData.get("thresholdValue")),
       thresholdValueSecondary: toOptionalNumber(formData.get("thresholdValueSecondary")),
-      symptomSeverity: toOptionalString(formData.get("symptomSeverity")) as any,
+      symptomSeverity: toOptionalString(formData.get("symptomSeverity")) as SymptomSeverity | null,
       medicationMissedCount: toOptionalNumber(formData.get("medicationMissedCount")),
       syncStaleHours: toOptionalNumber(formData.get("syncStaleHours")),
     },

--- a/app/care-team/page.tsx
+++ b/app/care-team/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { headers } from "next/headers";
-import { Sparkles, UserRoundPlus, Users } from "lucide-react";
+import { Sparkles, UserRoundPlus } from "lucide-react";
 import { db } from "@/lib/db";
 import { requireUser } from "@/lib/session";
 import { getSharedPatientCards } from "@/lib/access";
@@ -16,7 +16,7 @@ import {
   updateCareAccessPermissionsAction,
 } from "./actions";
 
-function inviteTone(status: string, expiresAt: Date) {
+function inviteTone(status: string, expiresAt: Date): "neutral" | "warning" | "success" | "danger" {
   const expired = status === "PENDING" && expiresAt <= new Date();
   if (expired) return "danger";
   if (status === "ACTIVE") return "success";
@@ -224,7 +224,7 @@ export default async function CareTeamPage() {
                         </p>
                         <p className="text-sm text-muted-foreground">Owner email: {invite.owner.email}</p>
                       </div>
-                      <StatusPill tone={inviteTone(invite.status, invite.expiresAt) as any}>
+                      <StatusPill tone={inviteTone(invite.status, invite.expiresAt)}>
                         {displayStatus(invite.status, invite.expiresAt)}
                       </StatusPill>
                     </div>
@@ -342,7 +342,7 @@ export default async function CareTeamPage() {
                           Expires: {invite.expiresAt.toLocaleString()}
                         </p>
                       </div>
-                      <StatusPill tone={inviteTone(invite.status, invite.expiresAt) as any}>
+                      <StatusPill tone={inviteTone(invite.status, invite.expiresAt)}>
                         {shownStatus}
                       </StatusPill>
                     </div>

--- a/app/labs/page.tsx
+++ b/app/labs/page.tsx
@@ -1,3 +1,4 @@
+import { LabFlag } from "@prisma/client";
 import { FlaskConical, PencilLine, Search, Trash2 } from "lucide-react";
 import { AppShell } from "@/components/app-shell";
 import { PageHeader, EmptyState } from "@/components/common";
@@ -39,7 +40,7 @@ export default async function LabsPage({
             ],
           }
         : {}),
-      ...(flag ? { flag: flag as any } : {}),
+      ...(flag ? { flag: flag as LabFlag } : {}),
     },
     orderBy: { dateTaken: "desc" },
   });

--- a/app/medications/page.tsx
+++ b/app/medications/page.tsx
@@ -1,5 +1,5 @@
 import { endOfDay, format, startOfDay } from "date-fns";
-import { Pill, ShieldCheck } from "lucide-react";
+import { ShieldCheck } from "lucide-react";
 import { AppShell } from "@/components/app-shell";
 import { EmptyState, PageHeader } from "@/components/common";
 import {

--- a/app/review-queue/print/page.tsx
+++ b/app/review-queue/print/page.tsx
@@ -5,13 +5,6 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { requireUser } from "@/lib/session";
 import { getReviewQueueData } from "@/lib/review-queue";
 
-const toneClasses = {
-  danger: "danger",
-  warning: "warning",
-  success: "success",
-  info: "info",
-  neutral: "neutral",
-} as const;
 
 const categoryLabel: Record<string, string> = {
   OVERDUE_REMINDER: "Overdue reminder",

--- a/app/symptoms/page.tsx
+++ b/app/symptoms/page.tsx
@@ -1,5 +1,5 @@
 import { format } from "date-fns";
-import { ActivitySquare, AlertCircle } from "lucide-react";
+import { AlertCircle } from "lucide-react";
 import { AppShell } from "@/components/app-shell";
 import { PageHeader, EmptyState } from "@/components/common";
 import { deleteSymptom, saveSymptom, toggleSymptomResolved, updateSymptom } from "@/app/actions";

--- a/app/vitals/page.tsx
+++ b/app/vitals/page.tsx
@@ -1,5 +1,5 @@
 import { format } from "date-fns";
-import { HeartPulse, Activity } from "lucide-react";
+import { Activity } from "lucide-react";
 import { AppShell } from "@/components/app-shell";
 import { PageHeader, EmptyState } from "@/components/common";
 import { deleteVital, saveVital, updateVital } from "@/app/actions";

--- a/lib/alerts/queries.ts
+++ b/lib/alerts/queries.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "@prisma/client";
+import { AlertRuleCategory, AlertSeverity, AlertStatus, Prisma } from "@prisma/client";
 import { db } from "@/lib/db";
 import { resolveAlertSource } from "@/lib/alerts/source";
 import type { AlertDetail, AlertListItem } from "@/lib/alerts/types";
@@ -45,9 +45,9 @@ export async function getAlertList(args: {
 }) {
   const where: Prisma.AlertEventWhereInput = {
     userId: args.userId,
-    ...(args.status && args.status !== "ALL" ? { status: args.status as any } : {}),
-    ...(args.severity && args.severity !== "ALL" ? { severity: args.severity as any } : {}),
-    ...(args.category && args.category !== "ALL" ? { category: args.category as any } : {}),
+    ...(args.status && args.status !== "ALL" ? { status: args.status as AlertStatus } : {}),
+    ...(args.severity && args.severity !== "ALL" ? { severity: args.severity as AlertSeverity } : {}),
+    ...(args.category && args.category !== "ALL" ? { category: args.category as AlertRuleCategory } : {}),
   };
 
   const rows = await db.alertEvent.findMany({

--- a/lib/jobs/handlers.ts
+++ b/lib/jobs/handlers.ts
@@ -1,4 +1,4 @@
-import { AppointmentStatus, ReadingSource, SyncJobStatus } from "@prisma/client";
+import { ReadingSource, ReminderState, SyncJobStatus } from "@prisma/client";
 import { db } from "@/lib/db";
 import {
   type AlertEvaluationJobData,
@@ -89,9 +89,9 @@ export async function handleDailyHealthSummaryJob(
     where: {
       userId: payload.userId,
       state: {
-        in: ["DUE", "SENT", "OVERDUE"] as any,
+        in: [ReminderState.DUE, ReminderState.SENT, ReminderState.OVERDUE],
       },
-    } as any,
+    },
   });
 
   const summaryLines = [

--- a/lib/jobs/job-run-store.ts
+++ b/lib/jobs/job-run-store.ts
@@ -1,6 +1,5 @@
 import { db } from "@/lib/db";
 import {
-  JOB_KIND,
   JOB_RUN_STATUS,
   type JobKindValue,
 } from "@/lib/domain/enums";

--- a/lib/jobs/queues.ts
+++ b/lib/jobs/queues.ts
@@ -4,7 +4,6 @@ import { JOB_BACKOFF_DELAY_MS } from "@/lib/jobs/constants";
 import { QUEUE_NAMES } from "@/lib/jobs/contracts";
 
 declare global {
-  // eslint-disable-next-line no-var
   var vitavaultQueues:
     | {
         alertsQueue?: Queue;

--- a/lib/jobs/redis.ts
+++ b/lib/jobs/redis.ts
@@ -2,7 +2,6 @@ import IORedis from "ioredis";
 import { hasRedisConfig } from "@/lib/jobs/connection";
 
 declare global {
-  // eslint-disable-next-line no-var
   var vitavaultBullRedis: IORedis | undefined;
 }
 

--- a/lib/ops-health.ts
+++ b/lib/ops-health.ts
@@ -1,5 +1,6 @@
 import {
   AlertStatus,
+  CareAccessStatus,
   DeviceConnectionStatus,
   JobRunStatus,
   LabFlag,
@@ -136,8 +137,8 @@ export async function getOpsHealthData(userId: string, role: SupportedRole): Pro
       }),
     }),
     isAdmin(role)
-      ? db.careAccess.count({ where: { status: "ACTIVE" as any } })
-      : db.careAccess.count({ where: { ownerUserId: userId, status: "ACTIVE" as any } }),
+      ? db.careAccess.count({ where: { status: CareAccessStatus.ACTIVE } })
+      : db.careAccess.count({ where: { ownerUserId: userId, status: CareAccessStatus.ACTIVE } }),
     db.jobRun.findMany({
       where: scopedWhere(role, userId, {
         status: { in: [JobRunStatus.FAILED, JobRunStatus.RETRYING] },

--- a/lib/reminders/queries.ts
+++ b/lib/reminders/queries.ts
@@ -1,4 +1,4 @@
-import { Prisma, ReminderState } from "@prisma/client";
+import { Prisma, ReminderState, ReminderType } from "@prisma/client";
 import { db } from "@/lib/db";
 
 export async function getReminderCenterData(args: {
@@ -8,8 +8,8 @@ export async function getReminderCenterData(args: {
 }) {
   const where: Prisma.ReminderWhereInput = {
     userId: args.userId,
-    ...(args.state && args.state !== "ALL" ? { state: args.state as any } : {}),
-    ...(args.type && args.type !== "ALL" ? { type: args.type as any } : {}),
+    ...(args.state && args.state !== "ALL" ? { state: args.state as ReminderState } : {}),
+    ...(args.type && args.type !== "ALL" ? { type: args.type as ReminderType } : {}),
   };
 
   const reminders = await db.reminder.findMany({


### PR DESCRIPTION
## Summary
- replaced unsafe `any` casts with Prisma enum-based typing
- fixed Care Team `StatusPill` tone typing
- cleaned unused imports and constants across app modules
- removed stale eslint-disable directives in jobs files

## Why this matters
This reduces real TypeScript/lint debt in app code and makes CI output more meaningful for future PRs.

## Testing
- [x] run `npm run lint`
- [x] open alerts page
- [x] open care team page
- [x] open labs page
- [x] open reminders page
- [x] open ops page