### PR TITLE
Fix 16 follow-up: align tests with admin data shapes

### DIFF
--- a/tests/admin-dashboard.test.ts
+++ b/tests/admin-dashboard.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AppRole, CareAccessStatus, JobRunStatus, ReminderState } from "@prisma/client";
+
+const countMock = vi.fn();
+const userFindManyMock = vi.fn();
+const careInviteFindManyMock = vi.fn();
+const jobRunFindManyMock = vi.fn();
+const accessAuditFindManyMock = vi.fn();
+const alertAuditFindManyMock = vi.fn();
+const reminderAuditFindManyMock = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    user: {
+      count: countMock,
+      findMany: userFindManyMock,
+    },
+    careInvite: {
+      count: countMock,
+      findMany: careInviteFindManyMock,
+    },
+    careAccess: {
+      count: countMock,
+    },
+    alertEvent: {
+      count: countMock,
+    },
+    jobRun: {
+      count: countMock,
+      findMany: jobRunFindManyMock,
+    },
+    mobileSessionToken: {
+      count: countMock,
+    },
+    accessAuditLog: {
+      findMany: accessAuditFindManyMock,
+    },
+    alertAuditLog: {
+      findMany: alertAuditFindManyMock,
+    },
+    reminderAuditLog: {
+      findMany: reminderAuditFindManyMock,
+    },
+  },
+}));
+
+describe("admin workspace data", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    countMock.mockReset();
+    userFindManyMock.mockReset();
+    careInviteFindManyMock.mockReset();
+    jobRunFindManyMock.mockReset();
+    accessAuditFindManyMock.mockReset();
+    alertAuditFindManyMock.mockReset();
+    reminderAuditFindManyMock.mockReset();
+  });
+
+  it("aggregates summary, recent lists, and merged audit feed", async () => {
+    countMock
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(3)
+      .mockResolvedValueOnce(4)
+      .mockResolvedValueOnce(5)
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(6);
+
+    userFindManyMock
+      .mockResolvedValueOnce([
+        {
+          id: "u2",
+          name: "Bob",
+          email: "bob@example.com",
+          role: AppRole.PATIENT,
+          emailVerified: null,
+          createdAt: new Date("2026-04-24T02:00:00.000Z"),
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "u1",
+          name: "Alice",
+          email: "alice@example.com",
+          role: AppRole.PATIENT,
+          emailVerified: new Date(),
+          createdAt: new Date("2026-04-24T01:00:00.000Z"),
+          _count: { reminders: 2, alertEvents: 1, documents: 3, mobileSessionTokens: 1 },
+        },
+      ]);
+
+    careInviteFindManyMock.mockResolvedValue([
+      {
+        id: "invite_1",
+        email: "care@example.com",
+        accessRole: "CAREGIVER",
+        status: CareAccessStatus.PENDING,
+        createdAt: new Date("2026-04-24T03:00:00.000Z"),
+        expiresAt: new Date("2026-04-30T00:00:00.000Z"),
+        owner: { id: "u1", name: "Alice", email: "alice@example.com" },
+        grantedBy: { id: "u1", name: "Alice", email: "alice@example.com" },
+      },
+    ]);
+
+    jobRunFindManyMock.mockResolvedValue([
+      {
+        id: "job_1",
+        jobKind: "ALERT_SCAN",
+        jobName: "Alert scan",
+        queueName: "alerts",
+        status: JobRunStatus.FAILED,
+        createdAt: new Date("2026-04-24T05:00:00.000Z"),
+        errorMessage: "Boom",
+        user: { id: "u1", name: "Alice", email: "alice@example.com" },
+      },
+    ]);
+
+    accessAuditFindManyMock.mockResolvedValue([
+      {
+        id: "access_1",
+        action: "GRANTED",
+        targetType: "CareAccess",
+        targetId: "access_1",
+        metadataJson: "Granted by admin",
+        createdAt: new Date("2026-04-24T03:30:00.000Z"),
+        owner: { id: "u1", name: "Alice", email: "alice@example.com" },
+        actor: { id: "u9", name: "Admin", email: "admin@example.com" },
+      },
+    ]);
+
+    alertAuditFindManyMock.mockResolvedValue([
+      {
+        id: "alert_log_1",
+        action: "ACKNOWLEDGED",
+        note: "Handled by clinician",
+        createdAt: new Date("2026-04-24T04:00:00.000Z"),
+        user: { id: "u1", name: "Alice", email: "alice@example.com" },
+        actor: { id: "u3", name: "Clinician", email: "clinician@example.com" },
+        alert: { id: "alert_1", title: "Critical BP" },
+        rule: null,
+      },
+    ]);
+
+    reminderAuditFindManyMock.mockResolvedValue([
+      {
+        id: "reminder_log_1",
+        action: "EMAIL_SENT",
+        note: "Reminder emailed",
+        createdAt: new Date("2026-04-24T04:30:00.000Z"),
+        user: { id: "u1", name: "Alice", email: "alice@example.com" },
+        actor: { id: "sys", name: "System", email: "system@example.com" },
+        reminder: { id: "rem_1", title: "Morning meds", state: ReminderState.SENT },
+      },
+    ]);
+
+    const { getAdminWorkspaceData } = await import("@/lib/admin-dashboard");
+    const data = await getAdminWorkspaceData();
+
+    expect(data.summary.totalUsers).toBe(2);
+    expect(data.summary.pendingInvites).toBe(3);
+    expect(data.summary.activeCareAccess).toBe(4);
+    expect(data.userRoster).toHaveLength(1);
+    expect(data.userRoster[0].role).toBe(AppRole.PATIENT);
+    expect(data.userRoster[0]._count.alertEvents).toBe(1);
+    expect(data.recentUsers[0].email).toBe("bob@example.com");
+    expect(data.recentInvites[0].email).toBe("care@example.com");
+    expect(data.recentJobRuns[0].jobKind).toBe("ALERT_SCAN");
+    expect(data.auditFeed).toHaveLength(3);
+    expect(data.auditFeed[0].source).toBe("REMINDER");
+    expect(data.auditFeed[1].source).toBe("ALERT");
+    expect(data.auditFeed[2].source).toBe("ACCESS");
+  });
+});

