### PR TITLE
Harden patient summary PDF and print export flow

### DIFF
--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, CalendarDays, FileText, ShieldCheck } from "lucide-react";
+import { AlertTriangle, CalendarDays, FileText, ShieldCheck, Sparkles, Users } from "lucide-react";
 import { AppShell } from "@/components/app-shell";
 import { requireUser } from "@/lib/session";
 import { Badge, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
@@ -12,7 +12,22 @@ import { getPatientSummaryData } from "@/lib/patient-summary";
 export default async function SummaryPage() {
   const user = await requireUser();
   const data = await getPatientSummaryData(user.id!);
-  const { profile, meds, appointments, labs, vitals, symptoms, vaccinations, reminders, docs, alerts, stats } = data;
+  const {
+    generatedAt,
+    profile,
+    meds,
+    appointments,
+    labs,
+    vitals,
+    symptoms,
+    vaccinations,
+    reminders,
+    docs,
+    alerts,
+    stats,
+    latestInsight,
+    careAccess,
+  } = data;
 
   return (
     <AppShell>
@@ -25,6 +40,7 @@ export default async function SummaryPage() {
               <div className="flex flex-wrap gap-3">
                 <Badge className="bg-background/70">Print-ready</Badge>
                 <Badge className="bg-background/70">PDF-friendly</Badge>
+                <Badge className="bg-background/70">{stats.careMembers} active share{stats.careMembers === 1 ? "" : "s"}</Badge>
                 <SummaryExportActions />
               </div>
             }
@@ -84,6 +100,87 @@ export default async function SummaryPage() {
                       <p className="text-sm font-medium">Care notes</p>
                       <p className="mt-2 text-sm text-muted-foreground">{profile?.notes ?? "—"}</p>
                     </DataCard>
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader>
+                    <div className="flex items-center gap-2">
+                      <FileText className="h-4 w-4 text-primary" />
+                      <CardTitle>Export profile</CardTitle>
+                    </div>
+                    <CardDescription className="mt-1">
+                      Snapshot metadata for handoff-ready PDF exports.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    <DataCard>
+                      <div className="grid gap-3 text-sm md:grid-cols-2">
+                        <p><span className="font-medium">Prepared:</span> {formatDateTime(generatedAt)}</p>
+                        <p><span className="font-medium">Prepared by:</span> {user.name ?? user.email ?? "Signed-in user"}</p>
+                        <p><span className="font-medium">Reminder items:</span> {stats.reminders}</p>
+                        <p><span className="font-medium">Documents attached:</span> {stats.documents}</p>
+                        <p><span className="font-medium">Open alerts:</span> {stats.alerts}</p>
+                        <p><span className="font-medium">AI insight included:</span> {latestInsight ? "Yes" : "No"}</p>
+                      </div>
+                    </DataCard>
+                    <DataCard>
+                      <p className="text-sm font-medium">Print modes</p>
+                      <ul className="mt-2 space-y-1 text-sm text-muted-foreground">
+                        <li>• Standard PDF view for detailed patient handoff exports.</li>
+                        <li>• Compact auto-print view for a tighter browser Save as PDF flow.</li>
+                        <li>• Current page print keeps the richer card layout intact for internal use.</li>
+                      </ul>
+                    </DataCard>
+                  </CardContent>
+                </Card>
+
+                {latestInsight ? (
+                  <Card>
+                    <CardHeader>
+                      <div className="flex items-center gap-2">
+                        <Sparkles className="h-4 w-4 text-primary" />
+                        <CardTitle>Latest AI insight</CardTitle>
+                      </div>
+                      <CardDescription className="mt-1">
+                        Most recent generated clinical-style summary.
+                      </CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                      <DataCard>
+                        <p className="font-medium">{latestInsight.title}</p>
+                        <p className="mt-2 text-sm text-muted-foreground">{latestInsight.summary}</p>
+                        <p className="mt-2 text-xs text-muted-foreground">Generated {formatDateTime(latestInsight.createdAt)}</p>
+                      </DataCard>
+                    </CardContent>
+                  </Card>
+                ) : null}
+
+                <Card>
+                  <CardHeader>
+                    <div className="flex items-center gap-2">
+                      <Users className="h-4 w-4 text-primary" />
+                      <CardTitle>Care-team export access</CardTitle>
+                    </div>
+                    <CardDescription className="mt-1">
+                      Active members currently included in the patient-sharing layer.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    {careAccess.length ? careAccess.map((member) => (
+                      <DataCard key={member.id}>
+                        <div className="flex flex-wrap items-start justify-between gap-3 text-sm">
+                          <div>
+                            <p className="font-medium">{member.member.name ?? member.member.email ?? "Care team member"}</p>
+                            <p className="mt-1 text-muted-foreground">{member.accessRole} • {member.status}</p>
+                          </div>
+                          <div className="text-right text-muted-foreground">
+                            <p>Export {member.canExport ? "enabled" : "disabled"}</p>
+                            <p>Edit {member.canEditRecords ? "enabled" : "disabled"}</p>
+                          </div>
+                        </div>
+                      </DataCard>
+                    )) : <p className="text-sm text-muted-foreground">No active care-team access relationships.</p>}
                   </CardContent>
                 </Card>
 
@@ -182,41 +279,47 @@ export default async function SummaryPage() {
                         <DataCard key={item.id}>
                           <p className="font-medium">{item.vaccineName}</p>
                           <p className="mt-1 text-sm text-muted-foreground">Dose {item.doseNumber} • {formatDate(item.dateTaken)}</p>
-                          <p className="text-sm text-muted-foreground">Next due: {formatDate(item.nextDueDate)}</p>
+                          <p className="text-sm text-muted-foreground">Next due {formatDate(item.nextDueDate)}</p>
                         </DataCard>
-                      )) : <p className="text-sm text-muted-foreground">No vaccination records available.</p>}
+                      )) : <p className="text-sm text-muted-foreground">No vaccinations available.</p>}
                     </CardContent>
                   </Card>
                 </div>
 
