### PR TITLE
Fix 18: add full public demo experience

### DIFF
--- a/app/demo/admin/page.tsx
+++ b/app/demo/admin/page.tsx
@@ -1,0 +1,19 @@
+import { DemoHeader, DemoSection, MetricGrid, SimpleTable } from "@/components/demo-primitives";
+import { demoAdmin } from "@/lib/demo-data";
+
+export default function DemoAdminPage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="Admin Workspace" description="User oversight, moderation actions, audit visibility, and platform-level review." />
+      <MetricGrid items={demoAdmin.metrics} />
+      <div className="grid gap-6 xl:grid-cols-[1.15fr_0.85fr]">
+        <DemoSection title="User roster">
+          <SimpleTable headers={["User", "Role", "Status", "Sessions", "Alerts", "Documents"]} rows={demoAdmin.roster.map((item) => [item.name, item.role, item.status, String(item.sessions), String(item.alerts), String(item.documents)])} />
+        </DemoSection>
+        <DemoSection title="Audit feed">
+          <SimpleTable headers={["Source", "Message", "When"]} rows={demoAdmin.audit.map((item) => [item.source, item.message, item.at])} />
+        </DemoSection>
+      </div>
+    </div>
+  );
+}

--- a/app/demo/ai-insights/page.tsx
+++ b/app/demo/ai-insights/page.tsx
@@ -1,0 +1,23 @@
+import { DemoHeader, DemoSection, ToneBadge } from "@/components/demo-primitives";
+import { demoAiInsights } from "@/lib/demo-data";
+
+export default function DemoAiInsightsPage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="AI Insights" description="Narrative summaries and action-oriented pattern detection over the patient's history." />
+      <DemoSection title="Generated insights">
+        <div className="space-y-3">
+          {demoAiInsights.map((item) => (
+            <div key={item.title} className="rounded-2xl border border-border/60 bg-background/60 p-4">
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <p className="font-medium">{item.title}</p>
+                <ToneBadge value={item.severity} />
+              </div>
+              <p className="text-sm text-muted-foreground">{item.summary}</p>
+            </div>
+          ))}
+        </div>
+      </DemoSection>
+    </div>
+  );
+}

--- a/app/demo/alerts/page.tsx
+++ b/app/demo/alerts/page.tsx
@@ -1,0 +1,18 @@
+import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitives";
+import { demoAlerts } from "@/lib/demo-data";
+
+export default function DemoAlertsPage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="Alert Center" description="Threshold rules, event statuses, categories, and review context." />
+      <div className="grid gap-6 xl:grid-cols-2">
+        <DemoSection title="Alert events">
+          <SimpleTable headers={["Title", "Severity", "Status", "Category", "Source", "Created"]} rows={demoAlerts.events.map((item) => [item.title, item.severity, item.status, item.category, item.source, item.createdAt])} />
+        </DemoSection>
+        <DemoSection title="Alert rules">
+          <SimpleTable headers={["Rule", "Category", "Severity", "Status"]} rows={demoAlerts.rules.map((item) => [item.name, item.category, item.severity, item.status])} />
+        </DemoSection>
+      </div>
+    </div>
+  );
+}

--- a/app/demo/appointments/page.tsx
+++ b/app/demo/appointments/page.tsx
@@ -1,0 +1,13 @@
+import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitives";
+import { demoAppointments } from "@/lib/demo-data";
+
+export default function DemoAppointmentsPage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="Appointments" description="Upcoming and completed visits with clinic context, status, and follow-up notes." />
+      <DemoSection title="Appointment timeline">
+        <SimpleTable headers={["Visit", "When", "Location", "Status", "Doctor", "Notes"]} rows={demoAppointments.map((item) => [item.title, item.when, item.location, item.status, item.doctor, item.note])} />
+      </DemoSection>
+    </div>
+  );
+}

--- a/app/demo/care-team/page.tsx
+++ b/app/demo/care-team/page.tsx
@@ -1,0 +1,18 @@
+import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitives";
+import { demoCareTeam } from "@/lib/demo-data";
+
+export default function DemoCareTeamPage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="Care Team" description="Shared access, pending invites, and role-based collaboration across patient care." />
+      <div className="grid gap-6 xl:grid-cols-2">
+        <DemoSection title="Active members">
+          <SimpleTable headers={["Name", "Role", "Access", "Status"]} rows={demoCareTeam.members.map((item) => [item.name, item.role, item.access, item.status])} />
+        </DemoSection>
+        <DemoSection title="Pending invites">
+          <SimpleTable headers={["Recipient", "Role", "Sent", "Delivery", "Status"]} rows={demoCareTeam.invites.map((item) => [item.recipient, item.role, item.sentAt, item.delivery, item.status])} />
+        </DemoSection>
+      </div>
+    </div>
+  );
+}

--- a/app/demo/dashboard/page.tsx
+++ b/app/demo/dashboard/page.tsx
@@ -1,0 +1,19 @@
+import { DemoHeader, DemoSection, MetricGrid, SimpleTable } from "@/components/demo-primitives";
+import { demoDashboardStats, demoTimeline, demoReminders } from "@/lib/demo-data";
+
+export default function DemoDashboardPage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="Dashboard" description="A premium at-a-glance overview of patient health, outstanding tasks, and recent events." />
+      <MetricGrid items={demoDashboardStats} />
+      <div className="grid gap-6 xl:grid-cols-2">
+        <DemoSection title="Recent timeline">
+          <SimpleTable headers={["When", "Type", "Title", "Detail"]} rows={demoTimeline.map((item) => [item.at, item.type, item.title, item.detail])} />
+        </DemoSection>
+        <DemoSection title="Reminder center snapshot">
+          <SimpleTable headers={["Reminder", "When", "Channel", "State"]} rows={demoReminders.map((item) => [item.title, item.when, item.channel, item.state])} />
+        </DemoSection>
+      </div>
+    </div>
+  );
+}

--- a/app/demo/device-connection/page.tsx
+++ b/app/demo/device-connection/page.tsx
@@ -1,0 +1,13 @@
+import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitives";
+import { demoDevices } from "@/lib/demo-data";
+
+export default function DemoDeviceConnectionPage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="Device Connections" description="Connected apps and devices that feed VitaVault vitals and sync workflows." />
+      <DemoSection title="Connection status">
+        <SimpleTable headers={["Provider", "Status", "Last sync", "Readings", "Notes"]} rows={demoDevices.map((item) => [item.provider, item.status, item.lastSync, item.readings, item.note ?? "—"])} />
+      </DemoSection>
+    </div>
+  );
+}

