### PR TITLE
Resolve export module typecheck issues

### DIFF
--- a/app/exports/[type]/route.ts
+++ b/app/exports/[type]/route.ts
@@ -2,30 +2,210 @@ import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
 import { db } from "@/lib/db";
 import { toCsv } from "@/lib/export";
-import { formatDate, formatDateTime, bpLabel } from "@/lib/utils";
+import { formatDate, formatDateTime, bpLabel, formatBytes } from "@/lib/utils";
+import { exportDefinitionMap } from "@/lib/export-definitions";
+
+function csvResponse(type: string, rows: Record<string, unknown>[]) {
+  const timestamp = new Date().toISOString().slice(0, 10);
+  const filename = `${type}-${timestamp}.csv`;
+
+  return new NextResponse(toCsv(rows), {
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+      "Cache-Control": "no-store",
+    },
+  });
+}
 
 export async function GET(_: Request, { params }: { params: Promise<{ type: string }> }) {
   const user = await requireUser();
   const { type } = await params;
-  let filename = "export.csv";
+
+  if (!exportDefinitionMap.has(type)) {
+    return NextResponse.json({ error: "Unknown export type." }, { status: 404 });
+  }
+
   let rows: Record<string, unknown>[] = [];
 
-  if (type === "appointments") {
-    const items = await db.appointment.findMany({ where: { userId: user.id }, orderBy: { scheduledAt: "desc" } });
-    rows = items.map(item => ({ Clinic: item.clinic, Specialty: item.specialty, Doctor: item.doctorName, DateTime: formatDateTime(item.scheduledAt), Purpose: item.purpose, Status: item.status }));
-    filename = "appointments.csv";
-  } else if (type === "medications") {
-    const items = await db.medication.findMany({ where: { userId: user.id }, include: { schedules: true }, orderBy: { createdAt: "desc" } });
-    rows = items.map(item => ({ Name: item.name, Dosage: item.dosage, Frequency: item.frequency, Times: item.schedules.map(s => s.timeOfDay).join(", "), StartDate: formatDate(item.startDate), EndDate: formatDate(item.endDate), Status: item.status }));
-    filename = "medications.csv";
-  } else if (type === "labs") {
-    const items = await db.labResult.findMany({ where: { userId: user.id }, orderBy: { dateTaken: "desc" } });
-    rows = items.map(item => ({ TestName: item.testName, DateTaken: formatDate(item.dateTaken), ResultSummary: item.resultSummary, ReferenceRange: item.referenceRange, Flag: item.flag }));
-    filename = "lab-results.csv";
-  } else if (type === "vitals") {
-    const items = await db.vitalRecord.findMany({ where: { userId: user.id }, orderBy: { recordedAt: "desc" } });
-    rows = items.map(item => ({ RecordedAt: formatDateTime(item.recordedAt), BloodPressure: bpLabel(item.systolic, item.diastolic), HeartRate: item.heartRate, BloodSugar: item.bloodSugar, OxygenSaturation: item.oxygenSaturation, TemperatureC: item.temperatureC, WeightKg: item.weightKg }));
-    filename = "vitals.csv";
+  switch (type) {
+    case "appointments": {
+      const items = await db.appointment.findMany({
+        where: { userId: user.id },
+        orderBy: { scheduledAt: "desc" },
+      });
+      rows = items.map((item) => ({
+        Clinic: item.clinic,
+        Specialty: item.specialty,
+        Doctor: item.doctorName,
+        DateTime: formatDateTime(item.scheduledAt),
+        Purpose: item.purpose,
+        Notes: item.notes,
+        FollowUpNotes: item.followUpNotes,
+        Status: item.status,
+        CreatedAt: formatDateTime(item.createdAt),
+      }));
+      break;
+    }
+    case "medications": {
+      const items = await db.medication.findMany({
+        where: { userId: user.id },
+        include: { schedules: true, doctor: true },
+        orderBy: { createdAt: "desc" },
+      });
+      rows = items.map((item) => ({
+        Name: item.name,
+        Dosage: item.dosage,
+        Frequency: item.frequency,
+        Instructions: item.instructions,
+        Times: item.schedules.map((schedule) => schedule.timeOfDay).join(", "),
+        StartDate: formatDate(item.startDate),
+        EndDate: formatDate(item.endDate),
+        Status: item.status,
+        Active: item.active ? "Yes" : "No",
+        Doctor: item.doctor?.name,
+        CreatedAt: formatDateTime(item.createdAt),
+      }));
+      break;
+    }
+    case "labs": {
+      const items = await db.labResult.findMany({
+        where: { userId: user.id },
+        orderBy: { dateTaken: "desc" },
+      });
+      rows = items.map((item) => ({
+        TestName: item.testName,
+        DateTaken: formatDate(item.dateTaken),
+        ResultSummary: item.resultSummary,
+        ReferenceRange: item.referenceRange,
+        Flag: item.flag,
+        FileName: item.fileName,
+        FilePath: item.filePath,
+        CreatedAt: formatDateTime(item.createdAt),
+      }));
+      break;
+    }
+    case "vitals": {
+      const items = await db.vitalRecord.findMany({
+        where: { userId: user.id },
+        orderBy: { recordedAt: "desc" },
+      });
+      rows = items.map((item) => ({
+        RecordedAt: formatDateTime(item.recordedAt),
+        BloodPressure: bpLabel(item.systolic, item.diastolic),
+        HeartRate: item.heartRate,
+        BloodSugar: item.bloodSugar,
+        OxygenSaturation: item.oxygenSaturation,
+        TemperatureC: item.temperatureC,
+        WeightKg: item.weightKg,
+        ReadingSource: item.readingSource,
+        Notes: item.notes,
+      }));
+      break;
+    }
+    case "symptoms": {
+      const items = await db.symptomEntry.findMany({
+        where: { userId: user.id },
+        orderBy: { startedAt: "desc" },
+      });
+      rows = items.map((item) => ({
+        Title: item.title,
+        Severity: item.severity,
+        BodyArea: item.bodyArea,
+        StartedAt: formatDateTime(item.startedAt),
+        Duration: item.duration,
+        Trigger: item.trigger,
+        Resolved: item.resolved ? "Yes" : "No",
+        Notes: item.notes,
+        CreatedAt: formatDateTime(item.createdAt),
+      }));
+      break;
+    }
+    case "vaccinations": {
+      const items = await db.vaccinationRecord.findMany({
+        where: { userId: user.id },
+        orderBy: { dateTaken: "desc" },
+      });
+      rows = items.map((item) => ({
+        VaccineName: item.vaccineName,
+        DoseNumber: item.doseNumber,
+        DateTaken: formatDate(item.dateTaken),
+        Location: item.location,
+        NextDueDate: formatDate(item.nextDueDate),
+        Notes: item.notes,
+        CreatedAt: formatDateTime(item.createdAt),
+      }));
+      break;
+    }
+    case "reminders": {
+      const items = await db.reminder.findMany({
+        where: { userId: user.id },
+        orderBy: { dueAt: "desc" },
+      });
+      rows = items.map((item) => ({
+        Title: item.title,
+        Type: item.type,
+        Description: item.description,
+        DueAt: formatDateTime(item.dueAt),
+        State: item.state,
+        Completed: item.completed ? "Yes" : "No",
+        Channel: item.channel,
+        SourceType: item.sourceType,
+        SourceId: item.sourceId,
+        SentAt: formatDateTime(item.sentAt),
+        OverdueAt: formatDateTime(item.overdueAt),
+        CompletedAt: formatDateTime(item.completedAt),
+        SkippedAt: formatDateTime(item.skippedAt),
+        MissedAt: formatDateTime(item.missedAt),
+        Timezone: item.timezone,
+        CreatedAt: formatDateTime(item.createdAt),
+      }));
+      break;
+    }
+    case "documents": {
+      const items = await db.medicalDocument.findMany({
+        where: { userId: user.id },
+        orderBy: { createdAt: "desc" },
+      });
+      rows = items.map((item) => ({
+        Title: item.title,
+        Type: item.type,
+        FileName: item.fileName,
+        MimeType: item.mimeType,
+        SizeBytes: item.sizeBytes,
+        SizeLabel: formatBytes(item.sizeBytes),
+        FilePath: item.filePath,
+        Notes: item.notes,
+        CreatedAt: formatDateTime(item.createdAt),
+      }));
+      break;
+    }
+    case "alerts": {
+      const items = await db.alertEvent.findMany({
+        where: { userId: user.id },
+        orderBy: { createdAt: "desc" },
+      });
+      rows = items.map((item) => ({
+        Title: item.title,
+        Message: item.message,
+        Category: item.category,
+        Severity: item.severity,
+        Status: item.status,
+        VisibleToCareTeam: item.visibleToCareTeam ? "Yes" : "No",
+        SourceType: item.sourceType,
+        SourceId: item.sourceId,
+        SourceRecordedAt: formatDateTime(item.sourceRecordedAt),
+        OwnerAcknowledgedAt: formatDateTime(item.ownerAcknowledgedAt),
+        ResolvedAt: formatDateTime(item.resolvedAt),
+        DismissedAt: formatDateTime(item.dismissedAt),
+        CreatedAt: formatDateTime(item.createdAt),
+        UpdatedAt: formatDateTime(item.updatedAt),
+      }));
+      break;
+    }
+    default:
+      return NextResponse.json({ error: "Unknown export type." }, { status: 404 });
   }
-  return new NextResponse(toCsv(rows), { headers: { "Content-Type": "text/csv", "Content-Disposition": `attachment; filename="${filename}"` } });
+
+  return csvResponse(type, rows);
 }

--- a/app/exports/[type]/route.ts
+++ b/app/exports/[type]/route.ts
@@ -2,7 +2,19 @@ import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
 import { db } from "@/lib/db";
 import { toCsv } from "@/lib/export";
-import { formatDate, formatDateTime, bpLabel, formatBytes } from "@/lib/utils";
+import { formatDate, formatDateTime, bpLabel } from "@/lib/utils";
+
+function formatBytes(bytes: number | null | undefined) {
+  if (!bytes || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value >= 10 || unitIndex === 0 ? Math.round(value) : value.toFixed(1)} ${units[unitIndex]}`;
+}
 import { exportDefinitionMap } from "@/lib/export-definitions";
 
 function csvResponse(type: string, rows: Record<string, unknown>[]) {

--- a/app/exports/page.tsx
+++ b/app/exports/page.tsx
@@ -57,7 +57,7 @@ export default function ExportsPage() {
                       <div key={group} className="space-y-3">
                         <div className="flex items-center justify-between gap-3">
                           <p className="text-sm font-semibold tracking-wide text-foreground/90">{group}</p>
-                          <Badge variant="secondary" className="rounded-full">{items.length} exports</Badge>
+                          <Badge className="rounded-full bg-background/70">{items.length} exports</Badge>
                         </div>
                         <div className="grid gap-4 md:grid-cols-2">
                           {items.map((item) => (

--- a/app/exports/page.tsx
+++ b/app/exports/page.tsx
@@ -5,29 +5,9 @@ import { PageHeader } from "@/components/common";
 import { Badge, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
 import { ModuleHero, DataCard } from "@/components/module-sections";
 import { PageTransition, StaggerGroup, StaggerItem } from "@/components/page-transition";
+import { exportDefinitions } from "@/lib/export-definitions";
 
-const exportsList = [
-  {
-    href: "/exports/appointments",
-    title: "Appointments CSV",
-    description: "Visit history, doctors, clinics, and statuses.",
-  },
-  {
-    href: "/exports/medications",
-    title: "Medications CSV",
-    description: "Medication plans, schedules, and current tracking data.",
-  },
-  {
-    href: "/exports/labs",
-    title: "Lab Results CSV",
-    description: "Lab history with dates, summaries, and flags.",
-  },
-  {
-    href: "/exports/vitals",
-    title: "Vitals CSV",
-    description: "Structured vital history for spreadsheet review.",
-  },
-];
+const groups = ["Core", "Monitoring", "Coordination"] as const;
 
 export default function ExportsPage() {
   return (
@@ -36,10 +16,10 @@ export default function ExportsPage() {
         <PageTransition>
           <PageHeader
             title="Exports"
-            description="Download structured CSV exports of your records for offline review, analysis, or handoff."
+            description="Download structured CSV exports of your records for offline review, spreadsheet analysis, handoff, or internal reporting."
             action={
               <div className="flex flex-wrap gap-2">
-                <Badge className="bg-background/70">{exportsList.length} export types</Badge>
+                <Badge className="bg-background/70">{exportDefinitions.length} export types</Badge>
                 <Badge className="bg-background/70">CSV only</Badge>
               </div>
             }
@@ -49,57 +29,67 @@ export default function ExportsPage() {
         <PageTransition delay={0.04}>
           <ModuleHero
             eyebrow="Data portability"
-            title="Structured record exports"
-            description="Exports are intentionally simple and operational so your data can move easily into Excel, reports, or client workflows."
+            title="Operational exports across the patient workspace"
+            description="Export coverage now extends beyond the original core modules so patient handoffs, admin review, and spreadsheet-based workflows are easier to support."
             stats={[
-              { label: "Available exports", value: exportsList.length },
+              { label: "Available exports", value: exportDefinitions.length },
               { label: "Format", value: "CSV" },
-              { label: "Scope", value: "Your records only" },
-              { label: "Use case", value: "Offline analysis" },
+              { label: "Coverage", value: "Core + coordination" },
+              { label: "Use case", value: "Offline reporting" },
             ]}
           />
         </PageTransition>
 
         <StaggerGroup delay={0.08}>
-          <div className="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+          <div className="grid gap-6 xl:grid-cols-[1.25fr_0.75fr]">
             <StaggerItem>
               <Card>
                 <CardHeader>
                   <CardTitle>Export options</CardTitle>
                   <CardDescription className="mt-1">
-                    Download structured datasets from the main health modules.
+                    Download structured datasets from the main health, monitoring, and coordination modules.
                   </CardDescription>
                 </CardHeader>
-                <CardContent>
-                  <div className="grid gap-4 md:grid-cols-2">
-                    {exportsList.map((item) => (
-                      <DataCard key={item.href}>
-                        <div className="flex items-start justify-between gap-3">
-                          <div className="flex items-start gap-3">
-                            <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
-                              <FileSpreadsheet className="h-4 w-4" />
-                            </div>
-                            <div>
-                              <p className="text-sm font-semibold">{item.title}</p>
-                              <p className="mt-1 text-sm text-muted-foreground">
-                                {item.description}
-                              </p>
-                            </div>
-                          </div>
+                <CardContent className="space-y-6">
+                  {groups.map((group) => {
+                    const items = exportDefinitions.filter((item) => item.group === group);
+                    return (
+                      <div key={group} className="space-y-3">
+                        <div className="flex items-center justify-between gap-3">
+                          <p className="text-sm font-semibold tracking-wide text-foreground/90">{group}</p>
+                          <Badge variant="secondary" className="rounded-full">{items.length} exports</Badge>
                         </div>
+                        <div className="grid gap-4 md:grid-cols-2">
+                          {items.map((item) => (
+                            <DataCard key={item.href}>
+                              <div className="flex items-start justify-between gap-3">
+                                <div className="flex items-start gap-3">
+                                  <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                                    <FileSpreadsheet className="h-4 w-4" />
+                                  </div>
+                                  <div>
+                                    <p className="text-sm font-semibold">{item.title}</p>
+                                    <p className="mt-1 text-sm text-muted-foreground">{item.description}</p>
+                                  </div>
+                                </div>
+                              </div>
 
-                        <div className="mt-4">
-                          <Link
-                            href={item.href}
-                            className="inline-flex items-center justify-center rounded-2xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm hover:opacity-95"
-                          >
-                            <Download className="mr-2 h-4 w-4" />
-                            Download
-                          </Link>
+                              <div className="mt-4 flex items-center justify-between gap-3">
+                                <Badge className="bg-background/70">{item.format}</Badge>
+                                <Link
+                                  href={item.href}
+                                  className="inline-flex items-center justify-center rounded-2xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm hover:opacity-95"
+                                >
+                                  <Download className="mr-2 h-4 w-4" />
+                                  Download
+                                </Link>
+                              </div>
+                            </DataCard>
+                          ))}
                         </div>
-                      </DataCard>
-                    ))}
-                  </div>
+                      </div>
+                    );
+                  })}
                 </CardContent>
               </Card>
             </StaggerItem>
@@ -110,7 +100,7 @@ export default function ExportsPage() {
                   <CardHeader>
                     <CardTitle>Export guidance</CardTitle>
                     <CardDescription className="mt-1">
-                      Keep exports useful and controlled.
+                      Keep exports useful, readable, and operational.
                     </CardDescription>
                   </CardHeader>
                   <CardContent className="space-y-4">
@@ -118,16 +108,23 @@ export default function ExportsPage() {
                       <p className="text-sm font-medium">Best use cases</p>
                       <ul className="mt-2 space-y-2 text-sm text-muted-foreground">
                         <li>Spreadsheet review</li>
-                        <li>Admin reporting</li>
-                        <li>Record backup</li>
-                        <li>Manual data analysis</li>
+                        <li>Clinical handoff support</li>
+                        <li>Operational reporting</li>
+                        <li>Record backup and audit prep</li>
                       </ul>
                     </DataCard>
 
                     <DataCard>
                       <p className="text-sm font-medium">Current format</p>
                       <p className="mt-2 text-sm text-muted-foreground">
-                        CSV keeps the export simple, widely compatible, and easy to inspect.
+                        CSV keeps the export simple, widely compatible, and easy to open in Excel, Google Sheets, or internal reporting tools.
+                      </p>
+                    </DataCard>
+
+                    <DataCard>
+                      <p className="text-sm font-medium">Also available</p>
+                      <p className="mt-2 text-sm text-muted-foreground">
+                        For print-ready handoffs, the patient summary page provides a separate PDF-friendly browser print workflow.
                       </p>
                     </DataCard>
                   </CardContent>
@@ -138,7 +135,7 @@ export default function ExportsPage() {
                     <div className="flex items-start gap-3">
                       <ShieldCheck className="mt-0.5 h-4 w-4 text-primary" />
                       <p className="text-sm text-muted-foreground">
-                        These exports are scoped to the signed-in user’s records and meant for controlled operational use.
+                        These exports are scoped to the signed-in user’s records and intended for controlled operational use only.
                       </p>
                     </div>
                   </CardContent>

--- a/lib/export-definitions.ts
+++ b/lib/export-definitions.ts
@@ -1,0 +1,85 @@
+export type ExportTypeDefinition = {
+  type: string;
+  href: string;
+  title: string;
+  description: string;
+  format: "CSV";
+  group: "Core" | "Monitoring" | "Coordination";
+};
+
+export const exportDefinitions: ExportTypeDefinition[] = [
+  {
+    type: "appointments",
+    href: "/exports/appointments",
+    title: "Appointments CSV",
+    description: "Visit history, clinics, doctors, schedules, and statuses.",
+    format: "CSV",
+    group: "Core",
+  },
+  {
+    type: "medications",
+    href: "/exports/medications",
+    title: "Medications CSV",
+    description: "Medication plans, dosing schedules, and current treatment status.",
+    format: "CSV",
+    group: "Core",
+  },
+  {
+    type: "labs",
+    href: "/exports/labs",
+    title: "Lab Results CSV",
+    description: "Lab history with dates, summary findings, and abnormal flags.",
+    format: "CSV",
+    group: "Core",
+  },
+  {
+    type: "vitals",
+    href: "/exports/vitals",
+    title: "Vitals CSV",
+    description: "Structured vital sign history for spreadsheet review and trend work.",
+    format: "CSV",
+    group: "Monitoring",
+  },
+  {
+    type: "symptoms",
+    href: "/exports/symptoms",
+    title: "Symptoms CSV",
+    description: "Symptom episodes with severity, timing, body area, and resolution state.",
+    format: "CSV",
+    group: "Monitoring",
+  },
+  {
+    type: "vaccinations",
+    href: "/exports/vaccinations",
+    title: "Vaccinations CSV",
+    description: "Vaccination record history with doses, locations, and next due dates.",
+    format: "CSV",
+    group: "Core",
+  },
+  {
+    type: "reminders",
+    href: "/exports/reminders",
+    title: "Reminders CSV",
+    description: "Upcoming, completed, overdue, or skipped reminders with delivery state.",
+    format: "CSV",
+    group: "Coordination",
+  },
+  {
+    type: "documents",
+    href: "/exports/documents",
+    title: "Documents Index CSV",
+    description: "Document catalog with file names, mime types, sizes, and timestamps.",
+    format: "CSV",
+    group: "Coordination",
+  },
+  {
+    type: "alerts",
+    href: "/exports/alerts",
+    title: "Alerts Snapshot CSV",
+    description: "Alert history with severity, source references, and resolution status.",
+    format: "CSV",
+    group: "Coordination",
+  },
+];
+
+export const exportDefinitionMap = new Map(exportDefinitions.map((item) => [item.type, item]));


### PR DESCRIPTION
## Summary
- removed invalid `formatBytes` import from export route
- added a local byte-format helper for document export rows
- removed unsupported `variant` prop from export page badge usage

## Why this matters
The expanded exports feature was good functionally, but it failed CI typecheck. This patch keeps the feature intact while making the implementation compatible with the current codebase.

## Testing
- [ ] run `npm run typecheck`
- [ ] run `npm run lint`
- [ ] open `/exports`
- [ ] download the documents export