--- a/tests/exports-route.test.ts
+++ b/tests/exports-route.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const authMock = vi.fn();
+const findManyMock = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  auth: authMock,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    medication: {
+      findMany: findManyMock,
+    },
+  },
+}));
+
+describe("exports route", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    authMock.mockReset();
+    findManyMock.mockReset();
+  });
+
+  it("returns 404 json for an unknown export type", async () => {
+    authMock.mockResolvedValue({ user: { id: "user_1" } });
+    const { GET } = await import("@/app/exports/[type]/route");
+    const response = await GET(new Request("http://localhost/exports/nope"), {
+      params: Promise.resolve({ type: "nope" }),
+    } as never);
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toBe("Unknown export type.");
+  });
+
+  it("returns medication data as CSV for the current user", async () => {
+    authMock.mockResolvedValue({ user: { id: "user_1" } });
+    findManyMock.mockResolvedValue([
+      {
+        name: "Metformin",
+        dosage: "500mg",
+        frequency: "Twice daily",
+        instructions: "After meals",
+        schedules: [{ timeOfDay: "08:00" }, { timeOfDay: "20:00" }],
+        startDate: new Date("2026-04-20T08:00:00.000Z"),
+        endDate: null,
+        status: "",
+        active: false,
+        doctor: null,
+        createdAt: new Date("2026-04-20T08:00:00.000Z"),
+      },
+    ]);
+
+    const { GET } = await import("@/app/exports/[type]/route");
+    const response = await GET(new Request("http://localhost/exports/medications"), {
+      params: Promise.resolve({ type: "medications" }),
+    } as never);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toContain("text/csv");
+    expect(response.headers.get("Content-Disposition")).toContain("medications-");
+    const csv = await response.text();
+    expect(csv).toContain("Name,Dosage,Frequency,Instructions,Times");
+    expect(csv).toContain("Metformin");
+    expect(csv).toContain("08:00, 20:00");
+  });
+});