--- a/app/demo/doctors/page.tsx
+++ b/app/demo/doctors/page.tsx
@@ -1,0 +1,13 @@
+import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitives";
+import { demoDoctors } from "@/lib/demo-data";
+
+export default function DemoDoctorsPage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="Doctors" description="Specialists, clinic details, and contact information linked to care workflows." />
+      <DemoSection title="Provider directory">
+        <SimpleTable headers={["Doctor", "Specialty", "Clinic", "Phone", "Email"]} rows={demoDoctors.map((item) => [item.name, item.specialty, item.clinic, item.phone, item.email])} />
+      </DemoSection>
+    </div>
+  );
+}

--- a/app/demo/documents/page.tsx
+++ b/app/demo/documents/page.tsx
@@ -1,0 +1,13 @@
+import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitives";
+import { demoDocuments } from "@/lib/demo-data";
+
+export default function DemoDocumentsPage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="Documents" description="Protected document delivery, record linking, and clinically useful file organization." />
+      <DemoSection title="Document library">
+        <SimpleTable headers={["Document", "Type", "Linked to", "Access", "Size"]} rows={demoDocuments.map((item) => [item.name, item.type, item.linkedTo, item.access, item.size])} />
+      </DemoSection>
+    </div>
+  );
+}

--- a/app/demo/exports/page.tsx
+++ b/app/demo/exports/page.tsx
@@ -1,0 +1,13 @@
+import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitives";
+import { demoExports } from "@/lib/demo-data";
+
+export default function DemoExportsPage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="Exports" description="Business-friendly export formats for summaries, records, and operational review." />
+      <DemoSection title="Available exports">
+        <SimpleTable headers={["Export", "Format", "Status", "Notes"]} rows={demoExports.map((item) => [item.name, item.format, item.status, item.note])} />
+      </DemoSection>
+    </div>
+  );
+}

--- a/app/demo/health-profile/page.tsx
+++ b/app/demo/health-profile/page.tsx
@@ -1,0 +1,26 @@
+import { DemoHeader, DemoSection, KeyValueList } from "@/components/demo-primitives";
+import { demoPatient } from "@/lib/demo-data";
+
+export default function DemoHealthProfilePage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="Health Profile" description="Core demographic, risk, and emergency information that anchors the rest of VitaVault." />
+      <DemoSection title="Patient details">
+        <KeyValueList items={[
+          { label: "Full name", value: demoPatient.name },
+          { label: "Email", value: demoPatient.email },
+          { label: "Phone", value: demoPatient.phone },
+          { label: "Address", value: demoPatient.address },
+          { label: "Blood type", value: demoPatient.bloodType },
+          { label: "Emergency contact", value: demoPatient.emergencyContact },
+          { label: "Height", value: `${demoPatient.heightCm} cm` },
+          { label: "Weight", value: `${demoPatient.weightKg} kg` },
+          { label: "BMI", value: String(demoPatient.bmi) },
+          { label: "Allergies", value: demoPatient.allergies.join(", ") },
+          { label: "Chronic conditions", value: demoPatient.chronicConditions.join(", ") },
+          { label: "Last updated", value: demoPatient.lastUpdated },
+        ]} />
+      </DemoSection>
+    </div>
+  );
+}

--- a/app/demo/jobs/page.tsx
+++ b/app/demo/jobs/page.tsx
@@ -1,0 +1,13 @@
+import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitives";
+import { demoJobs } from "@/lib/demo-data";
+
+export default function DemoJobsPage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="Jobs" description="Background processing visibility for alert scans, reminders, and sync workflows." />
+      <DemoSection title="Recent job runs">
+        <SimpleTable headers={["Job", "Queue", "Status", "When"]} rows={demoJobs.map((item) => [item.job, item.queue, item.status, item.at])} />
+      </DemoSection>
+    </div>
+  );
+}

--- a/app/demo/labs/page.tsx
+++ b/app/demo/labs/page.tsx
@@ -1,0 +1,13 @@
+import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitives";
+import { demoLabs } from "@/lib/demo-data";
+
+export default function DemoLabsPage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="Labs" description="Lab trends, status indicators, and uploaded result context." />
+      <DemoSection title="Latest lab set">
+        <SimpleTable headers={["Test", "Value", "Trend", "Status", "Collected", "Lab"]} rows={demoLabs.map((item) => [item.test, item.value, item.trend, item.status, item.collectedAt, item.lab])} />
+      </DemoSection>
+    </div>
+  );
+}

--- a/app/demo/layout.tsx
+++ b/app/demo/layout.tsx
@@ -1,0 +1,5 @@
+import DemoShell from "@/components/demo-shell";
+
+export default function DemoLayout({ children }: { children: React.ReactNode }) {
+  return <DemoShell>{children}</DemoShell>;
+}

--- a/app/demo/medications/page.tsx
+++ b/app/demo/medications/page.tsx
@@ -1,0 +1,13 @@
+import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitives";
+import { demoMedications } from "@/lib/demo-data";
+
+export default function DemoMedicationsPage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="Medications" description="Schedules, adherence signals, linked doctors, and patient-facing instructions." />
+      <DemoSection title="Active medication plan">
+        <SimpleTable headers={["Medication", "Dosage", "Frequency", "Times", "Status", "Doctor", "Adherence", "Instructions"]} rows={demoMedications.map((item) => [item.name, item.dosage, item.frequency, item.times.join(", "), item.status, item.doctor, item.adherence, item.instructions])} />
+      </DemoSection>
+    </div>
+  );
+}

