### PR TITLE
Add email verification and password reset flows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,8 @@ OPENAI_API_KEY=""
 OPENAI_MODEL="gpt-5-mini"
 INTERNAL_API_SECRET=
 
-
-# Optional outbound email delivery for care invites, reminders, and alert digests
+# Account email workflows
+APP_URL="http://localhost:3000"
+EMAIL_VERIFICATION_REQUIRED="false"
 RESEND_API_KEY=""
 RESEND_FROM_EMAIL="VitaVault <no-reply@example.com>"

--- a/app/account-actions.ts
+++ b/app/account-actions.ts
@@ -1,0 +1,156 @@
+"use server";
+
+import bcrypt from "bcryptjs";
+import { z } from "zod";
+
+import { db } from "@/lib/db";
+import { requireUser } from "@/lib/session";
+import {
+  clearPasswordResetToken,
+  consumePasswordResetToken,
+  isEmailDeliveryConfigured,
+  sendEmailVerificationEmail,
+  sendPasswordResetEmail,
+} from "@/lib/account-email";
+
+export type AccountActionState = {
+  error: string | null;
+  success: string | null;
+};
+
+const initialResponse = { error: null, success: null } satisfies AccountActionState;
+
+const forgotPasswordSchema = z.object({
+  email: z.string().trim().email(),
+});
+
+const resetPasswordSchema = z
+  .object({
+    token: z.string().min(1),
+    password: z.string().min(8).max(64),
+    confirmPassword: z.string().min(8).max(64),
+  })
+  .superRefine((value, ctx) => {
+    if (value.password !== value.confirmPassword) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["confirmPassword"],
+        message: "Passwords do not match.",
+      });
+    }
+  });
+
+export async function resendVerificationEmailAction(): Promise<AccountActionState> {
+  const user = await requireUser();
+
+  if (!user.email) {
+    return { error: "Signed-in user has no email address.", success: null };
+  }
+
+  const dbUser = await db.user.findUnique({
+    where: { id: user.id! },
+    select: { id: true, email: true, name: true, emailVerified: true },
+  });
+
+  if (!dbUser) {
+    return { error: "User not found.", success: null };
+  }
+
+  if (dbUser.emailVerified) {
+    return { error: null, success: "Your email is already verified." };
+  }
+
+  if (!isEmailDeliveryConfigured()) {
+    return {
+      error: "Verification email delivery is not configured yet.",
+      success: null,
+    };
+  }
+
+  await sendEmailVerificationEmail(dbUser);
+
+  return {
+    error: null,
+    success: "Verification email sent. Please check your inbox.",
+  };
+}
+
+export async function forgotPasswordAction(
+  _: AccountActionState = initialResponse,
+  formData: FormData
+): Promise<AccountActionState> {
+  const parsed = forgotPasswordSchema.safeParse({
+    email: formData.get("email"),
+  });
+
+  if (!parsed.success) {
+    return {
+      error: parsed.error.issues[0]?.message ?? "Enter a valid email address.",
+      success: null,
+    };
+  }
+
+  if (!isEmailDeliveryConfigured()) {
+    return {
+      error: "Password reset email delivery is not configured yet.",
+      success: null,
+    };
+  }
+
+  const email = parsed.data.email.toLowerCase().trim();
+
+  const user = await db.user.findUnique({
+    where: { email },
+    select: { id: true, email: true, name: true, passwordHash: true },
+  });
+
+  if (user?.passwordHash) {
+    await sendPasswordResetEmail(user);
+  }
+
+  return {
+    error: null,
+    success: "If an account exists for that email, a reset link has been sent.",
+  };
+}
+
+export async function resetPasswordAction(
+  _: AccountActionState = initialResponse,
+  formData: FormData
+): Promise<AccountActionState> {
+  const parsed = resetPasswordSchema.safeParse({
+    token: formData.get("token"),
+    password: formData.get("password"),
+    confirmPassword: formData.get("confirmPassword"),
+  });
+
+  if (!parsed.success) {
+    return {
+      error: parsed.error.issues[0]?.message ?? "Invalid password reset request.",
+      success: null,
+    };
+  }
+
+  const tokenRecord = await consumePasswordResetToken(parsed.data.token);
+
+  if (!tokenRecord) {
+    return {
+      error: "This reset link is invalid or expired.",
+      success: null,
+    };
+  }
+
+  const passwordHash = await bcrypt.hash(parsed.data.password, 12);
+
+  await db.user.update({
+    where: { id: tokenRecord.userId },
+    data: { passwordHash },
+  });
+
+  await clearPasswordResetToken(tokenRecord.token);
+
+  return {
+    error: null,
+    success: "Password updated. You can now sign in with your new password.",
+  };
+}

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -18,6 +18,11 @@ import { requireUser } from "@/lib/session";
 import { deleteUpload, saveUpload } from "@/lib/upload";
 import { validateDocumentLinkOwnership } from "@/lib/document-links";
 import { healthProfileSchema, signupSchema } from "@/lib/validations";
