### PR TITLE
Align security page device connection query with Prisma enum

### DIFF
--- a/app/security/page.tsx
+++ b/app/security/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { DeviceConnectionStatus } from "@prisma/client";
 import { LockKeyhole, ShieldCheck, Smartphone, TriangleAlert } from "lucide-react";
 import { AppShell } from "@/components/app-shell";
 import { PageHeader, StatusPill } from "@/components/common";
@@ -51,7 +52,10 @@ export default async function SecurityPage() {
       take: 12,
     }),
     db.deviceConnection.count({
-      where: { userId: user.id!, status: { in: ["CONNECTED", "SYNCING", "NEEDS_REAUTH"] } },
+      where: {
+        userId: user.id!,
+        status: { in: [DeviceConnectionStatus.ACTIVE, DeviceConnectionStatus.ERROR] },
+      },
     }),
     db.careInvite.count({
       where: { ownerUserId: user.id!, status: "PENDING" },


### PR DESCRIPTION
## Summary
- imported `DeviceConnectionStatus` from Prisma
- replaced invalid device status string literals in the Security page
- counted active linked exposure using valid enum values only

## Why this matters
The Security Center feature was functionally fine, but it queried device connection statuses that do not exist in the current schema. This restores typecheck compatibility without changing the feature intent.

## Testing
- [ ] run `npm run typecheck`
- [ ] run `npm run lint`
- [ ] open `/security`
- [ ] confirm linked exposure card renders correctly