--- a/app/demo/ops/page.tsx
+++ b/app/demo/ops/page.tsx
@@ -1,0 +1,14 @@
+import { DemoHeader, DemoSection, MetricGrid, SimpleTable } from "@/components/demo-primitives";
+import { demoOps } from "@/lib/demo-data";
+
+export default function DemoOpsPage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="Operations" description="Readiness checks and high-level operational monitoring for delivery and sync workflows." />
+      <MetricGrid items={demoOps.metrics} />
+      <DemoSection title="Environment readiness">
+        <SimpleTable headers={["Check", "Status"]} rows={demoOps.readiness.map((item) => [item.label, item.status])} />
+      </DemoSection>
+    </div>
+  );
+}

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -1,0 +1,63 @@
+import { DemoHeader, DemoSection, MetricGrid, KeyValueList, ToneBadge, Badge } from "@/components/demo-primitives";
+import { demoDashboardStats, demoPatient, demoAiInsights, demoAlerts, demoNav } from "@/lib/demo-data";
+
+export default function DemoPage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="Explore VitaVault" description="A full no-login walkthrough of the product with realistic sample patient, admin, and ops data." />
+      <MetricGrid items={demoDashboardStats} />
+      <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
+        <DemoSection title="Patient snapshot" description="The demo uses a realistic chronic-care scenario so every VitaVault workflow has something meaningful to show.">
+          <KeyValueList items={[
+            { label: "Patient", value: demoPatient.name },
+            { label: "Age / Sex", value: `${demoPatient.age} · ${demoPatient.sex}` },
+            { label: "Blood type", value: demoPatient.bloodType },
+            { label: "Conditions", value: demoPatient.chronicConditions.join(", ") },
+            { label: "Allergies", value: demoPatient.allergies.join(", ") },
+            { label: "Emergency contact", value: demoPatient.emergencyContact },
+          ]} />
+        </DemoSection>
+        <DemoSection title="Feature coverage" description="Every main VitaVault area has a dedicated public demo page.">
+          <div className="grid gap-2 sm:grid-cols-2">
+            {demoNav.slice(1).map((item) => (
+              <div key={item.href} className="rounded-2xl border border-border/60 bg-background/60 p-3">
+                <p className="font-medium">{item.label}</p>
+                <p className="text-xs text-muted-foreground">{item.href}</p>
+              </div>
+            ))}
+          </div>
+        </DemoSection>
+      </div>
+      <div className="grid gap-6 lg:grid-cols-2">
+        <DemoSection title="AI insight preview" description="Shows the product's explanatory summaries and action guidance.">
+          <div className="space-y-3">
+            {demoAiInsights.map((item) => (
+              <div key={item.title} className="rounded-2xl border border-border/60 bg-background/60 p-4">
+                <div className="mb-2 flex items-center justify-between gap-2">
+                  <p className="font-medium">{item.title}</p>
+                  <ToneBadge value={item.severity} />
+                </div>
+                <p className="text-sm text-muted-foreground">{item.summary}</p>
+              </div>
+            ))}
+          </div>
+        </DemoSection>
+        <DemoSection title="Alert preview" description="The demo includes open, acknowledged, and rule-driven events.">
+          <div className="space-y-3">
+            {demoAlerts.events.map((item) => (
+              <div key={item.title} className="rounded-2xl border border-border/60 bg-background/60 p-4">
+                <div className="mb-2 flex flex-wrap gap-2">
+                  <ToneBadge value={item.severity} />
+                  <ToneBadge value={item.status} />
+                  <Badge>{item.category}</Badge>
+                </div>
+                <p className="font-medium">{item.title}</p>
+                <p className="text-sm text-muted-foreground">{item.source} · {item.createdAt}</p>
+              </div>
+            ))}
+          </div>
+        </DemoSection>
+      </div>
+    </div>
+  );
+}

--- a/app/demo/reminders/page.tsx
+++ b/app/demo/reminders/page.tsx
@@ -1,0 +1,13 @@
+import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitives";
+import { demoReminders } from "@/lib/demo-data";
+
+export default function DemoRemindersPage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="Reminders" description="Scheduled reminders, delivery channels, and dispatch state across meds and follow-ups." />
+      <DemoSection title="Reminder queue">
+        <SimpleTable headers={["Reminder", "When", "Channel", "State"]} rows={demoReminders.map((item) => [item.title, item.when, item.channel, item.state])} />
+      </DemoSection>
+    </div>
+  );
+}

--- a/app/demo/review-queue/page.tsx
+++ b/app/demo/review-queue/page.tsx
@@ -1,0 +1,13 @@
+import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitives";
+import { demoReviewQueue } from "@/lib/demo-data";
+
+export default function DemoReviewQueuePage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="Review Queue" description="Items surfaced for clinical follow-up, caregiver action, and admin handoff." />
+      <DemoSection title="Review workload">
+        <SimpleTable headers={["Item", "Source", "Tone", "Owner", "Status"]} rows={demoReviewQueue.map((item) => [item.item, item.source, item.tone, item.owner, item.status])} />
+      </DemoSection>
+    </div>
+  );
+}

--- a/app/demo/security/page.tsx
+++ b/app/demo/security/page.tsx
@@ -1,0 +1,16 @@
+import { DemoHeader, DemoSection, KeyValueList, SimpleTable } from "@/components/demo-primitives";
+import { demoSecurity } from "@/lib/demo-data";
+
+export default function DemoSecurityPage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="Security Center" description="Account posture, mobile session visibility, and controlled access surfaces." />
+      <DemoSection title="Security posture">
+        <KeyValueList items={demoSecurity.posture} />
+      </DemoSection>
+      <DemoSection title="Session inventory">
+        <SimpleTable headers={["Device", "Created", "Last used", "Expires", "State"]} rows={demoSecurity.sessions.map((item) => [item.device, item.createdAt, item.lastUsed, item.expires, item.state])} />
+      </DemoSection>
+    </div>
+  );
+}

--- a/app/demo/summary/page.tsx
+++ b/app/demo/summary/page.tsx
@@ -1,0 +1,16 @@
+import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitives";
+import { demoSummary } from "@/lib/demo-data";
+
+export default function DemoSummaryPage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="Patient Summary" description="Printable summary view and handoff snapshot for patient care conversations." />
+      <DemoSection title="Snapshot narrative">
+        <p className="text-sm leading-7 text-muted-foreground">{demoSummary.snapshot}</p>
+      </DemoSection>
+      <DemoSection title="Key highlights">
+        <SimpleTable headers={["Highlight"]} rows={demoSummary.highlights.map((item) => [item])} />
+      </DemoSection>
+    </div>
+  );
+}

--- a/app/demo/symptoms/page.tsx
+++ b/app/demo/symptoms/page.tsx
@@ -1,0 +1,13 @@
+import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitives";
+import { demoSymptoms } from "@/lib/demo-data";
+
+export default function DemoSymptomsPage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="Symptoms" description="Symptom tracking feeds alerts, review queues, and care-team follow-up." />
+      <DemoSection title="Logged symptoms">
+        <SimpleTable headers={["Symptom", "Severity", "Status", "Logged", "Notes"]} rows={demoSymptoms.map((item) => [item.name, item.severity, item.status, item.loggedAt, item.note])} />
+      </DemoSection>
+    </div>
+  );
+}

