### PR TITLE
Add reminder email delivery and alert digest emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@ OPENAI_API_KEY=""
 OPENAI_MODEL="gpt-5-mini"
 INTERNAL_API_SECRET=
 
-# Invite email delivery (optional)
-# If left blank, care invites still work in manual link mode using the shareable link.
+
+# Optional outbound email delivery for care invites, reminders, and alert digests
 RESEND_API_KEY=""
 RESEND_FROM_EMAIL="VitaVault <no-reply@example.com>"

--- a/app/alerts/actions.ts
+++ b/app/alerts/actions.ts
@@ -5,6 +5,7 @@ import { AlertRuleCategory, AlertSeverity, AlertSourceType, AlertStatus, Symptom
 import { db } from "@/lib/db";
 import { requireUser } from "@/lib/session";
 import { createAlertAuditLog } from "@/lib/alerts/audit";
+import { outboundEmailEnabled, sendAlertDigestEmail } from "@/lib/outbound-email";
 
 function toOptionalString(value: FormDataEntryValue | null) {
   const text = String(value ?? "").trim();
@@ -161,4 +162,60 @@ export async function deleteAlertRule(formData: FormData) {
 
   revalidatePath("/alerts/rules");
   revalidatePath("/alerts");
+}
+
+
+export async function sendAlertDigestAction() {
+  const user = await requireUser();
+
+  if (!user.email) {
+    throw new Error("Your account must have an email address to receive alert digests.");
+  }
+
+  if (!outboundEmailEnabled()) {
+    throw new Error("Email delivery is not configured.");
+  }
+
+  const alerts = await db.alertEvent.findMany({
+    where: {
+      userId: user.id!,
+      status: {
+        in: ["OPEN", "ACKNOWLEDGED"],
+      },
+    },
+    orderBy: [{ severity: "desc" }, { createdAt: "desc" }],
+    take: 10,
+    select: {
+      id: true,
+      title: true,
+      message: true,
+      severity: true,
+      status: true,
+      createdAt: true,
+    },
+  });
+
+  if (!alerts.length) {
+    throw new Error("No open or acknowledged alerts found.");
+  }
+
+  await sendAlertDigestEmail({
+    to: user.email,
+    patientName: user.name || user.email,
+    alerts,
+  });
+
+  await Promise.all(
+    alerts.map((alert) =>
+      createAlertAuditLog({
+        userId: user.id!,
+        alertId: alert.id,
+        actorUserId: user.id!,
+        action: "alert.digest_emailed",
+      }),
+    ),
+  );
+
+  revalidatePath("/alerts");
+  revalidatePath("/dashboard");
 }

--- a/app/alerts/page.tsx
+++ b/app/alerts/page.tsx
@@ -1,12 +1,14 @@
 import Link from "next/link";
-import { BellRing, CircleAlert, ShieldCheck, Workflow } from "lucide-react";
+import { BellRing, CircleAlert, Mail, ShieldCheck, Workflow } from "lucide-react";
 import { AppShell } from "@/components/app-shell";
 import { PageHeader, StatusPill } from "@/components/common";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
 import { requireUser } from "@/lib/session";
+import { outboundEmailEnabled } from "@/lib/outbound-email";
 import { getAlertList, getAlertRules } from "@/lib/alerts/queries";
 import { AlertFilterBar } from "@/components/alerts/alert-filter-bar";
 import { AlertList } from "@/components/alerts/alert-list";
+import { sendAlertDigestAction } from "./actions";
 
 export default async function AlertsPage({
   searchParams,
@@ -19,6 +21,8 @@ export default async function AlertsPage({
   const status = typeof params.status === "string" ? params.status : "ALL";
   const severity = typeof params.severity === "string" ? params.severity : "ALL";
   const category = typeof params.category === "string" ? params.category : "ALL";
+
+  const emailEnabled = outboundEmailEnabled();
 
   const [alerts, rules] = await Promise.all([
     getAlertList({
@@ -47,6 +51,15 @@ export default async function AlertsPage({
               >
                 Manage rules
               </Link>
+              <form action={sendAlertDigestAction}>
+                <button
+                  type="submit"
+                  className="inline-flex items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 py-2 text-sm font-medium hover:bg-muted/50"
+                >
+                  <Mail className="mr-2 h-4 w-4" />
+                  Email digest
+                </button>
+              </form>
               <Link
                 href="/dashboard"
                 className="inline-flex items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 py-2 text-sm font-medium hover:bg-muted/50"

--- a/app/reminders/actions.ts
+++ b/app/reminders/actions.ts
@@ -2,6 +2,9 @@
 
 import { revalidatePath } from "next/cache";
 import { requireUser } from "@/lib/session";
+import { db } from "@/lib/db";
+import { createReminderAuditLog } from "@/lib/reminders/service";
+import { outboundEmailEnabled, sendReminderEmail } from "@/lib/outbound-email";
 import {
   generateReminderInstances,
   markDueRemindersAsOverdue,
@@ -119,6 +122,125 @@ export async function updateReminderScheduleAction(formData: FormData) {
     quietHoursStart: parseOptionalString(formData.get("quietHoursStart")) ?? undefined,
     quietHoursEnd: parseOptionalString(formData.get("quietHoursEnd")) ?? undefined,
   });
+
+  revalidateReminderSurfaces();
+}
+
+export async function sendReminderEmailAction(formData: FormData) {
+  const user = await requireUser();
+  const reminderId = String(formData.get("reminderId") || "").trim();
+
+  if (!user.email) {
+    throw new Error("Your account must have an email address to receive reminder emails.");
+  }
+
+  const reminder = await db.reminder.findFirst({
+    where: {
+      id: reminderId,
+      userId: user.id!,
+    },
+    select: {
+      id: true,
+      title: true,
+      description: true,
+      dueAt: true,
+      state: true,
+      timezone: true,
+      gracePeriodMinutes: true,
+    },
+  });
+
+  if (!reminder) {
+    throw new Error("Reminder not found.");
+  }
+
+  if (!outboundEmailEnabled()) {
+    throw new Error("Email delivery is not configured.");
+  }
+
+  await sendReminderEmail({
+    to: user.email,
+    patientName: user.name || user.email,
+    reminder,
+  });
+
+  await db.reminder.update({
+    where: { id: reminder.id },
+    data: {
+      channel: "EMAIL",
+      state: reminder.state === "DUE" ? "SENT" : reminder.state,
+      sentAt: new Date(),
+    },
+  });
+
+  await createReminderAuditLog({
+    userId: user.id!,
+    actorUserId: user.id!,
+    reminderId: reminder.id,
+    action: "reminder.email_sent",
+    metadata: { manualSend: true },
+  });
+
+  revalidateReminderSurfaces();
+}
+
+export async function sendDueReminderDigestAction() {
+  const user = await requireUser();
+
+  if (!user.email) {
+    throw new Error("Your account must have an email address to receive reminder emails.");
+  }
+
+  if (!outboundEmailEnabled()) {
+    throw new Error("Email delivery is not configured.");
+  }
+
+  const reminders = await db.reminder.findMany({
+    where: {
+      userId: user.id!,
+      state: { in: ["DUE", "OVERDUE"] },
+    },
+    orderBy: [{ dueAt: "asc" }, { createdAt: "desc" }],
+    take: 5,
+    select: {
+      id: true,
+      title: true,
+      description: true,
+      dueAt: true,
+      state: true,
+      timezone: true,
+      gracePeriodMinutes: true,
+    },
+  });
+
+  if (!reminders.length) {
+    throw new Error("No due or overdue reminders found.");
+  }
+
+  for (const reminder of reminders) {
+    await sendReminderEmail({
+      to: user.email,
+      patientName: user.name || user.email,
+      reminder,
+    });
+
+    await db.reminder.update({
+      where: { id: reminder.id },
+      data: {
+        channel: "EMAIL",
+        state: reminder.state === "DUE" ? "SENT" : reminder.state,
+        sentAt: new Date(),
+      },
+    });
+
+    await createReminderAuditLog({
+      userId: user.id!,
+      actorUserId: user.id!,
+      reminderId: reminder.id,
+      action: "reminder.email_sent",
+      metadata: { manualSend: false, batchSend: true },
+    });
+  }
 
   revalidateReminderSurfaces();
 }

--- a/app/reminders/page.tsx
+++ b/app/reminders/page.tsx
@@ -1,4 +1,4 @@
-import { BellRing, CalendarSync, Clock3, Pill, Stethoscope } from "lucide-react";
+import { BellRing, CalendarSync, Clock3, Mail, Pill, Stethoscope } from "lucide-react";
 import { AppShell } from "@/components/app-shell";
 import { PageHeader, StatusPill } from "@/components/common";
 import {
@@ -9,6 +9,7 @@ import {
   CardTitle,
 } from "@/components/ui";
 import { requireUser } from "@/lib/session";
+import { outboundEmailEnabled } from "@/lib/outbound-email";
 import { getReminderCenterData } from "@/lib/reminders/queries";
 import {
   reminderStateLabel,
@@ -18,6 +19,8 @@ import {
 import {
   completeReminderAction,
   regenerateRemindersAction,
+  sendDueReminderDigestAction,
+  sendReminderEmailAction,
   skipReminderAction,
   snoozeReminderAction,
 } from "./actions";
@@ -45,6 +48,7 @@ export default async function RemindersPage({
     type,
   });
 
+  const emailEnabled = outboundEmailEnabled();
   const overdueCount = data.reminders.filter((item) => item.state === "OVERDUE").length;
   const dueSoonCount = data.reminders.filter((item) => {
     const dueMs = new Date(item.dueAt).getTime();
@@ -58,20 +62,32 @@ export default async function RemindersPage({
           title="Reminder Center"
           description="Medication and appointment reminders with due-state tracking, snooze controls, and regeneration tools."
           action={
-            <form action={regenerateRemindersAction} className="flex items-center gap-3">
-              <input
-                type="date"
-                name="targetDate"
-                defaultValue={toDateInputValue(new Date())}
-                className="rounded-2xl border border-border/70 bg-background/70 px-4 py-2.5 text-sm"
-              />
-              <button
-                type="submit"
-                className="inline-flex items-center justify-center rounded-2xl bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground shadow-sm hover:opacity-95"
-              >
-                Regenerate
-              </button>
-            </form>
+            <div className="flex flex-wrap items-center gap-3">
+              <form action={regenerateRemindersAction} className="flex items-center gap-3">
+                <input
+                  type="date"
+                  name="targetDate"
+                  defaultValue={toDateInputValue(new Date())}
+                  className="rounded-2xl border border-border/70 bg-background/70 px-4 py-2.5 text-sm"
+                />
+                <button
+                  type="submit"
+                  className="inline-flex items-center justify-center rounded-2xl bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground shadow-sm hover:opacity-95"
+                >
+                  Regenerate
+                </button>
+              </form>
+
+              <form action={sendDueReminderDigestAction}>
+                <button
+                  type="submit"
+                  className="inline-flex items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 py-2.5 text-sm font-medium hover:bg-muted/50"
+                >
+                  <Mail className="mr-2 h-4 w-4" />
+                  Email due reminders
+                </button>
+              </form>
+            </div>
           }
         />
 
@@ -110,10 +126,13 @@ export default async function RemindersPage({
 
               <div className="rounded-3xl border border-border/60 bg-background/40 p-5">
                 <div className="flex items-center justify-between">
-                  <p className="text-sm font-medium text-muted-foreground">Coverage</p>
+                  <p className="text-sm font-medium text-muted-foreground">Delivery mode</p>
                   <Pill className="h-5 w-5 text-emerald-500" />
                 </div>
-                <p className="mt-4 text-lg font-semibold">Medication + appointment</p>
+                <p className="mt-4 text-lg font-semibold">{emailEnabled ? "In-app + email" : "In-app only"}</p>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  {emailEnabled ? "Resend-backed email delivery is ready." : "Configure Resend to unlock outbound reminder emails."}
+                </p>
               </div>
             </CardContent>
           </Card>
@@ -232,6 +251,17 @@ export default async function RemindersPage({
                         className="inline-flex items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 py-2 text-sm font-medium hover:bg-muted/50"
                       >
                         Snooze
+                      </button>
+                    </form>
+
+                    <form action={sendReminderEmailAction}>
+                      <input type="hidden" name="reminderId" value={reminder.id} />
+                      <button
+                        type="submit"
+                        className="inline-flex items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 py-2 text-sm font-medium hover:bg-muted/50"
+                      >
+                        <Mail className="mr-2 h-4 w-4" />
+                        Send email
                       </button>
                     </form>
 

--- a/lib/outbound-email.ts
+++ b/lib/outbound-email.ts
@@ -1,0 +1,178 @@
+import { AlertSeverity, AlertStatus, ReminderState } from "@prisma/client";
+
+const RESEND_API_URL = "https://api.resend.com/emails";
+
+export function outboundEmailEnabled() {
+  return Boolean(process.env.RESEND_API_KEY && process.env.RESEND_FROM_EMAIL);
+}
+
+async function sendEmail(args: {
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+}) {
+  if (!outboundEmailEnabled()) {
+    throw new Error("Email delivery is not configured.");
+  }
+
+  const response = await fetch(RESEND_API_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.RESEND_API_KEY!}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: process.env.RESEND_FROM_EMAIL!,
+      to: [args.to],
+      subject: args.subject,
+      html: args.html,
+      text: args.text,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Email delivery failed: ${body || response.statusText}`);
+  }
+
+  return response.json().catch(() => null);
+}
+
+function reminderStateLabel(state: ReminderState) {
+  switch (state) {
+    case ReminderState.DUE:
+      return "Due";
+    case ReminderState.SENT:
+      return "Sent";
+    case ReminderState.OVERDUE:
+      return "Overdue";
+    case ReminderState.SKIPPED:
+      return "Skipped";
+    case ReminderState.COMPLETED:
+      return "Completed";
+    case ReminderState.MISSED:
+      return "Missed";
+    default:
+      return state;
+  }
+}
+
+function severityLabel(severity: AlertSeverity) {
+  return severity.charAt(0) + severity.slice(1).toLowerCase();
+}
+
+export async function sendReminderEmail(args: {
+  to: string;
+  patientName: string;
+  reminder: {
+    id: string;
+    title: string;
+    description: string | null;
+    dueAt: Date;
+    state: ReminderState;
+    timezone: string | null;
+    gracePeriodMinutes: number | null;
+  };
+}) {
+  const dueText = new Date(args.reminder.dueAt).toLocaleString("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: args.reminder.timezone || undefined,
+  });
+
+  const stateText = reminderStateLabel(args.reminder.state);
+  const subject = `VitaVault reminder: ${args.reminder.title}`;
+  const html = `
+    <div style="font-family:Arial,sans-serif;line-height:1.5;color:#111827">
+      <h2 style="margin-bottom:8px">Reminder for ${escapeHtml(args.patientName)}</h2>
+      <p style="margin:0 0 16px">This reminder was sent from VitaVault.</p>
+      <div style="border:1px solid #e5e7eb;border-radius:16px;padding:16px;background:#f9fafb">
+        <p style="margin:0 0 8px"><strong>Title:</strong> ${escapeHtml(args.reminder.title)}</p>
+        <p style="margin:0 0 8px"><strong>Due:</strong> ${escapeHtml(dueText)}</p>
+        <p style="margin:0 0 8px"><strong>Status:</strong> ${escapeHtml(stateText)}</p>
+        <p style="margin:0 0 8px"><strong>Grace period:</strong> ${args.reminder.gracePeriodMinutes ?? 60} minutes</p>
+        <p style="margin:0"><strong>Details:</strong> ${escapeHtml(args.reminder.description || "No additional description.")}</p>
+      </div>
+    </div>
+  `;
+  const text = [
+    `Reminder for ${args.patientName}`,
+    `Title: ${args.reminder.title}`,
+    `Due: ${dueText}`,
+    `Status: ${stateText}`,
+    `Grace period: ${args.reminder.gracePeriodMinutes ?? 60} minutes`,
+    `Details: ${args.reminder.description || "No additional description."}`,
+  ].join("\n");
+
+  return sendEmail({ to: args.to, subject, html, text });
+}
+
+export async function sendAlertDigestEmail(args: {
+  to: string;
+  patientName: string;
+  alerts: Array<{
+    id: string;
+    title: string;
+    message: string;
+    severity: AlertSeverity;
+    status: AlertStatus;
+    createdAt: Date;
+  }>;
+}) {
+  const openAlerts = args.alerts.filter((alert) => alert.status === AlertStatus.OPEN);
+  const criticalAlerts = args.alerts.filter((alert) => alert.severity === AlertSeverity.CRITICAL);
+  const subject = `VitaVault alert digest: ${openAlerts.length} open alert${openAlerts.length === 1 ? "" : "s"}`;
+  const rows = args.alerts
+    .map((alert) => {
+      const created = new Date(alert.createdAt).toLocaleString("en-US", {
+        dateStyle: "medium",
+        timeStyle: "short",
+      });
+      return `
+        <tr>
+          <td style="padding:10px;border-top:1px solid #e5e7eb">${escapeHtml(alert.title)}</td>
+          <td style="padding:10px;border-top:1px solid #e5e7eb">${escapeHtml(severityLabel(alert.severity))}</td>
+          <td style="padding:10px;border-top:1px solid #e5e7eb">${escapeHtml(alert.status)}</td>
+          <td style="padding:10px;border-top:1px solid #e5e7eb">${escapeHtml(created)}</td>
+        </tr>
+      `;
+    })
+    .join("");
+
+  const html = `
+    <div style="font-family:Arial,sans-serif;line-height:1.5;color:#111827">
+      <h2 style="margin-bottom:8px">Alert digest for ${escapeHtml(args.patientName)}</h2>
+      <p style="margin:0 0 16px">Open alerts: <strong>${openAlerts.length}</strong> · Critical alerts: <strong>${criticalAlerts.length}</strong></p>
+      <table style="width:100%;border-collapse:collapse;border:1px solid #e5e7eb;border-radius:16px;overflow:hidden;background:#fff">
+        <thead style="background:#f9fafb;text-align:left">
+          <tr>
+            <th style="padding:10px">Alert</th>
+            <th style="padding:10px">Severity</th>
+            <th style="padding:10px">Status</th>
+            <th style="padding:10px">Created</th>
+          </tr>
+        </thead>
+        <tbody>${rows || `<tr><td colspan="4" style="padding:12px">No alerts to include.</td></tr>`}</tbody>
+      </table>
+    </div>
+  `;
+  const text = [
+    `Alert digest for ${args.patientName}`,
+    `Open alerts: ${openAlerts.length}`,
+    `Critical alerts: ${criticalAlerts.length}`,
+    "",
+    ...args.alerts.map((alert) => `${alert.title} | ${severityLabel(alert.severity)} | ${alert.status} | ${new Date(alert.createdAt).toLocaleString()}`),
+  ].join("\n");
+
+  return sendEmail({ to: args.to, subject, html, text });
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}


### PR DESCRIPTION
## Summary
- added outbound reminder email delivery
- added bulk "Email due reminders" action
- added per-reminder email send action
- added alert digest email action
- added audit logging for reminder email sends and alert digests
- surfaced email delivery readiness in Reminder Center and Alert Center
- reused Resend-style outbound email configuration

## Why this matters
This makes VitaVault feel much more like a business-ready communication workflow instead of an in-app-only tracker.

## Testing
- [x] set `RESEND_API_KEY`
- [x] set `RESEND_FROM_EMAIL`
- [x] run `npm run typecheck`
- [x] run `npm run lint`
- [x] open `/reminders`
- [x] send one reminder email
- [x] send bulk due reminders
- [x] open `/alerts`
- [x] send alert digest email