### PR TITLE
Resolve reminder email follow-up typecheck and lint issues

### DIFF
--- a/app/alerts/page.tsx
+++ b/app/alerts/page.tsx
@@ -4,7 +4,6 @@ import { AppShell } from "@/components/app-shell";
 import { PageHeader, StatusPill } from "@/components/common";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
 import { requireUser } from "@/lib/session";
-import { outboundEmailEnabled } from "@/lib/outbound-email";
 import { getAlertList, getAlertRules } from "@/lib/alerts/queries";
 import { AlertFilterBar } from "@/components/alerts/alert-filter-bar";
 import { AlertList } from "@/components/alerts/alert-list";
@@ -22,7 +21,6 @@ export default async function AlertsPage({
   const severity = typeof params.severity === "string" ? params.severity : "ALL";
   const category = typeof params.category === "string" ? params.category : "ALL";
 
-  const emailEnabled = outboundEmailEnabled();
 
   const [alerts, rules] = await Promise.all([
     getAlertList({

--- a/lib/reminders/service.ts
+++ b/lib/reminders/service.ts
@@ -13,7 +13,7 @@ function parseTimeOfDay(timeOfDay: string) {
   };
 }
 
-async function createReminderAuditLog(args: {
+export async function createReminderAuditLog(args: {
   userId: string;
   reminderId?: string | null;
   actorUserId?: string | null;


### PR DESCRIPTION
## Summary
- exported `createReminderAuditLog` from the reminders service
- removed unused alert page email readiness variable

## Why this matters
The reminder email feature introduced a valid service dependency, but the helper was not exported. This patch keeps the feature intact and restores CI health.

## Testing
- [x] run `npm run typecheck`
- [x] run `npm run lint`
- [x] open `/reminders`
- [ ] send one reminder email
- [ ] open `/alerts`