--- a/tests/invite-email.test.ts
+++ b/tests/invite-email.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("care invite email helpers", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    delete process.env.RESEND_API_KEY;
+    delete process.env.RESEND_FROM_EMAIL;
+  });
+
+  it("reports invite delivery as disabled without env vars", async () => {
+    const mod = await import("@/lib/invite-email");
+    expect(mod.isInviteEmailConfigured()).toBe(false);
+  });
+
+  it("returns a non-attempted result when invite email delivery is not configured", async () => {
+    const mod = await import("@/lib/invite-email");
+
+    const result = await mod.sendCareInviteEmail({
+      to: "invitee@example.com",
+      inviteLink: "https://example.com/invite/token",
+      ownerName: "Patient Name",
+      ownerEmail: "patient@example.com",
+      accessRole: "CAREGIVER",
+      expiresAt: new Date("2026-04-25T10:00:00.000Z"),
+      note: "Please review the latest records.",
+    });
+
+    expect(result).toEqual({
+      attempted: false,
+      sent: false,
+      reason: "Invite email delivery is not configured.",
+    });
+  });
+
+  it("sends the invite email through Resend when configured", async () => {
+    process.env.RESEND_API_KEY = "resend_test_key";
+    process.env.RESEND_FROM_EMAIL = "VitaVault <no-reply@example.com>";
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "msg_123" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const mod = await import("@/lib/invite-email");
+    const result = await mod.sendCareInviteEmail({
+      to: "invitee@example.com",
+      inviteLink: "https://example.com/invite/token",
+      ownerName: "Patient <Name>",
+      ownerEmail: "patient@example.com",
+      accessRole: "CAREGIVER",
+      expiresAt: new Date("2026-04-25T10:00:00.000Z"),
+      note: "Bring reports & prescriptions.",
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.resend.com/emails",
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(result).toEqual({
+      attempted: true,
+      sent: true,
+      provider: "resend",
+      messageId: "msg_123",
+    });
+  });
+});

--- a/tests/outbound-email.test.ts
+++ b/tests/outbound-email.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AlertSeverity, AlertStatus, ReminderState } from "@prisma/client";
+
+describe("outbound email helpers", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    delete process.env.RESEND_API_KEY;
+    delete process.env.RESEND_FROM_EMAIL;
+  });
+
+  it("reports outbound delivery as disabled without env vars", async () => {
+    const mod = await import("@/lib/outbound-email");
+    expect(mod.outboundEmailEnabled()).toBe(false);
+  });
+
+  it("throws when reminder email delivery is attempted without configuration", async () => {
+    const mod = await import("@/lib/outbound-email");
+
+    await expect(
+      mod.sendReminderEmail({
+        to: "patient@example.com",
+        patientName: "Patient",
+        reminder: {
+          id: "rem_1",
+          title: "Medication reminder",
+          description: "Take your evening dose",
+          dueAt: new Date("2026-04-25T10:00:00.000Z"),
+          state: ReminderState.DUE,
+          timezone: "Asia/Manila",
+          gracePeriodMinutes: 30,
+        },
+      })
+    ).rejects.toThrow("Email delivery is not configured.");
+  });
+
+  it("sends an alert digest email through Resend when configured", async () => {
+    process.env.RESEND_API_KEY = "resend_test_key";
+    process.env.RESEND_FROM_EMAIL = "VitaVault <no-reply@example.com>";
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "msg_456" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const mod = await import("@/lib/outbound-email");
+    await mod.sendAlertDigestEmail({
+      to: "patient@example.com",
+      patientName: "Patient",
+      alerts: [
+        {
+          id: "alert_1",
+          title: "High heart rate",
+          message: "Heart rate stayed elevated.",
+          severity: AlertSeverity.CRITICAL,
+          status: AlertStatus.OPEN,
+          createdAt: new Date("2026-04-25T10:00:00.000Z"),
+        },
+      ],
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, request] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const payload = JSON.parse(String(request.body));
+
+    expect(payload.subject).toContain("1 open alert");
+    expect(payload.to).toEqual(["patient@example.com"]);
+  });
+});