--- a/app/demo/timeline/page.tsx
+++ b/app/demo/timeline/page.tsx
@@ -1,0 +1,13 @@
+import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitives";
+import { demoTimeline } from "@/lib/demo-data";
+
+export default function DemoTimelinePage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="Unified Timeline" description="Cross-module chronology tying together reminders, labs, alerts, and visits." />
+      <DemoSection title="Patient activity timeline">
+        <SimpleTable headers={["When", "Type", "Title", "Detail"]} rows={demoTimeline.map((item) => [item.at, item.type, item.title, item.detail])} />
+      </DemoSection>
+    </div>
+  );
+}

--- a/app/demo/vaccinations/page.tsx
+++ b/app/demo/vaccinations/page.tsx
@@ -1,0 +1,13 @@
+import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitives";
+import { demoVaccinations } from "@/lib/demo-data";
+
+export default function DemoVaccinationsPage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="Vaccinations" description="Immunization history and preventive gaps in one place." />
+      <DemoSection title="Vaccination records">
+        <SimpleTable headers={["Vaccine", "Date", "Provider", "Status"]} rows={demoVaccinations.map((item) => [item.name, item.date, item.provider, item.status])} />
+      </DemoSection>
+    </div>
+  );
+}

--- a/app/demo/vitals/page.tsx
+++ b/app/demo/vitals/page.tsx
@@ -1,0 +1,13 @@
+import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitives";
+import { demoVitals } from "@/lib/demo-data";
+
+export default function DemoVitalsPage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader title="Vitals" description="Trend-friendly vitals tracking for chronic-care follow-up and review." />
+      <DemoSection title="Current vitals snapshot">
+        <SimpleTable headers={["Metric", "Latest", "Range", "Notes"]} rows={demoVitals.map((item) => [item.metric, item.latest, item.range, item.note])} />
+      </DemoSection>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,44 +1,11 @@
 import Link from "next/link";
