### PR TITLE
Add document linking for appointments, labs, and doctors

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -16,6 +16,7 @@ import { auth, signIn } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { requireUser } from "@/lib/session";
 import { deleteUpload, saveUpload } from "@/lib/upload";
+import { validateDocumentLinkOwnership } from "@/lib/document-links";
 import { healthProfileSchema, signupSchema } from "@/lib/validations";
 
 export type AuthActionState = {
@@ -749,6 +750,7 @@ export async function uploadDocument(formData: FormData) {
   }
 
   const upload = await saveUpload(file);
+  const link = await validateDocumentLinkOwnership(user.id, formData.get("linkedRecordKey"));
 
   await db.medicalDocument.create({
     data: {
@@ -756,17 +758,23 @@ export async function uploadDocument(formData: FormData) {
       title: requiredString(formData, "title", "Document title"),
       type: String(formData.get("type") || "OTHER") as DocumentType,
       notes: String(formData.get("notes") || "").trim() || null,
+      linkedRecordType: link.linkedRecordType,
+      linkedRecordId: link.linkedRecordId,
       ...upload,
     },
   });
 
   revalidatePath("/documents");
   revalidatePath("/dashboard");
+  revalidatePath("/appointments");
+  revalidatePath("/labs");
+  revalidatePath("/doctors");
 }
 
 export async function updateDocumentMetadata(formData: FormData) {
   const user = await requireUser();
   const id = requiredString(formData, "id", "Document id");
+  const link = await validateDocumentLinkOwnership(user.id, formData.get("linkedRecordKey"));
 
   await db.medicalDocument.updateMany({
     where: { id, userId: user.id },
@@ -774,11 +782,16 @@ export async function updateDocumentMetadata(formData: FormData) {
       title: requiredString(formData, "title", "Document title"),
       type: String(formData.get("type") || "OTHER") as DocumentType,
       notes: String(formData.get("notes") || "").trim() || null,
+      linkedRecordType: link.linkedRecordType,
+      linkedRecordId: link.linkedRecordId,
     },
   });
 
   revalidatePath("/documents");
   revalidatePath("/dashboard");
+  revalidatePath("/appointments");
+  revalidatePath("/labs");
+  revalidatePath("/doctors");
 }
 
 export async function deleteDocument(formData: FormData) {

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -1,4 +1,4 @@
-import { FileText, PencilLine, Trash2, UploadCloud } from "lucide-react";
+import { FileText, Link2, PencilLine, Trash2, UploadCloud } from "lucide-react";
 import { AppShell } from "@/components/app-shell";
 import { PageHeader, EmptyState } from "@/components/common";
 import { deleteDocument, updateDocumentMetadata, uploadDocument } from "@/app/actions";
@@ -16,6 +16,7 @@ import { formatDateTime } from "@/lib/utils";
 import { ModuleFormCard, ModuleHero, ModuleListCard, DataCard } from "@/components/module-sections";
 import { PageTransition, StaggerGroup, StaggerItem } from "@/components/page-transition";
 import { getFocusedCardClass } from "@/lib/record-focus";
+import { getDocumentLinkSummary, serializeDocumentLinkKey } from "@/lib/document-links";
 
 export default async function DocumentsPage({
   searchParams,
@@ -26,12 +27,40 @@ export default async function DocumentsPage({
   const params = (await searchParams) ?? {};
   const focus = typeof params.focus === "string" ? params.focus : undefined;
 
-  const documents = await db.medicalDocument.findMany({
-    where: { userId: user.id },
-    orderBy: { createdAt: "desc" },
-  });
+  const [documents, appointments, labs, doctors] = await Promise.all([
+    db.medicalDocument.findMany({
+      where: { userId: user.id },
+      orderBy: { createdAt: "desc" },
+    }),
+    db.appointment.findMany({
+      where: { userId: user.id },
+      orderBy: { scheduledAt: "desc" },
+      take: 12,
+      select: { id: true, doctorName: true, clinic: true, scheduledAt: true, status: true },
+    }),
+    db.labResult.findMany({
+      where: { userId: user.id },
+      orderBy: { dateTaken: "desc" },
+      take: 12,
+      select: { id: true, testName: true, dateTaken: true, flag: true },
+    }),
+    db.doctor.findMany({
+      where: { userId: user.id },
+      orderBy: { updatedAt: "desc" },
+      take: 12,
+      select: { id: true, name: true, specialty: true, clinic: true },
+    }),
+  ]);
 
   const latest = documents[0] ?? null;
+  const linkedCount = documents.filter((document) => document.linkedRecordType && document.linkedRecordId).length;
+  const linkSummaries = await Promise.all(
+    documents.map(async (document) => [
+      document.id,
+      await getDocumentLinkSummary(user.id, document.linkedRecordType, document.linkedRecordId),
+    ] as const)
+  );
+  const linkMap = new Map(linkSummaries);
 
   return (
     <AppShell>
@@ -43,6 +72,7 @@ export default async function DocumentsPage({
             action={
               <div className="flex flex-wrap gap-2">
                 <Badge className="bg-background/70">{documents.length} files</Badge>
+                <Badge className="bg-background/70">{linkedCount} linked</Badge>
                 <Badge className="bg-background/70">
                   {latest ? `Latest: ${formatDateTime(latest.createdAt)}` : "No uploads yet"}
                 </Badge>
@@ -55,12 +85,12 @@ export default async function DocumentsPage({
           <ModuleHero
             eyebrow="Medical files"
             title="Structured clinical document storage"
-            description="Keep source files organized so appointments, labs, and care-team review become easier."
+            description="Keep source files organized so appointments, labs, doctors, and care-team review become easier."
             stats={[
               { label: "Stored files", value: documents.length },
+              { label: "Linked records", value: linkedCount },
               { label: "Latest upload", value: latest ? latest.title : "—" },
               { label: "Latest type", value: latest ? latest.type : "—" },
-              { label: "File-linked record", value: latest?.fileName ?? "—" },
             ]}
           />
         </PageTransition>
@@ -70,7 +100,7 @@ export default async function DocumentsPage({
             <StaggerItem>
               <ModuleFormCard
                 title="Upload document"
-                description="Store a structured title, type, notes, and the source file."
+                description="Store a structured title, type, notes, source file, and an optional linked record."
               >
                 <form action={uploadDocument} className="grid gap-4">
                   <div className="space-y-2">
@@ -85,8 +115,42 @@ export default async function DocumentsPage({
                       <option value="PRESCRIPTION">Prescription</option>
                       <option value="SCAN">Imaging / Scan</option>
                       <option value="DISCHARGE_SUMMARY">Discharge Summary</option>
-                      <option value="CERTIFICATE">Consult / Medical Certificate</option>
+                      <option value="CERTIFICATE">Consult Note / Certificate</option>
                       <option value="OTHER">Other</option>
+                    </Select>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label>Link to existing record</Label>
+                    <Select name="linkedRecordKey" defaultValue="">
+                      <option value="">No linked record</option>
+                      {appointments.length ? (
+                        <optgroup label="Appointments">
+                          {appointments.map((appointment) => (
+                            <option key={appointment.id} value={`APPOINTMENT:${appointment.id}`}>
+                              {appointment.doctorName} · {appointment.clinic} · {formatDateTime(appointment.scheduledAt)}
+                            </option>
+                          ))}
+                        </optgroup>
+                      ) : null}
+                      {labs.length ? (
+                        <optgroup label="Lab results">
+                          {labs.map((lab) => (
+                            <option key={lab.id} value={`LAB_RESULT:${lab.id}`}>
+                              {lab.testName} · {lab.flag} · {formatDateTime(lab.dateTaken)}
+                            </option>
+                          ))}
+                        </optgroup>
+                      ) : null}
+                      {doctors.length ? (
+                        <optgroup label="Doctors">
+                          {doctors.map((doctor) => (
+                            <option key={doctor.id} value={`DOCTOR:${doctor.id}`}>
+                              {doctor.name} · {[doctor.specialty, doctor.clinic].filter(Boolean).join(" · ") || "Directory entry"}
+                            </option>
+                          ))}
+                        </optgroup>
+                      ) : null}
                     </Select>
                   </div>
 
@@ -115,101 +179,158 @@ export default async function DocumentsPage({
             <StaggerItem>
               <ModuleListCard
                 title="Document library"
-                description="Review uploaded files and open them when needed."
+                description="Review uploaded files, linked context, and open the source record when needed."
               >
                 <div className="space-y-4">
                   {documents.length ? (
-                    documents.map((document) => (
-                      <DataCard
+                    documents.map((document) => {
+                      const linked = linkMap.get(document.id) ?? null;
+
+                      return (
+                        <DataCard
                           key={document.id}
                           id={`item-${document.id}`}
                           className={getFocusedCardClass(focus, document.id)}
                         >
-                        <div className="flex flex-wrap items-start justify-between gap-3">
-                          <div>
-                            <h3 className="text-lg font-semibold">{document.title}</h3>
-                            <p className="text-sm text-muted-foreground">
-                              Uploaded: {formatDateTime(document.createdAt)}
+                          <div className="flex flex-wrap items-start justify-between gap-3">
+                            <div>
+                              <h3 className="text-lg font-semibold">{document.title}</h3>
+                              <p className="text-sm text-muted-foreground">
+                                Uploaded: {formatDateTime(document.createdAt)}
+                              </p>
+                            </div>
+                            <Badge className="bg-background/70">{document.type}</Badge>
+                          </div>
+
+                          {linked ? (
+                            <div className="mt-4 rounded-2xl border border-primary/20 bg-primary/5 p-4">
+                              <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                                <Link2 className="h-4 w-4 text-primary" />
+                                Linked record
+                              </div>
+                              <div className="mt-2 flex flex-wrap items-center gap-3">
+                                <Badge className="bg-background/80">{linked.label}</Badge>
+                                <a href={linked.href} className="text-sm font-medium text-primary">
+                                  Open linked record
+                                </a>
+                              </div>
+                              <p className="mt-2 text-sm text-muted-foreground">{linked.meta}</p>
+                            </div>
+                          ) : null}
+
+                          <div className="mt-4 rounded-2xl border border-border/60 bg-background/40 p-4">
+                            <div className="flex items-center gap-2">
+                              <FileText className="h-4 w-4 text-primary" />
+                              <p className="text-sm font-medium">Notes</p>
+                            </div>
+                            <p className="mt-2 text-sm text-muted-foreground">
+                              {document.notes ?? "No notes added."}
                             </p>
                           </div>
-                          <Badge className="bg-background/70">{document.type}</Badge>
-                        </div>
 
-                        <div className="mt-4 rounded-2xl border border-border/60 bg-background/40 p-4">
-                          <div className="flex items-center gap-2">
-                            <FileText className="h-4 w-4 text-primary" />
-                            <p className="text-sm font-medium">Notes</p>
+                          <div className="mt-4 flex flex-wrap items-center gap-3">
+                            {document.fileName ? (
+                              <Badge className="bg-background/70">{document.fileName}</Badge>
+                            ) : null}
+
+                            {document.filePath ? (
+                              <a
+                                href={document.filePath}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="text-sm font-medium text-primary"
+                              >
+                                Open file
+                              </a>
+                            ) : null}
                           </div>
-                          <p className="mt-2 text-sm text-muted-foreground">
-                            {document.notes ?? "No notes added."}
-                          </p>
-                        </div>
 
-                        <div className="mt-4 flex flex-wrap items-center gap-3">
-                          {document.fileName ? (
-                            <Badge className="bg-background/70">{document.fileName}</Badge>
-                          ) : null}
+                          <details className="mt-4 rounded-2xl border border-border/60 bg-background/40 p-4">
+                            <summary className="flex cursor-pointer list-none items-center gap-2 text-sm font-medium text-foreground">
+                              <PencilLine className="h-4 w-4 text-primary" />
+                              Manage document
+                            </summary>
 
-                          {document.filePath ? (
-                            <a
-                              href={document.filePath}
-                              target="_blank"
-                              rel="noreferrer"
-                              className="text-sm font-medium text-primary"
-                            >
-                              Open file
-                            </a>
-                          ) : null}
-                        </div>
+                            <div className="mt-4 grid gap-4">
+                              <form action={updateDocumentMetadata} className="grid gap-4">
+                                <input type="hidden" name="id" value={document.id} />
 
-                        <details className="mt-4 rounded-2xl border border-border/60 bg-background/40 p-4">
-                          <summary className="flex cursor-pointer list-none items-center gap-2 text-sm font-medium text-foreground">
-                            <PencilLine className="h-4 w-4 text-primary" />
-                            Manage document
-                          </summary>
+                                <div className="space-y-2">
+                                  <Label>Title</Label>
+                                  <Input name="title" required defaultValue={document.title} />
+                                </div>
 
-                          <div className="mt-4 grid gap-4">
-                            <form action={updateDocumentMetadata} className="grid gap-4">
-                              <input type="hidden" name="documentId" value={document.id} />
+                                <div className="space-y-2">
+                                  <Label>Type</Label>
+                                  <Select name="type" defaultValue={document.type}>
+                                    <option value="LAB_RESULT">Lab Result</option>
+                                    <option value="PRESCRIPTION">Prescription</option>
+                                    <option value="SCAN">Imaging / Scan</option>
+                                    <option value="DISCHARGE_SUMMARY">Discharge Summary</option>
+                                    <option value="CERTIFICATE">Consult Note / Certificate</option>
+                                    <option value="OTHER">Other</option>
+                                  </Select>
+                                </div>
 
-                              <div className="space-y-2">
-                                <Label>Title</Label>
-                                <Input name="title" required defaultValue={document.title} />
-                              </div>
+                                <div className="space-y-2">
+                                  <Label>Link to existing record</Label>
+                                  <Select
+                                    name="linkedRecordKey"
+                                    defaultValue={serializeDocumentLinkKey(document.linkedRecordType, document.linkedRecordId)}
+                                  >
+                                    <option value="">No linked record</option>
+                                    {appointments.length ? (
+                                      <optgroup label="Appointments">
+                                        {appointments.map((appointment) => (
+                                          <option key={appointment.id} value={`APPOINTMENT:${appointment.id}`}>
+                                            {appointment.doctorName} · {appointment.clinic} · {formatDateTime(appointment.scheduledAt)}
+                                          </option>
+                                        ))}
+                                      </optgroup>
+                                    ) : null}
+                                    {labs.length ? (
+                                      <optgroup label="Lab results">
+                                        {labs.map((lab) => (
+                                          <option key={lab.id} value={`LAB_RESULT:${lab.id}`}>
+                                            {lab.testName} · {lab.flag} · {formatDateTime(lab.dateTaken)}
+                                          </option>
+                                        ))}
+                                      </optgroup>
+                                    ) : null}
+                                    {doctors.length ? (
+                                      <optgroup label="Doctors">
+                                        {doctors.map((doctor) => (
+                                          <option key={doctor.id} value={`DOCTOR:${doctor.id}`}>
+                                            {doctor.name} · {[doctor.specialty, doctor.clinic].filter(Boolean).join(" · ") || "Directory entry"}
+                                          </option>
+                                        ))}
+                                      </optgroup>
+                                    ) : null}
+                                  </Select>
+                                </div>
 
-                              <div className="space-y-2">
-                                <Label>Type</Label>
-                                <Select name="type" defaultValue={document.type}>
-                                  <option value="LAB_RESULT">Lab Result</option>
-                                  <option value="PRESCRIPTION">Prescription</option>
-                                  <option value="SCAN">Imaging / Scan</option>
-                                  <option value="DISCHARGE_SUMMARY">Discharge Summary</option>
-                                  <option value="CERTIFICATE">Consult / Medical Certificate</option>
-                                  <option value="OTHER">Other</option>
-                                </Select>
-                              </div>
+                                <div className="space-y-2">
+                                  <Label>Notes</Label>
+                                  <Textarea name="notes" className="min-h-[110px]" defaultValue={document.notes ?? ""} />
+                                </div>
 
-                              <div className="space-y-2">
-                                <Label>Notes</Label>
-                                <Textarea name="notes" className="min-h-[110px]" defaultValue={document.notes ?? ""} />
-                              </div>
+                                <Button type="submit" variant="outline">
+                                  Save changes
+                                </Button>
+                              </form>
 
-                              <Button type="submit" variant="outline">
-                                Save changes
-                              </Button>
-                            </form>
-
-                            <form action={deleteDocument}>
-                              <input type="hidden" name="documentId" value={document.id} />
-                              <Button type="submit" variant="destructive">
-                                <Trash2 className="h-4 w-4" />
-                                Delete document
-                              </Button>
-                            </form>
-                          </div>
-                        </details>
-                      </DataCard>
-                    ))
+                              <form action={deleteDocument}>
+                                <input type="hidden" name="id" value={document.id} />
+                                <Button type="submit" variant="destructive">
+                                  <Trash2 className="h-4 w-4" />
+                                  Delete document
+                                </Button>
+                              </form>
+                            </div>
+                          </details>
+                        </DataCard>
+                      );
+                    })
                   ) : (
                     <EmptyState
                       title="No documents yet"

--- a/lib/document-links.ts
+++ b/lib/document-links.ts
@@ -1,0 +1,162 @@
+import { type DocumentLinkType } from "@prisma/client";
+import { db } from "@/lib/db";
+
+export type ParsedDocumentLink = {
+  linkedRecordType: DocumentLinkType | null;
+  linkedRecordId: string | null;
+};
+
+export type DocumentLinkSummary = {
+  label: string;
+  href: string;
+  meta: string;
+};
+
+export function parseDocumentLinkKey(raw: FormDataEntryValue | string | null | undefined): ParsedDocumentLink {
+  const value = typeof raw === "string" ? raw.trim() : "";
+  if (!value) {
+    return { linkedRecordType: null, linkedRecordId: null };
+  }
+
+  const [type, ...rest] = value.split(":");
+  const id = rest.join(":").trim();
+
+  if (!id || !type) {
+    throw new Error("Invalid linked record selection.");
+  }
+
+  if (type !== "APPOINTMENT" && type !== "LAB_RESULT" && type !== "DOCTOR") {
+    throw new Error("Unsupported linked record type.");
+  }
+
+  return {
+    linkedRecordType: type as DocumentLinkType,
+    linkedRecordId: id,
+  };
+}
+
+export function serializeDocumentLinkKey(
+  linkedRecordType?: DocumentLinkType | null,
+  linkedRecordId?: string | null
+) {
+  if (!linkedRecordType || !linkedRecordId) return "";
+  return `${linkedRecordType}:${linkedRecordId}`;
+}
+
+export async function validateDocumentLinkOwnership(
+  userId: string,
+  raw: FormDataEntryValue | string | null | undefined
+): Promise<ParsedDocumentLink> {
+  const parsed = parseDocumentLinkKey(raw);
+
+  if (!parsed.linkedRecordType || !parsed.linkedRecordId) {
+    return parsed;
+  }
+
+  let exists = false;
+
+  if (parsed.linkedRecordType === "APPOINTMENT") {
+    exists = Boolean(
+      await db.appointment.findFirst({
+        where: { id: parsed.linkedRecordId, userId },
+        select: { id: true },
+      })
+    );
+  }
+
+  if (parsed.linkedRecordType === "LAB_RESULT") {
+    exists = Boolean(
+      await db.labResult.findFirst({
+        where: { id: parsed.linkedRecordId, userId },
+        select: { id: true },
+      })
+    );
+  }
+
+  if (parsed.linkedRecordType === "DOCTOR") {
+    exists = Boolean(
+      await db.doctor.findFirst({
+        where: { id: parsed.linkedRecordId, userId },
+        select: { id: true },
+      })
+    );
+  }
+
+  if (!exists) {
+    throw new Error("The selected linked record was not found.");
+  }
+
+  return parsed;
+}
+
+export async function getDocumentLinkSummary(
+  userId: string,
+  linkedRecordType?: DocumentLinkType | null,
+  linkedRecordId?: string | null
+): Promise<DocumentLinkSummary | null> {
+  if (!linkedRecordType || !linkedRecordId) return null;
+
+  if (linkedRecordType === "APPOINTMENT") {
+    const appointment = await db.appointment.findFirst({
+      where: { id: linkedRecordId, userId },
+      select: {
+        id: true,
+        doctorName: true,
+        clinic: true,
+        scheduledAt: true,
+        status: true,
+      },
+    });
+
+    if (!appointment) return null;
+
+    return {
+      label: `Appointment · ${appointment.doctorName}`,
+      href: `/appointments?focus=${appointment.id}`,
+      meta: `${appointment.clinic} · ${appointment.status} · ${new Intl.DateTimeFormat("en-PH", {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }).format(appointment.scheduledAt)}`,
+    };
+  }
+
+  if (linkedRecordType === "LAB_RESULT") {
+    const lab = await db.labResult.findFirst({
+      where: { id: linkedRecordId, userId },
+      select: {
+        id: true,
+        testName: true,
+        flag: true,
+        dateTaken: true,
+      },
+    });
+
+    if (!lab) return null;
+
+    return {
+      label: `Lab result · ${lab.testName}`,
+      href: `/labs?focus=${lab.id}`,
+      meta: `${lab.flag} · ${new Intl.DateTimeFormat("en-PH", {
+        dateStyle: "medium",
+      }).format(lab.dateTaken)}`,
+    };
+  }
+
+  const doctor = await db.doctor.findFirst({
+    where: { id: linkedRecordId, userId },
+    select: {
+      id: true,
+      name: true,
+      specialty: true,
+      clinic: true,
+    },
+  });
+
+  if (!doctor) return null;
+
+  return {
+    label: `Doctor · ${doctor.name}`,
+    href: `/doctors?focus=${doctor.id}`,
+    meta: [doctor.specialty, doctor.clinic].filter(Boolean).join(" · ") || "Directory entry",
+  };
+}

--- a/prisma/migrations/20260423040000_add_document_record_links/migration.sql
+++ b/prisma/migrations/20260423040000_add_document_record_links/migration.sql
@@ -1,0 +1,13 @@
+-- CreateEnum
+CREATE TYPE "DocumentLinkType" AS ENUM ('APPOINTMENT', 'LAB_RESULT', 'DOCTOR');
+
+-- AlterTable
+ALTER TABLE "MedicalDocument"
+ADD COLUMN     "linkedRecordId" TEXT,
+ADD COLUMN     "linkedRecordType" "DocumentLinkType";
+
+-- CreateIndex
+CREATE INDEX "MedicalDocument_userId_createdAt_idx" ON "MedicalDocument"("userId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "MedicalDocument_userId_linkedRecordType_linkedRecordId_idx" ON "MedicalDocument"("userId", "linkedRecordType", "linkedRecordId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -211,17 +211,22 @@ model VaccinationRecord {
 }
 
 model MedicalDocument {
-  id        String       @id @default(cuid())
-  userId    String
-  title     String
-  type      DocumentType
-  filePath  String
-  fileName  String
-  mimeType  String
-  sizeBytes Int
-  notes     String?
-  createdAt DateTime     @default(now())
-  user      User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id               String           @id @default(cuid())
+  userId           String
+  title            String
+  type             DocumentType
+  filePath         String
+  fileName         String
+  mimeType         String
+  sizeBytes        Int
+  notes            String?
+  linkedRecordType DocumentLinkType?
+  linkedRecordId   String?
+  createdAt        DateTime         @default(now())
+  user             User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, createdAt])
+  @@index([userId, linkedRecordType, linkedRecordId])
 }
 
 model Reminder {
@@ -723,6 +728,12 @@ enum DocumentType {
   CERTIFICATE
   SCAN
   OTHER
+}
+
+enum DocumentLinkType {
+  APPOINTMENT
+  LAB_RESULT
+  DOCTOR
 }
 
 enum CareAccessRole {


### PR DESCRIPTION
## Summary
- added document-to-record linking for appointments, lab results, and doctors
- added linked record selection to document upload and edit flows
- added linked record summary and deep-linking in the document library
- validated linked record ownership server-side
- added Prisma schema + migration for linked document metadata
- fixed document action hidden field usage to use `id` consistently

## Why this matters
This makes the document module feel much more like part of the actual care workflow instead of just a file bucket. It improves navigation, review context, and handoff quality.

## Testing
- [ ] run `npx prisma migrate dev --name add_document_record_links`
- [ ] run `npx prisma generate`
- [ ] run `npm run typecheck`
- [ ] run `npm run lint`
- [ ] upload a document with no link
- [ ] upload a document linked to an appointment
- [ ] upload a document linked to a lab result
- [ ] upload a document linked to a doctor
- [ ] edit an existing document and change its linked record
- [ ] confirm "Open linked record" works