-                <Card>
-                  <CardHeader>
-                    <CardTitle>Labs and recent vitals</CardTitle>
-                    <CardDescription className="mt-1">Recent clinical results and basic vital snapshot.</CardDescription>
-                  </CardHeader>
-                  <CardContent className="grid gap-6 lg:grid-cols-2">
-                    <div className="space-y-3">
-                      <p className="text-sm font-medium">Lab results</p>
+                <div className="grid gap-6 lg:grid-cols-2">
+                  <Card>
+                    <CardHeader>
+                      <CardTitle>Recent labs</CardTitle>
+                      <CardDescription className="mt-1">Latest tests and highlighted flags.</CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-3">
                       {labs.length ? labs.map((item) => (
                         <DataCard key={item.id}>
                           <p className="font-medium">{item.testName}</p>
-                          <p className="mt-1 text-sm text-muted-foreground">{formatDate(item.dateTaken)} • {item.resultSummary}</p>
-                          <p className="text-sm text-muted-foreground">{item.flag}</p>
+                          <p className="mt-1 text-sm text-muted-foreground">{formatDate(item.dateTaken)} • {item.flag}</p>
+                          <p className="text-sm text-muted-foreground">{item.resultSummary}</p>
                         </DataCard>
                       )) : <p className="text-sm text-muted-foreground">No lab results available.</p>}
-                    </div>
-                    <div className="space-y-3">
-                      <p className="text-sm font-medium">Vitals</p>
+                    </CardContent>
+                  </Card>
+
+                  <Card>
+                    <CardHeader>
+                      <CardTitle>Recent vitals</CardTitle>
+                      <CardDescription className="mt-1">Recent measurements captured in the record.</CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-3">
                       {vitals.length ? vitals.map((item) => (
                         <DataCard key={item.id}>
                           <p className="font-medium">{formatDateTime(item.recordedAt)}</p>
                           <p className="mt-1 text-sm text-muted-foreground">BP {bpLabel(item.systolic, item.diastolic)} • HR {item.heartRate ?? "—"}</p>
-                          <p className="text-sm text-muted-foreground">Sugar {item.bloodSugar ?? "—"} • Weight {item.weightKg ?? "—"}</p>
+                          <p className="text-sm text-muted-foreground">Blood sugar {item.bloodSugar ?? "—"} • O₂ {item.oxygenSaturation ?? "—"}</p>
+                          <p className="text-sm text-muted-foreground">Temp {item.temperatureC ?? "—"} • Weight {item.weightKg ?? "—"}</p>
                         </DataCard>
-                      )) : <p className="text-sm text-muted-foreground">No vitals available.</p>}
-                    </div>
-                  </CardContent>
-                </Card>
+                      )) : <p className="text-sm text-muted-foreground">No vital records available.</p>}
+                    </CardContent>
+                  </Card>
+                </div>
 
                 <div className="grid gap-6 lg:grid-cols-2">
                   <Card>