-import {
-  ArrowRight,
-  CalendarClock,
-  FileHeart,
-  HeartPulse,
-  Pill,
-  ShieldCheck,
-  TrendingUp,
-} from "lucide-react";
-import {
-  Badge,
-  Button,
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui";
+import { ArrowRight, CalendarClock, FileHeart, HeartPulse, Pill, ShieldCheck, TrendingUp } from "lucide-react";
 
 const features = [
-  {
-    title: "Medication schedules",
-    icon: Pill,
-    description: "Track dosage, reminders, and adherence in one flow.",
-  },
-  {
-    title: "Labs and documents",
-    icon: FileHeart,
-    description: "Store PDFs and important health records securely.",
-  },
-  {
-    title: "Appointments",
-    icon: CalendarClock,
-    description: "Plan visits, clinic notes, and follow-ups with clarity.",
-  },
-  {
-    title: "Health insights",
-    icon: TrendingUp,
-    description: "See trends across blood pressure, sugar, and weight.",
-  },
+  { title: "Medication schedules", icon: Pill, description: "Track dosage, reminders, and adherence in one flow." },
+  { title: "Labs and documents", icon: FileHeart, description: "Store PDFs and important health records securely." },
+  { title: "Appointments", icon: CalendarClock, description: "Plan visits, clinic notes, and follow-ups with clarity." },
+  { title: "Health insights", icon: TrendingUp, description: "See trends across blood pressure, sugar, and weight." },
 ];
 
 function Logo() {
@@ -49,9 +16,7 @@ function Logo() {
       </div>
       <div>
         <p className="text-2xl font-semibold tracking-tight">VitaVault</p>
-        <p className="text-sm text-muted-foreground">
-          Personal Health Record Companion
-        </p>
+        <p className="text-sm text-muted-foreground">Personal Health Record Companion</p>
       </div>
     </div>
   );
@@ -64,82 +29,55 @@ export default function HomePage() {
         <header className="flex items-center justify-between rounded-3xl border bg-white/70 px-4 py-4 shadow-sm backdrop-blur md:px-6">
           <Logo />
           <div className="flex items-center gap-3">
-            <Link href="/login">
-              <Button variant="outline" className="rounded-2xl px-6">
-                Login
-              </Button>
-            </Link>
-            <Link href="/signup">
-              <Button className="rounded-2xl px-6">Get Started</Button>
-            </Link>
+            <Link href="/login" className="rounded-2xl border border-border/60 px-6 py-2 font-medium hover:bg-muted/60">Login</Link>
+            <Link href="/signup" className="rounded-2xl bg-primary px-6 py-2 font-medium text-primary-foreground">Get Started</Link>
           </div>
         </header>
 
         <section className="grid gap-10 py-10 lg:grid-cols-[1.1fr_0.9fr] lg:items-center lg:py-16">
           <div className="space-y-8">
-            <Badge className="rounded-full px-4 py-2 text-sm">
+            <span className="inline-flex items-center rounded-full border border-border/60 bg-background/70 px-4 py-2 text-sm font-medium">
               <ShieldCheck className="mr-2 h-4 w-4" />
               Secure, private, and startup-grade UX
-            </Badge>
+            </span>
 
             <div className="space-y-5">
               <h1 className="max-w-4xl text-5xl font-semibold tracking-tight text-foreground sm:text-6xl lg:text-7xl">
                 Manage your personal health records in one polished workspace.
               </h1>
-
               <p className="max-w-3xl text-lg leading-8 text-muted-foreground sm:text-xl">
-                VitaVault gives patients a premium dashboard for medications,
-                appointments, labs, vitals, symptoms, documents, reminders, and
-                printable summaries.
+                VitaVault gives patients a premium dashboard for medications, appointments, labs, vitals, symptoms, documents,
+                reminders, and printable summaries.
               </p>
             </div>
 
             <div className="flex flex-wrap gap-4">
-              <Link href="/signup">
-                <Button size="lg" className="rounded-2xl px-7">
-                  Create account
-                  <ArrowRight className="ml-2 h-4 w-4" />
-                </Button>
+              <Link href="/signup" className="inline-flex items-center rounded-2xl bg-primary px-7 py-3 font-medium text-primary-foreground">
+                Create account
+                <ArrowRight className="ml-2 h-4 w-4" />
               </Link>
-
-              <Link href="/login">
-                <Button size="lg" variant="outline" className="rounded-2xl px-7">
-                  View demo
-                </Button>
-              </Link>
+              <Link href="/demo" className="rounded-2xl border border-border/60 px-7 py-3 font-medium hover:bg-muted/60">View demo</Link>
             </div>
           </div>
 
-          <Card className="rounded-[2rem] border bg-white/80 shadow-xl backdrop-blur">
-            <CardHeader className="space-y-3">
-              <CardTitle className="text-4xl">Flagship health dashboard</CardTitle>
-              <CardDescription className="text-lg">
-                Beautiful cards, fast actions, charts, reminders, and activity
-                history.
-              </CardDescription>
-            </CardHeader>
-
-            <CardContent className="grid gap-5 sm:grid-cols-2">
+          <div className="rounded-[2rem] border bg-white/80 p-6 shadow-xl backdrop-blur">
+            <div className="space-y-3">
+              <h2 className="text-4xl font-semibold">Flagship health dashboard</h2>
+              <p className="text-lg text-muted-foreground">Beautiful cards, fast actions, charts, reminders, and activity history.</p>
+            </div>
+            <div className="mt-6 grid gap-5 sm:grid-cols-2">
               {features.map((feature) => {
                 const Icon = feature.icon;
-
                 return (
-                  <div
-                    key={feature.title}
-                    className="rounded-3xl border bg-background/80 p-6 shadow-sm"
-                  >
+                  <div key={feature.title} className="rounded-3xl border bg-background/80 p-6 shadow-sm">
                     <Icon className="mb-4 h-7 w-7 text-primary" />
-                    <h3 className="mb-2 text-2xl font-semibold tracking-tight">
-                      {feature.title}
-                    </h3>
-                    <p className="text-base leading-7 text-muted-foreground">
-                      {feature.description}
-                    </p>
+                    <h3 className="mb-2 text-2xl font-semibold tracking-tight">{feature.title}</h3>
+                    <p className="text-base leading-7 text-muted-foreground">{feature.description}</p>
                   </div>
                 );
               })}
-            </CardContent>
-          </Card>
+            </div>
+          </div>
         </section>
       </div>
     </main>

--- a/components/demo-primitives.tsx
+++ b/components/demo-primitives.tsx
@@ -1,0 +1,106 @@
+import Link from "next/link";
+
+const toneClasses: Record<string, string> = {
+  danger: "border-red-200 bg-red-50 text-red-700 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-300",
+  warning: "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-300",
+  success: "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-300",
+  info: "border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-900/40 dark:bg-sky-950/30 dark:text-sky-300",
+  neutral: "border-border/60 bg-background/70 text-foreground",
+};
+
+function inferTone(value: string) {
+  const normalized = value.toLowerCase();
+  if (["critical", "deactivated", "error", "failed", "revoked"].some((token) => normalized.includes(token))) return "danger";
+  if (["warning", "due", "retry", "watch"].some((token) => normalized.includes(token))) return "warning";
+  if (["active", "good", "ready", "verified", "succeeded", "up to date", "healthy", "configured"].some((token) => normalized.includes(token))) return "success";
+  if (["pending", "monitor", "open", "queued", "info"].some((token) => normalized.includes(token))) return "info";
+  return "neutral";
+}
+
+export function DemoHeader({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="flex flex-wrap items-start justify-between gap-4 rounded-[28px] border border-border/60 bg-background/75 p-6 shadow-sm">
+      <div>
+        <h1 className="text-3xl font-semibold tracking-tight">{title}</h1>
+        <p className="mt-2 max-w-3xl text-sm text-muted-foreground">{description}</p>
+      </div>
+      <div className="flex gap-2">
+        <Link href="/demo/summary" className="rounded-2xl border border-border/60 px-4 py-2 text-sm font-medium hover:bg-muted/60">Summary</Link>
+        <Link href="/demo/admin" className="rounded-2xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground">Admin view</Link>
+      </div>
+    </div>
+  );
+}
+
+export function DemoSection({ title, description, children }: { title: string; description?: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-[28px] border border-border/60 bg-background/75 p-6 shadow-sm">
+      <div className="mb-4">
+        <h2 className="text-xl font-semibold tracking-tight">{title}</h2>
+        {description ? <p className="mt-1 text-sm text-muted-foreground">{description}</p> : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+export function MetricGrid({ items }: { items: { label: string; value: string; note?: string }[] }) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      {items.map((item) => (
+        <div key={item.label} className="rounded-[28px] border border-border/60 bg-background/75 p-5 shadow-sm">
+          <p className="text-sm text-muted-foreground">{item.label}</p>
+          <p className="mt-2 text-3xl font-semibold tracking-tight">{item.value}</p>
+          {item.note ? <p className="mt-2 text-sm text-muted-foreground">{item.note}</p> : null}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function KeyValueList({ items }: { items: { label: string; value: string }[] }) {
+  return (
+    <dl className="grid gap-3 sm:grid-cols-2">
+      {items.map((item) => (
+        <div key={item.label} className="rounded-2xl border border-border/60 bg-background/60 p-4">
+          <dt className="text-sm text-muted-foreground">{item.label}</dt>
+          <dd className="mt-1 font-medium">{item.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+export function ToneBadge({ value }: { value: string }) {
+  const tone = inferTone(value);
+  return <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-medium ${toneClasses[tone]}`}>{value}</span>;
+}
+
+export function Badge({ children }: { children: React.ReactNode }) {
+  return <span className="inline-flex rounded-full border border-border/60 bg-background/70 px-2.5 py-1 text-xs font-medium">{children}</span>;
+}
+
+export function SimpleTable({ headers, rows }: { headers: string[]; rows: React.ReactNode[][] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="border-b border-border/60 text-left">
+            {headers.map((header) => (
+              <th key={header} className="px-3 py-2 font-medium text-muted-foreground">{header}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, rowIndex) => (
+            <tr key={rowIndex} className="border-b border-border/40 last:border-0">
+              {row.map((cell, cellIndex) => (
+                <td key={`${rowIndex}-${cellIndex}`} className="px-3 py-3 align-top">{cell}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/components/demo-shell.tsx
+++ b/components/demo-shell.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { HeartPulse, Sparkles } from "lucide-react";
+import { demoNav } from "@/lib/demo-data";
+import { cn } from "@/lib/utils";
+
+export default function DemoShell({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+
+  return (
+    <div className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.08),_transparent_35%),linear-gradient(to_bottom,_rgba(255,255,255,0.8),_rgba(248,250,252,1))]">
+      <div className="mx-auto max-w-7xl px-4 py-4 sm:px-6 lg:px-8">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-[28px] border border-border/60 bg-background/80 px-5 py-4 shadow-sm backdrop-blur">
+          <div className="flex items-center gap-3">
+            <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary text-primary-foreground">
+              <HeartPulse className="h-5 w-5" />
+            </div>
+            <div>
+              <p className="text-lg font-semibold tracking-tight">VitaVault Demo</p>
+              <p className="text-sm text-muted-foreground">Full public walkthrough with realistic sample data</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-3 py-1.5 text-xs font-medium"><Sparkles className="h-3.5 w-3.5" /> Read-only demo mode</span>
+            <Link href="/login" className="rounded-2xl border border-border/60 px-4 py-2 text-sm font-medium hover:bg-muted/60">Open real app</Link>
+          </div>
+        </div>
+        <div className="grid gap-6 lg:grid-cols-[260px_minmax(0,1fr)]">
+          <aside className="rounded-[28px] border border-border/60 bg-background/75 p-3 shadow-sm backdrop-blur">
+            <div className="max-h-[calc(100vh-120px)] overflow-y-auto pr-1">
+              <div className="mb-3 rounded-2xl border border-sky-200/50 bg-sky-50/70 p-3 text-sm text-sky-800 dark:border-sky-900/40 dark:bg-sky-950/30 dark:text-sky-200">
+                This demo mirrors VitaVault features without login, database writes, or private data.
+              </div>
+              <nav className="space-y-1">
+                {demoNav.map((item) => {
+                  const active = pathname === item.href;
+                  return (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      className={cn(
+                        "block rounded-2xl px-3 py-2 transition",
+                        active ? "bg-primary text-primary-foreground shadow-sm" : "hover:bg-muted/60",
+                      )}
+                    >
+                      <div className="text-sm font-medium">{item.label}</div>
+                      {item.description ? (
+                        <div className={cn("text-xs", active ? "text-primary-foreground/85" : "text-muted-foreground")}>
+                          {item.description}
+                        </div>
+                      ) : null}
+                    </Link>
+                  );
+                })}
+              </nav>
+            </div>
+          </aside>
+          <main>{children}</main>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -1,0 +1,230 @@
+export type DemoNavItem = { href: string; label: string; description?: string };
+
+export const demoPatient = {
+  name: "Elena Cruz",
+  age: 34,
+  sex: "Female",
+  bloodType: "O+",
+  email: "elena.cruz@example.com",
+  phone: "+63 917 555 0198",
+  emergencyContact: "Marco Cruz · +63 917 555 0117",
+  address: "Quezon City, Metro Manila",
+  allergies: ["Penicillin", "Shellfish"],
+  chronicConditions: ["Type 2 Diabetes", "Hypertension"],
+  heightCm: 163,
+  weightKg: 67,
+  bmi: 25.2,
+  lastUpdated: "April 24, 2026",
+};
+
+export const demoNav: DemoNavItem[] = [
+  { href: "/demo", label: "Overview", description: "Public product walkthrough" },
+  { href: "/demo/dashboard", label: "Dashboard" },
+  { href: "/demo/health-profile", label: "Health Profile" },
+  { href: "/demo/medications", label: "Medications" },
+  { href: "/demo/appointments", label: "Appointments" },
+  { href: "/demo/labs", label: "Labs" },
+  { href: "/demo/vitals", label: "Vitals" },
+  { href: "/demo/symptoms", label: "Symptoms" },
+  { href: "/demo/vaccinations", label: "Vaccinations" },
+  { href: "/demo/doctors", label: "Doctors" },
+  { href: "/demo/documents", label: "Documents" },
+  { href: "/demo/care-team", label: "Care Team" },
+  { href: "/demo/ai-insights", label: "AI Insights" },
+  { href: "/demo/alerts", label: "Alerts" },
+  { href: "/demo/timeline", label: "Timeline" },
+  { href: "/demo/reminders", label: "Reminders" },
+  { href: "/demo/review-queue", label: "Review Queue" },
+  { href: "/demo/summary", label: "Summary" },
+  { href: "/demo/exports", label: "Exports" },
+  { href: "/demo/device-connection", label: "Device Connections" },
+  { href: "/demo/jobs", label: "Jobs" },
+  { href: "/demo/ops", label: "Ops" },
+  { href: "/demo/security", label: "Security" },
+  { href: "/demo/admin", label: "Admin" },
+];
+
+export const demoDashboardStats = [
+  { label: "Open alerts", value: "6", note: "2 critical, 2 warning, 2 info" },
+  { label: "Due reminders", value: "14", note: "Medication, appointments, and follow-up tasks" },
+  { label: "Documents stored", value: "27", note: "Protected delivery with linked records" },
+  { label: "Care members", value: "4", note: "Family, physician, lab staff, and admin support" },
+];
+
+export const demoMedications = [
+  { name: "Metformin", dosage: "500 mg", frequency: "Twice daily", times: ["08:00", "20:00"], status: "Active", doctor: "Dr. Santos", adherence: "94%", instructions: "After meals" },
+  { name: "Losartan", dosage: "50 mg", frequency: "Once daily", times: ["07:00"], status: "Active", doctor: "Dr. Reyes", adherence: "98%", instructions: "Take with water" },
+  { name: "Atorvastatin", dosage: "20 mg", frequency: "Nightly", times: ["21:00"], status: "Active", doctor: "Dr. Reyes", adherence: "89%", instructions: "Avoid grapefruit juice" },
+];
+
+export const demoAppointments = [
+  { title: "Quarterly endocrinology review", when: "May 4, 2026 · 9:00 AM", location: "St. Luke's BGC", status: "UPCOMING", doctor: "Dr. Santos", note: "Discuss A1C trend and weight management plan" },
+  { title: "Eye screening", when: "May 11, 2026 · 2:00 PM", location: "VisionPlus Clinic", status: "UPCOMING", doctor: "Dr. Lim", note: "Annual diabetic retinopathy check" },
+  { title: "Annual physical exam", when: "April 10, 2026 · 11:30 AM", location: "Healthway", status: "COMPLETED", doctor: "Dr. Reyes", note: "Updated lab orders and cardiovascular risk review" },
+];
+
+export const demoLabs = [
+  { test: "HbA1c", value: "6.8%", trend: "Improved from 7.4%", status: "Good", collectedAt: "Apr 20, 2026", lab: "Hi-Precision Diagnostics" },
+  { test: "LDL Cholesterol", value: "92 mg/dL", trend: "Stable", status: "Watch", collectedAt: "Apr 20, 2026", lab: "Hi-Precision Diagnostics" },
+  { test: "Creatinine", value: "0.88 mg/dL", trend: "Normal", status: "Normal", collectedAt: "Apr 20, 2026", lab: "St. Luke's Lab" },
+];
+
+export const demoVitals = [
+  { metric: "Blood Pressure", latest: "122 / 78", range: "118–128 / 76–82", note: "Controlled over the last 30 days" },
+  { metric: "Fasting Glucose", latest: "109 mg/dL", range: "102–118 mg/dL", note: "Slightly elevated but improving" },
+  { metric: "Weight", latest: "67.0 kg", range: "66.6–68.1 kg", note: "Down 1.4 kg from February" },
+  { metric: "Heart Rate", latest: "71 bpm", range: "68–77 bpm", note: "Stable resting trend" },
+];
+
+export const demoSymptoms = [
+  { name: "Morning headache", severity: "Mild", status: "Resolved", loggedAt: "Apr 22, 2026 · 7:15 AM", note: "Likely dehydration, improved after fluids" },
+  { name: "Occasional tingling in feet", severity: "Moderate", status: "Monitoring", loggedAt: "Apr 19, 2026 · 8:00 PM", note: "Flagged for next endocrinology review" },
+  { name: "Dry eyes", severity: "Mild", status: "Open", loggedAt: "Apr 18, 2026 · 4:20 PM", note: "Related to screen time and sleep quality" },
+];
+
+export const demoVaccinations = [
+  { name: "Influenza", date: "Oct 12, 2025", provider: "Healthway", status: "Up to date" },
+  { name: "COVID-19 booster", date: "Jan 18, 2026", provider: "Makati Med", status: "Up to date" },
+  { name: "Pneumococcal", date: "Recommended by Jul 2026", provider: "Primary physician", status: "Due soon" },
+];
+
+export const demoDoctors = [
+  { name: "Dr. Angela Santos", specialty: "Endocrinology", clinic: "St. Luke's BGC", phone: "+63 2 8789 7700", email: "asantos@stlukes.example.com" },
+  { name: "Dr. Paolo Reyes", specialty: "Internal Medicine", clinic: "Healthway Quezon City", phone: "+63 2 8123 4567", email: "preyes@healthway.example.com" },
+  { name: "Dr. Hazel Lim", specialty: "Ophthalmology", clinic: "VisionPlus Clinic", phone: "+63 2 8555 2100", email: "hlim@visionplus.example.com" },
+];
+
+export const demoDocuments = [
+  { name: "A1C-Apr-2026.pdf", type: "Lab Result", linkedTo: "HbA1c · Apr 20, 2026", access: "Protected", size: "284 KB" },
+  { name: "Annual-Physical-Summary.pdf", type: "Consult Note", linkedTo: "Annual physical exam", access: "Protected", size: "412 KB" },
+  { name: "Eye-Screening-Referral.pdf", type: "Referral", linkedTo: "Ophthalmology", access: "Protected", size: "198 KB" },
+];
+
+export const demoCareTeam = {
+  members: [
+    { name: "Marco Cruz", role: "Caregiver", access: "Medications, appointments, reminders", status: "Active" },
+    { name: "Dr. Angela Santos", role: "Doctor", access: "Labs, vitals, summary, alerts", status: "Active" },
+    { name: "Hi-Precision Diagnostics", role: "Lab Staff", access: "Lab upload only", status: "Limited" },
+    { name: "Admin Support", role: "Admin", access: "Operational oversight", status: "Active" },
+  ],
+  invites: [
+    { recipient: "daughter@example.com", role: "Caregiver", sentAt: "Apr 23, 2026", delivery: "Email sent", status: "Pending" },
+    { recipient: "dietitian@example.com", role: "Specialist", sentAt: "Apr 22, 2026", delivery: "Manual link copied", status: "Pending" },
+  ],
+};
+
+export const demoAiInsights = [
+  { title: "Blood sugar stability is improving", severity: "Positive", summary: "Recent fasting glucose and A1C trends suggest better adherence and diet consistency over the last 8 weeks." },
+  { title: "Neuropathy watch signal", severity: "Monitor", summary: "Foot tingling has appeared twice this month. Recommend discussing neuropathy screening and vitamin B12 status." },
+  { title: "Next preventive gap", severity: "Action", summary: "Pneumococcal vaccine is due soon and eye screening follow-up is already scheduled." },
+];
+
+export const demoAlerts = {
+  events: [
+    { title: "Foot tingling symptom cluster", severity: "WARNING", status: "OPEN", category: "Symptoms", source: "Symptom log", createdAt: "Apr 22, 2026 · 8:40 PM" },
+    { title: "Missed atorvastatin twice this week", severity: "INFO", status: "ACKNOWLEDGED", category: "Adherence", source: "Reminder engine", createdAt: "Apr 21, 2026 · 9:05 PM" },
+    { title: "A1C remained above target", severity: "WARNING", status: "OPEN", category: "Lab threshold", source: "Lab result", createdAt: "Apr 20, 2026 · 4:30 PM" },
+  ],
+  rules: [
+    { name: "A1C above 6.5%", category: "Lab", severity: "WARNING", status: "Enabled" },
+    { name: "Two skipped doses in 7 days", category: "Medication", severity: "INFO", status: "Enabled" },
+    { name: "Foot tingling repeated twice in 14 days", category: "Symptoms", severity: "WARNING", status: "Enabled" },
+  ],
+};
+
+export const demoTimeline = [
+  { at: "Apr 24, 2026 · 7:00 AM", type: "Reminder", title: "Morning medications sent", detail: "Metformin and Losartan were marked due and delivered by email + in-app" },
+  { at: "Apr 22, 2026 · 8:40 PM", type: "Alert", title: "Foot tingling alert opened", detail: "Created from symptom clustering rule" },
+  { at: "Apr 20, 2026 · 4:00 PM", type: "Lab", title: "A1C result uploaded", detail: "Linked document and alert evaluation completed" },
+  { at: "Apr 10, 2026 · 12:30 PM", type: "Appointment", title: "Annual physical completed", detail: "Summary export and follow-up tasks created" },
+];
+
+export const demoReminders = [
+  { title: "Metformin morning dose", when: "Today · 8:00 AM", channel: "Email + in-app", state: "Sent" },
+  { title: "Losartan refill review", when: "Tomorrow · 9:00 AM", channel: "In-app", state: "Due" },
+  { title: "Eye screening appointment", when: "May 11, 2026 · 1:00 PM", channel: "Email + in-app", state: "Scheduled" },
+];
+
+export const demoReviewQueue = [
+  { item: "Foot tingling follow-up", source: "Alert + symptom", tone: "Watch", owner: "Dr. Santos", status: "Pending review" },
+  { item: "Medication adherence drift", source: "Reminder engine", tone: "Info", owner: "Caregiver", status: "In progress" },
+  { item: "Preventive vaccine gap", source: "Summary engine", tone: "Healthy", owner: "Primary care", status: "Queued" },
+];
+
+export const demoSummary = {
+  snapshot: "Elena Cruz is a 34-year-old patient with diabetes and hypertension currently showing improved glycemic control, stable blood pressure, and one monitored neuropathy-related symptom signal.",
+  highlights: [
+    "A1C improved from 7.4% to 6.8% this quarter.",
+    "Blood pressure remained within target range over the last 30 days.",
+    "One warning alert remains open for recurring tingling in feet.",
+    "Pneumococcal vaccination is the next preventive care gap.",
+  ],
+};
+
+export const demoExports = [
+  { name: "Patient Summary PDF", format: "Browser PDF", status: "Ready", note: "Compact and standard print modes" },
+  { name: "Medication CSV", format: "CSV", status: "Ready", note: "Includes schedules and doctor linkage" },
+  { name: "Document Index CSV", format: "CSV", status: "Ready", note: "Shows protected file access references" },
+  { name: "Alerts Snapshot CSV", format: "CSV", status: "Ready", note: "Useful for admin review and handoff" },
+];
+
+export const demoDevices = [
+  { provider: "Health Connect", status: "Active", lastSync: "15 minutes ago", readings: "Glucose, steps, weight" },
+  { provider: "Apple Health import", status: "Error", lastSync: "2 days ago", readings: "Weight only", note: "Token refresh needed" },
+  { provider: "Bluetooth BP monitor", status: "Active", lastSync: "Today · 6:30 AM", readings: "Blood pressure" },
+];
+
+export const demoJobs = [
+  { job: "ALERT_SCAN", queue: "alerts", status: "Succeeded", at: "Today · 8:02 AM" },
+  { job: "REMINDER_DISPATCH", queue: "reminders", status: "Succeeded", at: "Today · 7:00 AM" },
+  { job: "DEVICE_SYNC", queue: "mobile-sync", status: "Retrying", at: "Today · 6:35 AM" },
+];
+
+export const demoOps = {
+  readiness: [
+    { label: "Database", status: "Ready" },
+    { label: "Email delivery", status: "Configured" },
+    { label: "Internal API auth", status: "Configured" },
+    { label: "Redis / job queues", status: "Ready with degraded fallback" },
+  ],
+  metrics: [
+    { label: "Pending invites", value: "2" },
+    { label: "Reminder emails (7d)", value: "48" },
+    { label: "Resolved alerts (24h)", value: "3" },
+    { label: "Sync failures", value: "1" },
+  ],
+};
+
+export const demoSecurity = {
+  posture: [
+    { label: "Password status", value: "Configured" },
+    { label: "Email verification", value: "Verified" },
+    { label: "Active mobile sessions", value: "3" },
+    { label: "Protected documents", value: "27 files" },
+  ],
+  sessions: [
+    { device: "Pixel 8 · Android", createdAt: "Apr 23, 2026", lastUsed: "10 minutes ago", expires: "May 23, 2026", state: "Active" },
+    { device: "iPad Safari", createdAt: "Apr 19, 2026", lastUsed: "Yesterday", expires: "May 19, 2026", state: "Active" },
+    { device: "MacBook Chrome", createdAt: "Apr 10, 2026", lastUsed: "Apr 21, 2026", expires: "May 10, 2026", state: "Revoked" },
+  ],
+};
+
+export const demoAdmin = {
+  metrics: [
+    { label: "Total users", value: "148" },
+    { label: "Verified users", value: "133" },
+    { label: "Deactivated users", value: "4" },
+    { label: "Failed jobs", value: "2" },
+  ],
+  roster: [
+    { name: "Elena Cruz", role: "PATIENT", status: "Active", sessions: 3, alerts: 2, documents: 27 },
+    { name: "Marco Cruz", role: "CAREGIVER", status: "Active", sessions: 1, alerts: 0, documents: 0 },
+    { name: "Admin Support", role: "ADMIN", status: "Active", sessions: 2, alerts: 0, documents: 0 },
+    { name: "Dormant Demo User", role: "PATIENT", status: "Deactivated", sessions: 0, alerts: 1, documents: 4 },
+  ],
+  audit: [
+    { source: "user", message: "Admin re-sent verification email to dietitian@example.com", at: "Apr 24, 2026 · 8:10 AM" },
+    { source: "security", message: "Revoked all mobile sessions for Dormant Demo User", at: "Apr 24, 2026 · 8:00 AM" },
+    { source: "access", message: "Caregiver invite accepted by Marco Cruz", at: "Apr 23, 2026 · 5:15 PM" },
+  ],
+};


### PR DESCRIPTION
## Summary
- added a full public `/demo` experience
- added read-only demo pages for VitaVault’s major product areas
- added realistic hardcoded sample data across patient, care, ops, security, and admin flows
- kept the real authenticated app untouched
- updated the homepage demo CTA to point to `/demo`

## Why this matters
This makes VitaVault much easier to showcase on Vercel and in portfolio/recruiter/client contexts without requiring login or database setup.

## Testing
- [x] npm run typecheck
- [x] npm run lint
- [x] npm run test:run
- [ ] open `/demo`
- [ ] click through all major demo routes
- [ ] confirm homepage “View demo” points to `/demo`