### PR TITLE
Add care invite email delivery with resend and revoke flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,8 @@ JOB_DASHBOARD_LIMIT="20"
 OPENAI_API_KEY=""
 OPENAI_MODEL="gpt-5-mini"
 INTERNAL_API_SECRET=
+
+# Invite email delivery (optional)
+# If left blank, care invites still work in manual link mode using the shareable link.
+RESEND_API_KEY=""
+RESEND_FROM_EMAIL="VitaVault <no-reply@example.com>"

--- a/app/care-team/actions.ts
+++ b/app/care-team/actions.ts
@@ -10,8 +10,40 @@ import { requireUser } from "@/lib/session";
 import { logAccessAudit } from "@/lib/access";
 import { CareAccessRole } from "@prisma/client";
 
+import { sendCareInviteEmail } from "@/lib/invite-email";
+
 function boolFromForm(formData: FormData, key: string) {
   return formData.get(key) === "on";
+}
+
+
+function getAppOrigin() {
+  return (
+    process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "") ||
+    process.env.NEXTAUTH_URL?.replace(/\/$/, "") ||
+    "http://localhost:3000"
+  );
+}
+
+async function deliverInviteEmail(args: {
+  email: string;
+  token: string;
+  ownerName: string;
+  ownerEmail: string;
+  accessRole: CareAccessRole;
+  expiresAt: Date;
+  note?: string | null;
+}) {
+  const inviteLink = `${getAppOrigin()}/invite/${args.token}`;
+  return sendCareInviteEmail({
+    to: args.email,
+    inviteLink,
+    ownerName: args.ownerName,
+    ownerEmail: args.ownerEmail,
+    accessRole: args.accessRole,
+    expiresAt: args.expiresAt,
+    note: args.note,
+  });
 }
 
 async function activateInviteForActor(args: {
@@ -191,6 +223,31 @@ export async function inviteCareMemberAction(formData: FormData) {
     },
   });
 