--- a/app/summary/print/page.tsx
+++ b/app/summary/print/page.tsx
@@ -4,6 +4,11 @@ import { getPatientSummaryData } from "@/lib/patient-summary";
 import { requireUser } from "@/lib/session";
 import { bpLabel, formatDate, formatDateTime } from "@/lib/utils";
 
+type SearchParams = Promise<{
+  autoprint?: string;
+  mode?: string;
+}>;
+
 function LineItem({ label, value }: { label: string; value: ReactNode }) {
   return (
     <div className="grid grid-cols-[180px_1fr] gap-3 border-b border-slate-200 py-2 text-sm">
@@ -13,31 +18,63 @@ function LineItem({ label, value }: { label: string; value: ReactNode }) {
   );
 }
 
-function Section({ title, children }: { title: string; children: ReactNode }) {
+function Section({ title, children, compact = false }: { title: string; children: ReactNode; compact?: boolean }) {
   return (
-    <section className="rounded-2xl border border-slate-200 bg-white p-5">
+    <section className={`rounded-2xl border border-slate-200 bg-white ${compact ? "p-4" : "p-5"}`}>
       <h2 className="text-base font-semibold text-slate-900">{title}</h2>
-      <div className="mt-3 space-y-2">{children}</div>
+      <div className={`mt-3 ${compact ? "space-y-2" : "space-y-2"}`}>{children}</div>
     </section>
   );
 }
 
-export default async function SummaryPrintPage() {
+function RecordCard({ children, compact = false }: { children: ReactNode; compact?: boolean }) {
+  return (
+    <div className={`rounded-xl border border-slate-200 text-sm ${compact ? "p-2.5" : "p-3"}`}>
+      {children}
+    </div>
+  );
+}
+
+export default async function SummaryPrintPage({ searchParams }: { searchParams?: SearchParams }) {
+  const resolvedSearchParams = (await searchParams) ?? {};
   const user = await requireUser();
-  const { profile, meds, appointments, labs, vitals, symptoms, vaccinations, reminders, docs, alerts, stats } = await getPatientSummaryData(user.id!);
+  const {
+    generatedAt,
+    profile,
+    meds,
+    appointments,
+    labs,
+    vitals,
+    symptoms,
+    vaccinations,
+    reminders,
+    docs,
+    alerts,
+    stats,
+    latestInsight,
+    careAccess,
+  } = await getPatientSummaryData(user.id!);
+
+  const compact = resolvedSearchParams.mode === "compact";
+  const autoprint = resolvedSearchParams.autoprint === "1";
+  const visibleReminders = compact ? reminders.slice(0, 5) : reminders;
+  const visibleDocs = compact ? docs.slice(0, 5) : docs;
+  const visibleAlerts = compact ? alerts.slice(0, 5) : alerts;
 
   return (
     <main className="min-h-screen bg-slate-100 print:bg-white">
-      <AutoPrintOnLoad />
-      <div className="mx-auto max-w-5xl space-y-6 p-6 print:max-w-none print:p-0">
+      {autoprint ? <AutoPrintOnLoad /> : null}
+      <div className={`mx-auto space-y-6 p-6 print:max-w-none print:p-0 ${compact ? "max-w-4xl" : "max-w-5xl"}`}>
         <header className="rounded-3xl border border-slate-200 bg-white p-6 print:rounded-none print:border-x-0 print:border-t-0">
-          <div className="flex items-start justify-between gap-6">
+          <div className="flex flex-wrap items-start justify-between gap-6">
             <div>
               <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">VitaVault</p>
               <h1 className="mt-2 text-3xl font-semibold text-slate-950">Patient Summary</h1>
-              <p className="mt-2 text-sm text-slate-600">Prepared for print / Save as PDF on {formatDate(new Date())}</p>
+              <p className="mt-2 text-sm text-slate-600">Prepared for print / Save as PDF on {formatDateTime(generatedAt)}</p>
+              <p className="mt-1 text-sm text-slate-600">Mode: {compact ? "Compact handoff view" : "Standard detailed view"}</p>
+              <p className="mt-1 text-sm text-slate-600">Prepared by {user.name ?? user.email ?? "Signed-in user"}</p>
             </div>
-            <div className="grid grid-cols-2 gap-3 text-right text-sm">
+            <div className={`grid gap-3 text-right text-sm ${compact ? "grid-cols-2" : "grid-cols-2 lg:grid-cols-4"}`}>
               <div className="rounded-2xl border border-slate-200 px-4 py-3">
                 <div className="text-xs uppercase tracking-wide text-slate-500">Alerts</div>
                 <div className="mt-1 text-2xl font-semibold">{stats.alerts}</div>
@@ -46,114 +83,158 @@ export default async function SummaryPrintPage() {
                 <div className="text-xs uppercase tracking-wide text-slate-500">Reminders</div>
                 <div className="mt-1 text-2xl font-semibold">{stats.reminders}</div>
               </div>
+              <div className="rounded-2xl border border-slate-200 px-4 py-3">
+                <div className="text-xs uppercase tracking-wide text-slate-500">Docs</div>
+                <div className="mt-1 text-2xl font-semibold">{stats.documents}</div>
+              </div>
+              <div className="rounded-2xl border border-slate-200 px-4 py-3">
+                <div className="text-xs uppercase tracking-wide text-slate-500">Care</div>
+                <div className="mt-1 text-2xl font-semibold">{stats.careMembers}</div>
+              </div>
             </div>
           </div>
         </header>
 
-        <Section title="Patient profile">
-          <LineItem label="Full name" value={profile?.fullName ?? user.name ?? "—"} />
-          <LineItem label="Date of birth" value={formatDate(profile?.dateOfBirth)} />
-          <LineItem label="Sex" value={profile?.sex ?? "—"} />
-          <LineItem label="Blood type" value={profile?.bloodType ?? "—"} />
-          <LineItem label="Height / Weight" value={`${profile?.heightCm ?? "—"} cm / ${profile?.weightKg ?? "—"} kg`} />
-          <LineItem label="Emergency contact" value={profile?.emergencyContactName ?? "—"} />
-          <LineItem label="Emergency phone" value={profile?.emergencyContactPhone ?? "—"} />
-          <LineItem label="Allergies" value={profile?.allergiesSummary ?? "—"} />
-          <LineItem label="Chronic conditions" value={profile?.chronicConditions ?? "—"} />
-          <LineItem label="Notes" value={profile?.notes ?? "—"} />
-        </Section>
+        <div className="grid gap-6 md:grid-cols-[1.05fr_0.95fr]">
+          <Section title="Patient profile" compact={compact}>
+            <LineItem label="Full name" value={profile?.fullName ?? user.name ?? "—"} />
+            <LineItem label="Date of birth" value={formatDate(profile?.dateOfBirth)} />
+            <LineItem label="Sex" value={profile?.sex ?? "—"} />
+            <LineItem label="Blood type" value={profile?.bloodType ?? "—"} />
+            <LineItem label="Height / Weight" value={`${profile?.heightCm ?? "—"} cm / ${profile?.weightKg ?? "—"} kg`} />
+            <LineItem label="Emergency contact" value={profile?.emergencyContactName ?? "—"} />
+            <LineItem label="Emergency phone" value={profile?.emergencyContactPhone ?? "—"} />
+            <LineItem label="Allergies" value={profile?.allergiesSummary ?? "—"} />
+            <LineItem label="Chronic conditions" value={profile?.chronicConditions ?? "—"} />
+            <LineItem label="Notes" value={profile?.notes ?? "—"} />
+          </Section>
+
+          <Section title="Export snapshot" compact={compact}>
+            <LineItem label="Prepared" value={formatDateTime(generatedAt)} />
+            <LineItem label="Prepared by" value={user.name ?? user.email ?? "Signed-in user"} />
+            <LineItem label="Mode" value={compact ? "Compact handoff view" : "Standard detailed view"} />
+            <LineItem label="AI insight" value={latestInsight ? latestInsight.title : "No generated insight included"} />
+            <LineItem label="Active care access" value={`${stats.careMembers} active member${stats.careMembers === 1 ? "" : "s"}`} />
+          </Section>
+        </div>
+
+        {latestInsight ? (
+          <Section title="Latest AI insight" compact={compact}>
+            <p className="text-sm font-semibold text-slate-900">{latestInsight.title}</p>
+            <p className="mt-2 text-sm text-slate-600">{latestInsight.summary}</p>
+            <p className="mt-2 text-xs text-slate-500">Generated {formatDateTime(latestInsight.createdAt)}</p>
+          </Section>
+        ) : null}
+
+        {careAccess.length ? (
+          <Section title="Care-team access snapshot" compact={compact}>
+            <div className="grid gap-3 md:grid-cols-2">
+              {careAccess.map((member) => (
+                <RecordCard key={member.id} compact={compact}>
+                  <p className="font-semibold text-slate-900">{member.member.name ?? member.member.email ?? "Care team member"}</p>
+                  <p className="mt-1 text-slate-600">{member.accessRole} • {member.status}</p>
+                  <p className="text-slate-600">Export {member.canExport ? "enabled" : "disabled"} • Edit {member.canEditRecords ? "enabled" : "disabled"}</p>
+                </RecordCard>
+              ))}
+            </div>
+          </Section>
+        ) : null}
 
         <div className="grid gap-6 md:grid-cols-2">
-          <Section title="Medications">
+          <Section title="Medications" compact={compact}>
             {meds.length ? meds.map((item) => (
-              <div key={item.id} className="rounded-xl border border-slate-200 p-3 text-sm">
+              <RecordCard key={item.id} compact={compact}>
                 <p className="font-semibold text-slate-900">{item.name}</p>
                 <p className="mt-1 text-slate-600">{item.dosage} • {item.frequency}</p>
                 <p className="text-slate-600">Times: {item.schedules.map((schedule) => schedule.timeOfDay).join(", ") || "—"}</p>
                 <p className="text-slate-600">Start {formatDate(item.startDate)} • End {formatDate(item.endDate)}</p>
-              </div>
+              </RecordCard>
             )) : <p className="text-sm text-slate-500">No medications available.</p>}
           </Section>
 
-          <Section title="Appointments">
+          <Section title="Appointments" compact={compact}>
             {appointments.length ? appointments.map((item) => (
-              <div key={item.id} className="rounded-xl border border-slate-200 p-3 text-sm">
+              <RecordCard key={item.id} compact={compact}>
                 <p className="font-semibold text-slate-900">{item.purpose}</p>
                 <p className="mt-1 text-slate-600">{item.doctorName} • {item.clinic}</p>
                 <p className="text-slate-600">{formatDateTime(item.scheduledAt)} • {item.status}</p>
-              </div>
+              </RecordCard>
             )) : <p className="text-sm text-slate-500">No appointments available.</p>}
           </Section>
         </div>
 
         <div className="grid gap-6 md:grid-cols-2">
-          <Section title="Recent labs">
+          <Section title="Recent labs" compact={compact}>
             {labs.length ? labs.map((item) => (
-              <div key={item.id} className="rounded-xl border border-slate-200 p-3 text-sm">
+              <RecordCard key={item.id} compact={compact}>
                 <p className="font-semibold text-slate-900">{item.testName}</p>
                 <p className="mt-1 text-slate-600">{formatDate(item.dateTaken)} • {item.flag}</p>
                 <p className="text-slate-600">{item.resultSummary}</p>
-              </div>
+              </RecordCard>
             )) : <p className="text-sm text-slate-500">No labs available.</p>}
           </Section>
 
-          <Section title="Recent vitals">
+          <Section title="Recent vitals" compact={compact}>
             {vitals.length ? vitals.map((item) => (
-              <div key={item.id} className="rounded-xl border border-slate-200 p-3 text-sm">
+              <RecordCard key={item.id} compact={compact}>
                 <p className="font-semibold text-slate-900">{formatDateTime(item.recordedAt)}</p>
                 <p className="mt-1 text-slate-600">BP {bpLabel(item.systolic, item.diastolic)} • HR {item.heartRate ?? "—"}</p>
                 <p className="text-slate-600">Blood sugar {item.bloodSugar ?? "—"} • O₂ {item.oxygenSaturation ?? "—"}</p>
                 <p className="text-slate-600">Temp {item.temperatureC ?? "—"} • Weight {item.weightKg ?? "—"}</p>
-              </div>
+              </RecordCard>
             )) : <p className="text-sm text-slate-500">No vitals available.</p>}
           </Section>
         </div>
 
         <div className="grid gap-6 md:grid-cols-2">
-          <Section title="Symptoms & vaccinations">
+          <Section title="Symptoms & vaccinations" compact={compact}>
             {symptoms.length ? symptoms.map((item) => (
-              <div key={item.id} className="rounded-xl border border-slate-200 p-3 text-sm">
+              <RecordCard key={item.id} compact={compact}>
                 <p className="font-semibold text-slate-900">{item.title}</p>
                 <p className="mt-1 text-slate-600">{item.severity} • {formatDateTime(item.startedAt)}</p>
                 <p className="text-slate-600">{item.notes ?? (item.resolved ? "Marked resolved." : "No notes provided.")}</p>
-              </div>
+              </RecordCard>
             )) : <p className="text-sm text-slate-500">No symptoms available.</p>}
 
             {vaccinations.length ? vaccinations.map((item) => (
-              <div key={item.id} className="rounded-xl border border-slate-200 p-3 text-sm">
+              <RecordCard key={item.id} compact={compact}>
                 <p className="font-semibold text-slate-900">{item.vaccineName}</p>
                 <p className="mt-1 text-slate-600">Dose {item.doseNumber} • {formatDate(item.dateTaken)}</p>
                 <p className="text-slate-600">Next due {formatDate(item.nextDueDate)}</p>
-              </div>
+              </RecordCard>
             )) : <p className="text-sm text-slate-500">No vaccinations available.</p>}
           </Section>
 
-          <Section title="Reminders, documents, and alerts">
-            {reminders.length ? reminders.map((item) => (
-              <div key={item.id} className="rounded-xl border border-slate-200 p-3 text-sm">
+          <Section title="Reminders, documents, and alerts" compact={compact}>
+            {visibleReminders.length ? visibleReminders.map((item) => (
+              <RecordCard key={item.id} compact={compact}>
                 <p className="font-semibold text-slate-900">{item.title}</p>
                 <p className="mt-1 text-slate-600">{formatDateTime(item.dueAt)} • {item.state}</p>
-                <p className="text-slate-600">{item.description ?? "No reminder description."}</p>
-              </div>
+                {!compact ? <p className="text-slate-600">{item.description ?? "No reminder description."}</p> : null}
+              </RecordCard>
             )) : <p className="text-sm text-slate-500">No reminders available.</p>}
 
-            {docs.length ? docs.map((item) => (
-              <div key={item.id} className="rounded-xl border border-slate-200 p-3 text-sm">
+            {visibleDocs.length ? visibleDocs.map((item) => (
+              <RecordCard key={item.id} compact={compact}>
                 <p className="font-semibold text-slate-900">{item.title}</p>
                 <p className="mt-1 text-slate-600">{item.type} • {item.fileName}</p>
                 <p className="text-slate-600">Added {formatDateTime(item.createdAt)}</p>
-              </div>
+              </RecordCard>
             )) : <p className="text-sm text-slate-500">No documents available.</p>}
 
-            {alerts.length ? alerts.map((item) => (
-              <div key={item.id} className="rounded-xl border border-slate-200 p-3 text-sm">
+            {visibleAlerts.length ? visibleAlerts.map((item) => (
+              <RecordCard key={item.id} compact={compact}>
                 <p className="font-semibold text-slate-900">{item.title}</p>
                 <p className="mt-1 text-slate-600">{item.severity} • {item.status}</p>
-                <p className="text-slate-600">{item.message}</p>
-              </div>
+                {!compact ? <p className="text-slate-600">{item.message}</p> : null}
+              </RecordCard>
             )) : <p className="text-sm text-slate-500">No alerts available.</p>}
           </Section>
         </div>
+
+        <footer className="rounded-2xl border border-slate-200 bg-white p-4 text-xs text-slate-500 print:rounded-none print:border-x-0 print:border-b-0">
+          This export is scoped to the signed-in patient workspace and is intended for controlled handoff, review, or browser Save as PDF workflows.
+        </footer>
       </div>
     </main>
   );

--- a/components/summary-export-actions.tsx
+++ b/components/summary-export-actions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FileText, Printer } from "lucide-react";
+import { FileText, Printer, Sparkles } from "lucide-react";
 
 export function SummaryExportActions() {
   return (
@@ -17,10 +17,19 @@ export function SummaryExportActions() {
         href="/summary/print"
         target="_blank"
         rel="noreferrer"
-        className="inline-flex h-10 items-center justify-center gap-2 rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium transition hover:bg-muted/60 hover:border-border"
+        className="inline-flex h-10 items-center justify-center gap-2 rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium transition hover:border-border hover:bg-muted/60"
       >
         <FileText className="h-4 w-4" />
-        Open print view
+        Standard PDF view
+      </a>
+      <a
+        href="/summary/print?mode=compact&autoprint=1"
+        target="_blank"
+        rel="noreferrer"
+        className="inline-flex h-10 items-center justify-center gap-2 rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium transition hover:border-border hover:bg-muted/60"
+      >
+        <Sparkles className="h-4 w-4" />
+        Compact auto-print PDF
       </a>
     </div>
   );

--- a/lib/patient-summary.ts
+++ b/lib/patient-summary.ts
@@ -1,6 +1,8 @@
 import { db } from "@/lib/db";
 
 export async function getPatientSummaryData(userId: string) {
+  const generatedAt = new Date();
+
   const [
     profile,
     meds,
@@ -12,6 +14,8 @@ export async function getPatientSummaryData(userId: string) {
     reminders,
     docs,
     alerts,
+    latestInsight,
+    careAccess,
   ] = await Promise.all([
     db.healthProfile.findUnique({ where: { userId } }),
     db.medication.findMany({
@@ -60,9 +64,28 @@ export async function getPatientSummaryData(userId: string) {
       orderBy: { createdAt: "desc" },
       take: 8,
     }),
+    db.aiInsight.findFirst({
+      where: { ownerUserId: userId },
+      orderBy: { createdAt: "desc" },
+    }),
+    db.careAccess.findMany({
+      where: { ownerUserId: userId, status: "ACTIVE" },
+      include: {
+        member: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+      take: 6,
+    }),
   ]);
 
   return {
+    generatedAt,
     profile,
     meds,
     appointments,
@@ -73,6 +96,8 @@ export async function getPatientSummaryData(userId: string) {
     reminders,
     docs,
     alerts,
+    latestInsight,
+    careAccess,
     stats: {
       medications: meds.length,
       appointments: appointments.length,
@@ -83,6 +108,8 @@ export async function getPatientSummaryData(userId: string) {
       reminders: reminders.length,
       documents: docs.length,
       alerts: alerts.length,
+      careMembers: careAccess.length,
+      hasInsight: latestInsight ? 1 : 0,
     },
   };
 }


### PR DESCRIPTION
## Summary
- upgraded the patient summary into a more polished export-ready workflow
- added export snapshot metadata
- included latest AI insight in summary exports when available
- included active care-team export/access snapshot
- added standard and compact PDF print modes
- changed auto-print behavior so it only runs when explicitly requested

## Why this matters
This makes VitaVault's summary feature feel much closer to a real business-facing handoff/export tool. It improves demo value, usability, and browser Save as PDF workflows without adding extra infrastructure complexity.

## Testing
- [x] open `/summary`
- [x] test "Print this page"
- [x] test "Standard PDF view"
- [x] test "Compact auto-print PDF"
- [x] confirm print page no longer auto-prints unless `autoprint=1`
- [x] confirm AI insight appears when available
- [x] confirm care-team access snapshot appears when available