### PR TITLE
Add protected document delivery with private storage support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ prisma/dev.db-journal
 # uploads
 public/uploads/*
 !public/uploads/.gitkeep
+private-uploads/*
+!private-uploads/.gitkeep
 
 # misc
 .DS_Store

--- a/app/api/documents/[id]/download/route.ts
+++ b/app/api/documents/[id]/download/route.ts
@@ -1,0 +1,65 @@
+import { readFile } from "fs/promises";
+import path from "path";
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { resolveStoredDocumentPath } from "@/lib/document-storage";
+
+export const runtime = "nodejs";
+
+function contentDisposition(fileName: string, mimeType: string) {
+  const safeName = path.basename(fileName).replace(/[\r\n"]/g, "-");
+  const encoded = encodeURIComponent(safeName);
+  const disposition = mimeType === "application/pdf" || mimeType.startsWith("image/") ? "inline" : "attachment";
+  return `${disposition}; filename="${safeName}"; filename*=UTF-8''${encoded}`;
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  const document = await db.medicalDocument.findFirst({
+    where: {
+      id,
+      userId: session.user.id,
+    },
+    select: {
+      title: true,
+      fileName: true,
+      filePath: true,
+      mimeType: true,
+    },
+  });
+
+  if (!document) {
+    return NextResponse.json({ error: "Document not found." }, { status: 404 });
+  }
+
+  const resolved = resolveStoredDocumentPath(document.filePath);
+
+  if (!resolved) {
+    return NextResponse.json({ error: "Document storage path is invalid." }, { status: 400 });
+  }
+
+  try {
+    const bytes = await readFile(resolved.absolutePath);
+    const response = new NextResponse(bytes);
+    response.headers.set("Content-Type", document.mimeType || "application/octet-stream");
+    response.headers.set(
+      "Content-Disposition",
+      contentDisposition(document.fileName || `${document.title}.bin`, document.mimeType || "application/octet-stream")
+    );
+    response.headers.set("Cache-Control", "private, no-store, max-age=0");
+    return response;
+  } catch {
+    return NextResponse.json({ error: "Document file is unavailable." }, { status: 404 });
+  }
+}

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -89,8 +89,8 @@ export default async function DocumentsPage({
             stats={[
               { label: "Stored files", value: documents.length },
               { label: "Linked records", value: linkedCount },
+              { label: "Access mode", value: "Protected delivery" },
               { label: "Latest upload", value: latest ? latest.title : "—" },
-              { label: "Latest type", value: latest ? latest.type : "—" },
             ]}
           />
         </PageTransition>
@@ -235,12 +235,12 @@ export default async function DocumentsPage({
 
                             {document.filePath ? (
                               <a
-                                href={document.filePath}
+                                href={`/api/documents/${document.id}/download`}
                                 target="_blank"
                                 rel="noreferrer"
                                 className="text-sm font-medium text-primary"
                               >
-                                Open file
+                                Open secure file
                               </a>
                             ) : null}
                           </div>

--- a/lib/document-storage.ts
+++ b/lib/document-storage.ts
@@ -1,0 +1,60 @@
+import path from "path";
+
+export const DOCUMENT_STORAGE_MODE =
+  process.env.DOCUMENT_STORAGE_MODE === "public" ? "public" : "private";
+
+function sanitizeStoredName(value: string) {
+  return path.basename(value).replace(/[^a-zA-Z0-9._-]/g, "-");
+}
+
+export function getPrivateUploadsDir() {
+  return path.join(process.cwd(), process.env.PRIVATE_UPLOAD_DIR || "private-uploads");
+}
+
+export function getPublicUploadsDir() {
+  return path.join(process.cwd(), "public", "uploads");
+}
+
+export function buildStoredDocumentPath(fileName: string) {
+  const safeName = sanitizeStoredName(fileName);
+
+  if (DOCUMENT_STORAGE_MODE === "public") {
+    return {
+      storage: "public" as const,
+      absolutePath: path.join(getPublicUploadsDir(), safeName),
+      filePath: `/uploads/${safeName}`,
+      fileName: safeName,
+    };
+  }
+
+  return {
+    storage: "private" as const,
+    absolutePath: path.join(getPrivateUploadsDir(), safeName),
+    filePath: `private:${safeName}`,
+    fileName: safeName,
+  };
+}
+
+export function resolveStoredDocumentPath(filePath: string) {
+  const normalized = String(filePath || "").replace(/\\/g, "/").trim();
+
+  if (normalized.startsWith("private:")) {
+    const storedName = sanitizeStoredName(normalized.slice("private:".length));
+    return {
+      storage: "private" as const,
+      absolutePath: path.join(getPrivateUploadsDir(), storedName),
+      relativePath: `private:${storedName}`,
+    };
+  }
+
+  if (normalized.startsWith("/uploads/")) {
+    const storedName = sanitizeStoredName(normalized.slice("/uploads/".length));
+    return {
+      storage: "public" as const,
+      absolutePath: path.join(getPublicUploadsDir(), storedName),
+      relativePath: `/uploads/${storedName}`,
+    };
+  }
+
+  return null;
+}

--- a/lib/upload.ts
+++ b/lib/upload.ts
@@ -1,5 +1,5 @@
 import { mkdir, rm, writeFile } from "fs/promises";
-import path from "path";
+import { buildStoredDocumentPath, getPublicUploadsDir, getPrivateUploadsDir, resolveStoredDocumentPath } from "@/lib/document-storage";
 
 const allowed = ["application/pdf", "image/png", "image/jpeg", "image/webp"];
 
@@ -8,15 +8,15 @@ export async function saveUpload(file: File) {
   if (file.size > 5 * 1024 * 1024) throw new Error("File must be 5MB or smaller.");
 
   const bytes = await file.arrayBuffer();
-  const dir = path.join(process.cwd(), "public", "uploads");
-  await mkdir(dir, { recursive: true });
-
   const safeName = `${Date.now()}-${file.name.replace(/[^a-zA-Z0-9._-]/g, "-")}`;
-  await writeFile(path.join(dir, safeName), Buffer.from(bytes));
+  const stored = buildStoredDocumentPath(safeName);
+  const dir = stored.storage === "public" ? getPublicUploadsDir() : getPrivateUploadsDir();
+  await mkdir(dir, { recursive: true });
+  await writeFile(stored.absolutePath, Buffer.from(bytes));
 
   return {
-    filePath: `/uploads/${safeName}`,
-    fileName: safeName,
+    filePath: stored.filePath,
+    fileName: stored.fileName,
     mimeType: file.type,
     sizeBytes: file.size,
   };
@@ -25,9 +25,8 @@ export async function saveUpload(file: File) {
 export async function deleteUpload(filePath: string | null | undefined) {
   if (!filePath) return;
 
-  const normalized = filePath.replace(/\\/g, "/");
-  if (!normalized.startsWith("/uploads/")) return;
+  const resolved = resolveStoredDocumentPath(filePath);
+  if (!resolved) return;
 
-  const absolutePath = path.join(process.cwd(), "public", normalized.replace(/^\//, ""));
-  await rm(absolutePath, { force: true });
+  await rm(resolved.absolutePath, { force: true });
 }


### PR DESCRIPTION
## Summary
- added authenticated document download route
- added private document storage support
- kept backward compatibility for existing public `/uploads/...` files
- updated document uploads to store new files in protected mode by default
- updated Documents page to use secure file access links
- added private upload directory ignore rules

## Why this matters
This makes VitaVault’s document handling much more production-minded by reducing direct public file exposure while keeping the current document workflow intact.

## Testing
- [ ] run `npm run typecheck`
- [ ] run `npm run lint`
- [ ] upload a new document
- [ ] confirm it opens through `/api/documents/[id]/download`
- [ ] confirm an older `/uploads/...` document still opens
- [ ] confirm signed-out access to the download route is blocked