+  let emailDelivery:
+    | { attempted: false; sent: false; reason: string }
+    | { attempted: true; sent: true; provider: string; messageId: string | null }
+    | { attempted: true; sent: false; reason: string };
+
+  try {
+    const result = await deliverInviteEmail({
+      email,
+      token: invite.token,
+      ownerName: actor.name ?? "A VitaVault patient",
+      ownerEmail: actor.email ?? "no-reply@vitavault.local",
+      accessRole,
+      expiresAt: invite.expiresAt,
+      note,
+    });
+
+    emailDelivery = result;
+  } catch (error) {
+    emailDelivery = {
+      attempted: true,
+      sent: false,
+      reason: error instanceof Error ? error.message : "Unknown invite email failure.",
+    };
+  }
+
   await logAccessAudit({
     ownerUserId: actor.id,
     actorUserId: actor.id,
@@ -200,6 +257,119 @@ export async function inviteCareMemberAction(formData: FormData) {
     metadata: {
       email,
       accessRole,
+      token: invite.token,
+      emailDelivery,
+    },
+  });
+
+  revalidatePath("/care-team");
+}
+
+export async function resendCareInviteAction(formData: FormData) {
+  const actor = await requireUser();
+  const inviteId = String(formData.get("inviteId") || "").trim();
+
+  if (!inviteId) {
+    throw new Error("Invite ID is required.");
+  }
+
+  const invite = await db.careInvite.findFirst({
+    where: {
+      id: inviteId,
+      ownerUserId: actor.id,
+      status: "PENDING",
+    },
+  });
+
+  if (!invite) {
+    throw new Error("Pending invite not found.");
+  }
+
+  const refreshedInvite = await db.careInvite.update({
+    where: { id: invite.id },
+    data: {
+      token: randomUUID(),
+      expiresAt: addDays(new Date(), 7),
+      updatedAt: new Date(),
+    },
+  });
+
+  let emailDelivery:
+    | { attempted: false; sent: false; reason: string }
+    | { attempted: true; sent: true; provider: string; messageId: string | null }
+    | { attempted: true; sent: false; reason: string };
+
+  try {
+    const result = await deliverInviteEmail({
+      email: refreshedInvite.email,
+      token: refreshedInvite.token,
+      ownerName: actor.name ?? "A VitaVault patient",
+      ownerEmail: actor.email ?? "no-reply@vitavault.local",
+      accessRole: refreshedInvite.accessRole,
+      expiresAt: refreshedInvite.expiresAt,
+      note: refreshedInvite.note,
+    });
+
+    emailDelivery = result;
+  } catch (error) {
+    emailDelivery = {
+      attempted: true,
+      sent: false,
+      reason: error instanceof Error ? error.message : "Unknown invite email failure.",
+    };
+  }
+
+  await logAccessAudit({
+    ownerUserId: actor.id,
+    actorUserId: actor.id,
+    action: "CARE_INVITE_RESENT",
+    targetType: "CareInvite",
+    targetId: refreshedInvite.id,
+    metadata: {
+      email: refreshedInvite.email,
+      token: refreshedInvite.token,
+      emailDelivery,
+    },
+  });
+
+  revalidatePath("/care-team");
+}
+
+export async function revokeCareInviteAction(formData: FormData) {
+  const actor = await requireUser();
+  const inviteId = String(formData.get("inviteId") || "").trim();
+
+  if (!inviteId) {
+    throw new Error("Invite ID is required.");
+  }
+
+  const invite = await db.careInvite.findFirst({
+    where: {
+      id: inviteId,
+      ownerUserId: actor.id,
+      status: "PENDING",
+    },
+  });
+
+  if (!invite) {
+    throw new Error("Pending invite not found.");
+  }
+
+  await db.careInvite.update({
+    where: { id: invite.id },
+    data: {
+      status: "REVOKED",
+    },
+  });
+
+  await logAccessAudit({
+    ownerUserId: actor.id,
+    actorUserId: actor.id,
+    action: "CARE_INVITE_REVOKED",
+    targetType: "CareInvite",
+    targetId: invite.id,
+    metadata: {
+      email: invite.email,
       token: invite.token,
     },
   });

--- a/app/care-team/page.tsx
+++ b/app/care-team/page.tsx
@@ -12,7 +12,9 @@ import {
   acceptCareInviteAction,
   declineCareInviteAction,
   inviteCareMemberAction,
+  resendCareInviteAction,
   revokeCareAccessAction,
+  revokeCareInviteAction,
   updateCareAccessPermissionsAction,
 } from "./actions";
 
@@ -41,6 +43,8 @@ export default async function CareTeamPage() {
     headerStore.get("x-forwarded-proto") ?? (host.includes("localhost") ? "http" : "https");
   const origin =
     process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "") || (host ? `${proto}://${host}` : "");
+
+  const emailDeliveryEnabled = Boolean(process.env.RESEND_API_KEY && process.env.RESEND_FROM_EMAIL);
 
   const [outgoingInvites, currentTeam, incomingInvites, sharedPatients] =
     await Promise.all([
@@ -79,7 +83,7 @@ export default async function CareTeamPage() {
       <div className="mx-auto max-w-7xl space-y-6 p-6">
         <PageHeader
           title="Care Team"
-          description="Invite caregivers, doctors, or lab staff to collaborate securely. Each invite generates a shareable link and can be accepted via email-matched sign-in."
+          description="Invite caregivers, doctors, or lab staff to collaborate securely. Each invite can now be emailed directly and still includes a fallback shareable link."
           action={
             <div className="flex flex-wrap gap-3">
               <Link
@@ -347,8 +351,13 @@ export default async function CareTeamPage() {
                       </StatusPill>
                     </div>
 
-                    <div className="mt-4">
+                    <div className="mt-4 space-y-2">
                       <CopyInviteField value={inviteLink} />
+                      <p className="text-xs text-muted-foreground">
+                        {emailDeliveryEnabled
+                          ? "Invite emails are enabled. You can resend the email anytime while the invite is pending."
+                          : "Manual link mode is active. Copy this invite URL and send it yourself."}
+                      </p>
                     </div>
 
                     <div className="mt-4 flex flex-wrap gap-3">
@@ -358,6 +367,30 @@ export default async function CareTeamPage() {
                       >
                         Open invite preview
                       </Link>
+
+                      {shownStatus === "PENDING" ? (
+                        <>
+                          <form action={resendCareInviteAction}>
+                            <input type="hidden" name="inviteId" value={invite.id} />
+                            <button
+                              type="submit"
+                              className="inline-flex items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 py-2 text-sm font-medium hover:bg-muted/50"
+                            >
+                              Resend email
+                            </button>
+                          </form>
+
+                          <form action={revokeCareInviteAction}>
+                            <input type="hidden" name="inviteId" value={invite.id} />
+                            <button
+                              type="submit"
+                              className="inline-flex items-center justify-center rounded-2xl border border-rose-200/70 bg-rose-50/70 px-4 py-2 text-sm font-medium text-rose-700 hover:bg-rose-100/70 dark:border-rose-900/50 dark:bg-rose-950/40 dark:text-rose-200"
+                            >
+                              Revoke invite
+                            </button>
+                          </form>
+                        </>
+                      ) : null}
                     </div>
                   </div>
                 );

--- a/lib/invite-email.ts
+++ b/lib/invite-email.ts
@@ -1,0 +1,95 @@
+export function isInviteEmailConfigured() {
+  return Boolean(process.env.RESEND_API_KEY && process.env.RESEND_FROM_EMAIL);
+}
+
+function escapeHtml(input: string) {
+  return input
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export async function sendCareInviteEmail(args: {
+  to: string;
+  inviteLink: string;
+  ownerName: string;
+  ownerEmail: string;
+  accessRole: string;
+  expiresAt: Date;
+  note?: string | null;
+}) {
+  const apiKey = process.env.RESEND_API_KEY;
+  const from = process.env.RESEND_FROM_EMAIL;
+
+  if (!apiKey || !from) {
+    return {
+      attempted: false,
+      sent: false,
+      reason: "Invite email delivery is not configured.",
+    } as const;
+  }
+
+  const safeOwnerName = escapeHtml(args.ownerName);
+  const safeOwnerEmail = escapeHtml(args.ownerEmail);
+  const safeAccessRole = escapeHtml(args.accessRole);
+  const safeInviteLink = escapeHtml(args.inviteLink);
+  const safeExpiry = escapeHtml(args.expiresAt.toLocaleString());
+  const safeNote = args.note ? escapeHtml(args.note) : "";
+
+  const subject = `${args.ownerName} invited you to VitaVault`;
+  const text = [
+    `You were invited by ${args.ownerName} (${args.ownerEmail}) to join a VitaVault care team.`,
+    `Role: ${args.accessRole}`,
+    `Expires: ${args.expiresAt.toLocaleString()}`,
+    args.note ? `Note: ${args.note}` : null,
+    `Accept invite: ${args.inviteLink}`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const html = `
+    <div style="font-family:Arial,sans-serif;line-height:1.6;color:#111827;max-width:640px;margin:0 auto;padding:24px;">
+      <h2 style="margin:0 0 12px;font-size:22px;">You were invited to a VitaVault care team</h2>
+      <p style="margin:0 0 12px;">${safeOwnerName} (${safeOwnerEmail}) invited you to collaborate in VitaVault.</p>
+      <p style="margin:0 0 6px;"><strong>Role:</strong> ${safeAccessRole}</p>
+      <p style="margin:0 0 6px;"><strong>Expires:</strong> ${safeExpiry}</p>
+      ${safeNote ? `<p style="margin:0 0 12px;"><strong>Note:</strong> ${safeNote}</p>` : ""}
+      <p style="margin:18px 0;">
+        <a href="${safeInviteLink}" style="display:inline-block;background:#111827;color:#ffffff;text-decoration:none;padding:12px 18px;border-radius:12px;font-weight:600;">Open invite</a>
+      </p>
+      <p style="margin:0 0 12px;font-size:14px;color:#4b5563;">This invite must be accepted using the exact email address it was sent to.</p>
+      <p style="margin:0;font-size:13px;color:#6b7280;word-break:break-all;">${safeInviteLink}</p>
+    </div>
+  `;
+
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from,
+      to: [args.to],
+      subject,
+      text,
+      html,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Resend request failed (${response.status}): ${errorText}`);
+  }
+
+  const payload = (await response.json()) as { id?: string };
+
+  return {
+    attempted: true,
+    sent: true,
+    provider: "resend",
+    messageId: payload.id ?? null,
+  } as const;
+}


### PR DESCRIPTION
## Summary
- added invite email delivery via Resend when configured
- kept manual share-link mode as fallback
- added resend email action for pending invites
- added revoke pending invite action
- refreshed token and expiry on resend
- added audit logging for invite send, resend, and revoke
- surfaced invite delivery mode in the Care Team page

## Why this matters
This makes Care Team feel much more like a real business-facing collaboration feature instead of a copy-link-only workflow.

## Testing
- [x] run `npm run typecheck`
- [x] run `npm run lint`
- [x] create invite with email delivery not configured
- [x] confirm invite still works with manual copy link
- [x] configure `RESEND_API_KEY` and `RESEND_FROM_EMAIL`
- [x] create invite and confirm email is sent
- [x] resend a pending invite
- [x] revoke a pending invite
- [x] confirm revoked invite can no longer be accepted