--- a/tests/security-actions.test.ts
+++ b/tests/security-actions.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireUserMock = vi.fn();
+const compareMock = vi.fn();
+const hashMock = vi.fn();
+const revalidatePathMock = vi.fn();
+const findUniqueMock = vi.fn();
+const userUpdateMock = vi.fn();
+const mobileUpdateManyMock = vi.fn();
+
+vi.mock("@/lib/session", () => ({
+  requireUser: requireUserMock,
+}));
+
+vi.mock("bcryptjs", () => ({
+  default: {
+    compare: compareMock,
+    hash: hashMock,
+  },
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: revalidatePathMock,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    user: {
+      findUnique: findUniqueMock,
+      update: userUpdateMock,
+    },
+    mobileSessionToken: {
+      updateMany: mobileUpdateManyMock,
+    },
+  },
+}));
+
+describe("security actions", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    requireUserMock.mockReset();
+    compareMock.mockReset();
+    hashMock.mockReset();
+    revalidatePathMock.mockReset();
+    findUniqueMock.mockReset();
+    userUpdateMock.mockReset();
+    mobileUpdateManyMock.mockReset();
+    requireUserMock.mockResolvedValue({ id: "user_1" });
+  });
+
+  it("rejects password changes when confirmation does not match", async () => {
+    const { changePasswordAction } = await import("@/app/security/actions");
+    const formData = new FormData();
+    formData.set("currentPassword", "old-password");
+    formData.set("newPassword", "new-password-123");
+    formData.set("confirmPassword", "different-password");
+
+    await expect(changePasswordAction(formData)).rejects.toThrow(
+      "New password and confirmation must match."
+    );
+  });
+
+  it("updates the password hash for a valid password rotation", async () => {
+    findUniqueMock.mockResolvedValue({ passwordHash: "stored-hash" });
+    compareMock.mockResolvedValue(true);
+    hashMock.mockResolvedValue("new-hash");
+
+    const { changePasswordAction } = await import("@/app/security/actions");
+    const formData = new FormData();
+    formData.set("currentPassword", "old-password");
+    formData.set("newPassword", "new-password-123");
+    formData.set("confirmPassword", "new-password-123");
+
+    await changePasswordAction(formData);
+
+    expect(userUpdateMock).toHaveBeenCalledWith({
+      where: { id: "user_1" },
+      data: { passwordHash: "new-hash" },
+    });
+    expect(revalidatePathMock).toHaveBeenCalledWith("/security");
+  });
+
+  it("revokes all active mobile sessions for the current user", async () => {
+    const { revokeAllMobileSessionsAction } = await import("@/app/security/actions");
+
+    await revokeAllMobileSessionsAction();
+
+    expect(mobileUpdateManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          userId: "user_1",
+          revokedAt: null,
+        },
+      })
+    );
+    expect(revalidatePathMock).toHaveBeenCalledWith("/security");
+  });
+});


### PR DESCRIPTION
## Summary
- updated admin dashboard tests to match actual workspace data shapes
- fixed DB mock names to match current models
- replaced invalid `kind` assertions with `source` and `jobKind`
- aligned exports 404 assertion with the current response text

## Why this matters
The remaining Fix 16 failures were test-shape mismatches, not product regressions. This keeps the expanded coverage while matching the real current implementation.

## Testing
- [x] npm run typecheck
- [x] npm run lint
- [x] npm run test:run