### PR TITLE
Align account email helper calls with expected payload

### DIFF
--- a/app/account-actions.ts
+++ b/app/account-actions.ts
@@ -67,7 +67,11 @@ export async function resendVerificationEmailAction(): Promise<AccountActionStat
     };
   }
 
-  await sendEmailVerificationEmail(dbUser);
+  await sendEmailVerificationEmail({
+    userId: dbUser.id,
+    email: dbUser.email,
+    name: dbUser.name,
+  });
 
   return {
     error: null,
@@ -79,6 +83,8 @@ export async function forgotPasswordAction(
   _: AccountActionState = initialResponse,
   formData: FormData
 ): Promise<AccountActionState> {
+  void _;
+
   const parsed = forgotPasswordSchema.safeParse({
     email: formData.get("email"),
   });
@@ -105,7 +111,11 @@ export async function forgotPasswordAction(
   });
 
   if (user?.passwordHash) {
-    await sendPasswordResetEmail(user);
+    await sendPasswordResetEmail({
+      userId: user.id,
+      email: user.email,
+      name: user.name,
+    });
   }
 
   return {
@@ -118,6 +128,8 @@ export async function resetPasswordAction(
   _: AccountActionState = initialResponse,
   formData: FormData
 ): Promise<AccountActionState> {
+  void _;
+
   const parsed = resetPasswordSchema.safeParse({
     token: formData.get("token"),
     password: formData.get("password"),

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -109,7 +109,11 @@ export async function signupAction(
   });
 
   if (isEmailDeliveryConfigured()) {
-    await sendEmailVerificationEmail(createdUser);
+    await sendEmailVerificationEmail({
+      userId: createdUser.id,
+      email: createdUser.email,
+      name: createdUser.name,
+    });
   }
 
   if (requireVerification) {


### PR DESCRIPTION
## Summary
- mapped Prisma user `id` to `userId` for account email helpers
- fixed resend verification email call payload
- fixed forgot password email call payload
- fixed signup verification email call payload
- removed follow-up lint warnings in account actions

## Why this matters
The email verification and password reset feature was implemented correctly in concept, but the helper calls used the wrong object shape. This restores typecheck compatibility without changing the feature flow.

## Testing
- [ ] run `npm run typecheck`
- [ ] run `npm run lint`
- [ ] create a new account
- [ ] send verification email
- [ ] request password reset