+import {
+  isEmailDeliveryConfigured,
+  isEmailVerificationRequired,
+  sendEmailVerificationEmail,
+} from "@/lib/account-email";
 
 export type AuthActionState = {
   error: string | null;
@@ -74,9 +79,18 @@ export async function signupAction(
     return { error: "An account with that email already exists.", success: null };
   }
 
+  const requireVerification = isEmailVerificationRequired();
+
+  if (requireVerification && !isEmailDeliveryConfigured()) {
+    return {
+      error: "Email verification is required, but email delivery is not configured yet.",
+      success: null,
+    };
+  }
+
   const passwordHash = await bcrypt.hash(password, 12);
 
-  await db.user.create({
+  const createdUser = await db.user.create({
     data: {
       name: parsed.data.name.trim(),
       email,
@@ -87,7 +101,23 @@ export async function signupAction(
         },
       },
     },
+    select: {
+      id: true,
+      email: true,
+      name: true,
+    },
   });
+
+  if (isEmailDeliveryConfigured()) {
+    await sendEmailVerificationEmail(createdUser);
+  }
+
+  if (requireVerification) {
+    return {
+      error: null,
+      success: "Account created. Please verify your email before signing in.",
+    };
+  }
 
   try {
     await signIn("credentials", {
@@ -122,6 +152,7 @@ export async function loginAction(
     select: {
       id: true,
       passwordHash: true,
+      emailVerified: true,
     },
   });
 
@@ -132,6 +163,13 @@ export async function loginAction(
   const isValid = await bcrypt.compare(password, user.passwordHash);
   if (!isValid) {
     return { error: "Invalid email or password.", success: null };
+  }
+
+  if (isEmailVerificationRequired() && !user.emailVerified) {
+    return {
+      error: "Please verify your email before signing in.",
+      success: null,
+    };
   }
 
   try {

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,0 +1,5 @@
+import { ForgotPasswordForm } from "@/components/account-recovery-forms";
+
+export default function ForgotPasswordPage() {
+  return <ForgotPasswordForm />;
+}

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+
+import { ResetPasswordForm } from "@/components/account-recovery-forms";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle, Button } from "@/components/ui";
+
+export default async function ResetPasswordPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ token?: string }>;
+}) {
+  const params = (await searchParams) ?? {};
+  const token = typeof params.token === "string" ? params.token : "";
+
+  if (!token) {
+    return (
+      <div className="mx-auto w-full max-w-md p-6">
+        <Card className="mt-10">
+          <CardHeader>
+            <CardTitle>Reset link required</CardTitle>
+            <CardDescription className="mt-1">
+              This page needs a valid reset link from your email.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Link href="/forgot-password">
+              <Button className="w-full">Request a new reset link</Button>
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return <ResetPasswordForm token={token} />;
+}

--- a/app/verify-email/page.tsx
+++ b/app/verify-email/page.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+
+import { auth } from "@/lib/auth";
+import { consumeEmailVerificationToken } from "@/lib/account-email";
+import { ResendVerificationForm } from "@/components/resend-verification-form";
+import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
+
+export default async function VerifyEmailPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ token?: string }>;
+}) {
+  const params = (await searchParams) ?? {};
+  const token = typeof params.token === "string" ? params.token : "";
+
+  const session = await auth();
+  const result = token
+    ? await consumeEmailVerificationToken(token)
+    : { ok: false as const, message: "Verification link is missing." };
+
+  return (
+    <div className="mx-auto w-full max-w-md p-6">
+      <Card className="mt-10">
+        <CardHeader>
+          <CardTitle>{result.ok ? "Email verified" : "Verification failed"}</CardTitle>
+          <CardDescription className="mt-1">{result.message}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Link href="/login">
+            <Button className="w-full">Go to login</Button>
+          </Link>
+          <Link href="/dashboard">
+            <Button variant="outline" className="w-full">Open dashboard</Button>
+          </Link>
+          {!token && session?.user?.id ? <ResendVerificationForm /> : null}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/account-recovery-forms.tsx
+++ b/components/account-recovery-forms.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import Link from "next/link";
+import { useActionState } from "react";
+
+import {
+  forgotPasswordAction,
+  resetPasswordAction,
+  type AccountActionState,
+} from "@/app/account-actions";
+import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Input } from "@/components/ui";
+
+const initialState: AccountActionState = { error: null, success: null };
+
+function InlineAlert({ tone, message }: { tone: "danger" | "success"; message: string }) {
+  const cls =
+    tone === "success"
+      ? "border-emerald-200/70 bg-emerald-50/70 text-emerald-800 dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-200"
+      : "border-rose-200/70 bg-rose-50/70 text-rose-800 dark:border-rose-900/50 dark:bg-rose-950/40 dark:text-rose-200";
+
+  return <div className={`rounded-3xl border p-3 text-sm ${cls}`}>{message}</div>;
+}
+
+export function ForgotPasswordForm() {
+  const [state, action] = useActionState(forgotPasswordAction, initialState);
+
+  return (
+    <div className="mx-auto w-full max-w-md p-6">
+      <Card className="mt-10">
+        <CardHeader>
+          <CardTitle>Forgot password</CardTitle>
+          <CardDescription className="mt-1">
+            Enter your email and we&apos;ll send you a reset link.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form action={action} className="space-y-4">
+            {state?.error ? <InlineAlert tone="danger" message={state.error} /> : null}
+            {state?.success ? <InlineAlert tone="success" message={state.success} /> : null}
+
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground/90">Email</p>
+              <Input name="email" type="email" placeholder="you@email.com" required />
+            </div>
+
+            <Button type="submit" className="w-full">
+              Send reset link
+            </Button>
+
+            <p className="text-center text-sm text-muted-foreground">
+              Remembered your password? <Link href="/login" className="font-medium text-primary">Back to login</Link>
+            </p>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export function ResetPasswordForm({ token }: { token: string }) {
+  const [state, action] = useActionState(resetPasswordAction, initialState);
+
+  return (
+    <div className="mx-auto w-full max-w-md p-6">
+      <Card className="mt-10">
+        <CardHeader>
+          <CardTitle>Reset password</CardTitle>
+          <CardDescription className="mt-1">
+            Choose a new password for your VitaVault account.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form action={action} className="space-y-4">
+            <input type="hidden" name="token" value={token} />
+
+            {state?.error ? <InlineAlert tone="danger" message={state.error} /> : null}
+            {state?.success ? <InlineAlert tone="success" message={state.success} /> : null}
+
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground/90">New password</p>
+              <Input name="password" type="password" placeholder="••••••••" required />
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground/90">Confirm new password</p>
+              <Input name="confirmPassword" type="password" placeholder="••••••••" required />
+            </div>
+
+            <Button type="submit" className="w-full">
+              Update password
+            </Button>
+
+            <p className="text-center text-sm text-muted-foreground">
+              Back to <Link href="/login" className="font-medium text-primary">login</Link>
+            </p>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/auth-form.tsx
+++ b/components/auth-form.tsx
@@ -64,7 +64,12 @@ export function SignupForm({ callbackUrl }: { callbackUrl?: string }) {
             </div>
 
             <div className="space-y-2">
-              <p className="text-sm font-medium text-foreground/90">Password</p>
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-sm font-medium text-foreground/90">Password</p>
+                <Link href="/forgot-password" className="text-xs font-medium text-primary">
+                  Forgot password?
+                </Link>
+              </div>
               <Input name="password" type="password" placeholder="••••••••" required />
             </div>
 
@@ -115,7 +120,12 @@ export function LoginForm({ callbackUrl }: { callbackUrl?: string }) {
             </div>
 
             <div className="space-y-2">
-              <p className="text-sm font-medium text-foreground/90">Password</p>
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-sm font-medium text-foreground/90">Password</p>
+                <Link href="/forgot-password" className="text-xs font-medium text-primary">
+                  Forgot password?
+                </Link>
+              </div>
               <Input name="password" type="password" placeholder="••••••••" required />
             </div>
 

--- a/components/resend-verification-form.tsx
+++ b/components/resend-verification-form.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useActionState } from "react";
+
+import { resendVerificationEmailAction, type AccountActionState } from "@/app/account-actions";
+import { Button } from "@/components/ui";
+
+const initialState: AccountActionState = { error: null, success: null };
+
+export function ResendVerificationForm() {
+  const [state, action, pending] = useActionState(resendVerificationEmailAction, initialState);
+
+  return (
+    <form action={action} className="space-y-3">
+      {state?.error ? (
+        <div className="rounded-2xl border border-rose-200/70 bg-rose-50/70 p-3 text-sm text-rose-800 dark:border-rose-900/50 dark:bg-rose-950/40 dark:text-rose-200">
+          {state.error}
+        </div>
+      ) : null}
+      {state?.success ? (
+        <div className="rounded-2xl border border-emerald-200/70 bg-emerald-50/70 p-3 text-sm text-emerald-800 dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-200">
+          {state.success}
+        </div>
+      ) : null}
+      <Button type="submit" variant="outline" className="w-full" disabled={pending}>
+        {pending ? "Sending..." : "Resend verification email"}
+      </Button>
+    </form>
+  );
+}

--- a/lib/account-email.ts
+++ b/lib/account-email.ts
@@ -1,0 +1,212 @@
+import { randomBytes } from "crypto";
+import { addHours } from "date-fns";
+
+import { db } from "@/lib/db";
+
+const EMAIL_VERIFICATION_PREFIX = "email-verify";
+const PASSWORD_RESET_PREFIX = "password-reset";
+
+function getBaseUrl() {
+  const raw =
+    process.env.APP_URL?.trim() ||
+    process.env.NEXTAUTH_URL?.trim() ||
+    "http://localhost:3000";
+
+  return raw.endsWith("/") ? raw.slice(0, -1) : raw;
+}
+
+export function isEmailDeliveryConfigured() {
+  return Boolean(
+    process.env.RESEND_API_KEY?.trim() && process.env.RESEND_FROM_EMAIL?.trim()
+  );
+}
+
+export function isEmailVerificationRequired() {
+  return String(process.env.EMAIL_VERIFICATION_REQUIRED || "false").toLowerCase() === "true";
+}
+
+async function sendEmail(args: {
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+}) {
+  const apiKey = process.env.RESEND_API_KEY?.trim();
+  const from = process.env.RESEND_FROM_EMAIL?.trim();
+
+  if (!apiKey || !from) {
+    throw new Error("Email delivery is not configured.");
+  }
+
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from,
+      to: [args.to],
+      subject: args.subject,
+      html: args.html,
+      text: args.text,
+    }),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Email send failed (${response.status}): ${body}`);
+  }
+}
+
+function buildVerificationIdentifier(userId: string) {
+  return `${EMAIL_VERIFICATION_PREFIX}:${userId}`;
+}
+
+function buildResetIdentifier(userId: string) {
+  return `${PASSWORD_RESET_PREFIX}:${userId}`;
+}
+
+function makeToken() {
+  return randomBytes(24).toString("hex");
+}
+
+async function createStoredToken(args: {
+  identifier: string;
+  expiresAt: Date;
+}) {
+  await db.verificationToken.deleteMany({
+    where: {
+      identifier: args.identifier,
+    },
+  });
+
+  const token = makeToken();
+
+  await db.verificationToken.create({
+    data: {
+      identifier: args.identifier,
+      token,
+      expires: args.expiresAt,
+    },
+  });
+
+  return token;
+}
+
+export async function sendEmailVerificationEmail(args: {
+  userId: string;
+  email: string;
+  name?: string | null;
+}) {
+  const token = await createStoredToken({
+    identifier: buildVerificationIdentifier(args.userId),
+    expiresAt: addHours(new Date(), 24),
+  });
+
+  const verifyUrl = `${getBaseUrl()}/verify-email?token=${encodeURIComponent(token)}`;
+  const greeting = args.name?.trim() || "there";
+
+  await sendEmail({
+    to: args.email,
+    subject: "Verify your VitaVault email",
+    html: `
+      <div style="font-family: Arial, sans-serif; line-height: 1.6; color: #111827;">
+        <h2>Verify your VitaVault email</h2>
+        <p>Hi ${greeting},</p>
+        <p>Please verify your email address to secure your account.</p>
+        <p>
+          <a href="${verifyUrl}" style="display:inline-block;padding:12px 18px;border-radius:12px;background:#111827;color:#ffffff;text-decoration:none;font-weight:600;">Verify email</a>
+        </p>
+        <p>If the button does not work, use this link:</p>
+        <p>${verifyUrl}</p>
+        <p>This link expires in 24 hours.</p>
+      </div>
+    `,
+    text: `Hi ${greeting},\n\nVerify your VitaVault email: ${verifyUrl}\n\nThis link expires in 24 hours.`,
+  });
+}
+
+export async function consumeEmailVerificationToken(token: string) {
+  const record = await db.verificationToken.findUnique({
+    where: { token },
+  });
+
+  if (!record || !record.identifier.startsWith(`${EMAIL_VERIFICATION_PREFIX}:`)) {
+    return { ok: false as const, message: "Invalid verification link." };
+  }
+
+  if (record.expires <= new Date()) {
+    await db.verificationToken.delete({ where: { token } }).catch(() => null);
+    return { ok: false as const, message: "This verification link has expired." };
+  }
+
+  const userId = record.identifier.split(":")[1];
+
+  await db.user.update({
+    where: { id: userId },
+    data: { emailVerified: new Date() },
+  });
+
+  await db.verificationToken.delete({ where: { token } });
+
+  return { ok: true as const, message: "Your email has been verified." };
+}
+
+export async function sendPasswordResetEmail(args: {
+  userId: string;
+  email: string;
+  name?: string | null;
+}) {
+  const token = await createStoredToken({
+    identifier: buildResetIdentifier(args.userId),
+    expiresAt: addHours(new Date(), 2),
+  });
+
+  const resetUrl = `${getBaseUrl()}/reset-password?token=${encodeURIComponent(token)}`;
+  const greeting = args.name?.trim() || "there";
+
+  await sendEmail({
+    to: args.email,
+    subject: "Reset your VitaVault password",
+    html: `
+      <div style="font-family: Arial, sans-serif; line-height: 1.6; color: #111827;">
+        <h2>Reset your password</h2>
+        <p>Hi ${greeting},</p>
+        <p>Use the link below to set a new password for your VitaVault account.</p>
+        <p>
+          <a href="${resetUrl}" style="display:inline-block;padding:12px 18px;border-radius:12px;background:#111827;color:#ffffff;text-decoration:none;font-weight:600;">Reset password</a>
+        </p>
+        <p>If the button does not work, use this link:</p>
+        <p>${resetUrl}</p>
+        <p>This link expires in 2 hours.</p>
+      </div>
+    `,
+    text: `Hi ${greeting},\n\nReset your VitaVault password: ${resetUrl}\n\nThis link expires in 2 hours.`,
+  });
+}
+
+export async function consumePasswordResetToken(token: string) {
+  const record = await db.verificationToken.findUnique({
+    where: { token },
+  });
+
+  if (!record || !record.identifier.startsWith(`${PASSWORD_RESET_PREFIX}:`)) {
+    return null;
+  }
+
+  if (record.expires <= new Date()) {
+    await db.verificationToken.delete({ where: { token } }).catch(() => null);
+    return null;
+  }
+
+  return {
+    token: record.token,
+    userId: record.identifier.split(":")[1],
+  };
+}
+
+export async function clearPasswordResetToken(token: string) {
+  await db.verificationToken.delete({ where: { token } }).catch(() => null);
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { AppRole } from "@prisma/client";
 
 import { db } from "@/lib/db";
+import { isEmailVerificationRequired } from "@/lib/account-email";
 
 const credentialsSchema = z.object({
   email: z.string().trim().email(),
@@ -56,6 +57,10 @@ export const authConfig = {
         const isValid = await bcrypt.compare(password, user.passwordHash);
 
         if (!isValid) {
+          return null;
+        }
+
+        if (isEmailVerificationRequired() && !user.emailVerified) {
           return null;
         }
 


### PR DESCRIPTION
## Summary
- added email verification email generation and token handling
- added resend verification email action and UI
- added forgot password request flow
- added reset password form and token handling
- added public account recovery pages
- added optional email verification enforcement via env
- added login form link to forgot password

## Why this matters
This closes a major account-security gap and makes VitaVault feel much more production-ready for real users.

## Testing
- [ ] set `APP_URL`
- [ ] set `RESEND_API_KEY`
- [ ] set `RESEND_FROM_EMAIL`
- [ ] run `npm run typecheck`
- [ ] run `npm run lint`
- [ ] create a new account
- [ ] confirm verification email arrives
- [ ] open verification link
- [ ] request a password reset
- [ ] open reset link
- [ ] sign in with the new password
- [ ] test resend verification flow while signed in
- [ ] optionally enable `EMAIL_VERIFICATION_REQUIRED=true` and confirm unverified login is blocked