### PR TITLE
Fix 18: add public demo experience and landing page demo access

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,44 @@
 import Link from "next/link";
-import { ArrowRight, CalendarClock, FileHeart, HeartPulse, Pill, ShieldCheck, TrendingUp } from "lucide-react";
+import {
+  ArrowRight,
+  CalendarClock,
+  FileHeart,
+  HeartPulse,
+  Pill,
+  ShieldCheck,
+  TrendingUp,
+} from "lucide-react";
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui";
 
 const features = [
-  { title: "Medication schedules", icon: Pill, description: "Track dosage, reminders, and adherence in one flow." },
-  { title: "Labs and documents", icon: FileHeart, description: "Store PDFs and important health records securely." },
-  { title: "Appointments", icon: CalendarClock, description: "Plan visits, clinic notes, and follow-ups with clarity." },
-  { title: "Health insights", icon: TrendingUp, description: "See trends across blood pressure, sugar, and weight." },
+  {
+    title: "Medication schedules",
+    icon: Pill,
+    description: "Track dosage, reminders, and adherence in one flow.",
+  },
+  {
+    title: "Labs and documents",
+    icon: FileHeart,
+    description: "Store PDFs and important health records securely.",
+  },
+  {
+    title: "Appointments",
+    icon: CalendarClock,
+    description: "Plan visits, clinic notes, and follow-ups with clarity.",
+  },
+  {
+    title: "Health insights",
+    icon: TrendingUp,
+    description: "See trends across blood pressure, sugar, and weight.",
+  },
 ];
 
 function Logo() {
@@ -16,7 +49,9 @@ function Logo() {
       </div>
       <div>
         <p className="text-2xl font-semibold tracking-tight">VitaVault</p>
-        <p className="text-sm text-muted-foreground">Personal Health Record Companion</p>
+        <p className="text-sm text-muted-foreground">
+          Personal Health Record Companion
+        </p>
       </div>
     </div>
   );
@@ -29,55 +64,87 @@ export default function HomePage() {
         <header className="flex items-center justify-between rounded-3xl border bg-white/70 px-4 py-4 shadow-sm backdrop-blur md:px-6">
           <Logo />
           <div className="flex items-center gap-3">
-            <Link href="/login" className="rounded-2xl border border-border/60 px-6 py-2 font-medium hover:bg-muted/60">Login</Link>
-            <Link href="/signup" className="rounded-2xl bg-primary px-6 py-2 font-medium text-primary-foreground">Get Started</Link>
+            <Link href="/demo">
+              <Button variant="outline" className="rounded-2xl px-6">
+                Demo
+              </Button>
+            </Link>
+            <Link href="/login">
+              <Button variant="outline" className="rounded-2xl px-6">
+                Login
+              </Button>
+            </Link>
+            <Link href="/signup">
+              <Button className="rounded-2xl px-6">Get Started</Button>
+            </Link>
           </div>
         </header>
 
         <section className="grid gap-10 py-10 lg:grid-cols-[1.1fr_0.9fr] lg:items-center lg:py-16">
           <div className="space-y-8">
-            <span className="inline-flex items-center rounded-full border border-border/60 bg-background/70 px-4 py-2 text-sm font-medium">
+            <Badge className="rounded-full px-4 py-2 text-sm">
               <ShieldCheck className="mr-2 h-4 w-4" />
               Secure, private, and startup-grade UX
-            </span>
+            </Badge>
 
             <div className="space-y-5">
               <h1 className="max-w-4xl text-5xl font-semibold tracking-tight text-foreground sm:text-6xl lg:text-7xl">
                 Manage your personal health records in one polished workspace.
               </h1>
+
               <p className="max-w-3xl text-lg leading-8 text-muted-foreground sm:text-xl">
-                VitaVault gives patients a premium dashboard for medications, appointments, labs, vitals, symptoms, documents,
-                reminders, and printable summaries.
+                VitaVault gives patients a premium dashboard for medications,
+                appointments, labs, vitals, symptoms, documents, reminders, and
+                printable summaries.
               </p>
             </div>
 
             <div className="flex flex-wrap gap-4">
-              <Link href="/signup" className="inline-flex items-center rounded-2xl bg-primary px-7 py-3 font-medium text-primary-foreground">
-                Create account
-                <ArrowRight className="ml-2 h-4 w-4" />
+              <Link href="/signup">
+                <Button size="lg" className="rounded-2xl px-7">
+                  Create account
+                  <ArrowRight className="ml-2 h-4 w-4" />
+                </Button>
               </Link>
-              <Link href="/demo" className="rounded-2xl border border-border/60 px-7 py-3 font-medium hover:bg-muted/60">View demo</Link>
+
+              <Link href="/demo">
+                <Button size="lg" variant="outline" className="rounded-2xl px-7">
+                  View demo
+                </Button>
+              </Link>
             </div>
           </div>
 
-          <div className="rounded-[2rem] border bg-white/80 p-6 shadow-xl backdrop-blur">
-            <div className="space-y-3">
-              <h2 className="text-4xl font-semibold">Flagship health dashboard</h2>
-              <p className="text-lg text-muted-foreground">Beautiful cards, fast actions, charts, reminders, and activity history.</p>
-            </div>
-            <div className="mt-6 grid gap-5 sm:grid-cols-2">
+          <Card className="rounded-[2rem] border bg-white/80 shadow-xl backdrop-blur">
+            <CardHeader className="space-y-3">
+              <CardTitle className="text-4xl">Flagship health dashboard</CardTitle>
+              <CardDescription className="text-lg">
+                Beautiful cards, fast actions, charts, reminders, and activity
+                history.
+              </CardDescription>
+            </CardHeader>
+
+            <CardContent className="grid gap-5 sm:grid-cols-2">
               {features.map((feature) => {
                 const Icon = feature.icon;
+
                 return (
-                  <div key={feature.title} className="rounded-3xl border bg-background/80 p-6 shadow-sm">
+                  <div
+                    key={feature.title}
+                    className="rounded-3xl border bg-background/80 p-6 shadow-sm"
+                  >
                     <Icon className="mb-4 h-7 w-7 text-primary" />
-                    <h3 className="mb-2 text-2xl font-semibold tracking-tight">{feature.title}</h3>
-                    <p className="text-base leading-7 text-muted-foreground">{feature.description}</p>
+                    <h3 className="mb-2 text-2xl font-semibold tracking-tight">
+                      {feature.title}
+                    </h3>
+                    <p className="text-base leading-7 text-muted-foreground">
+                      {feature.description}
+                    </p>
                   </div>
                 );
               })}
-            </div>
-          </div>
+            </CardContent>
+          </Card>
         </section>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- added a full public `/demo` experience for VitaVault
- added read-only demo pages for the major product areas
- added realistic hardcoded sample data across patient, care, alerts, security, ops, and admin views
- cleaned demo JSX, data, and lint issues
- added landing page demo access so users can explore VitaVault without logging in

## Why this matters
This makes VitaVault much easier to showcase on Vercel, in portfolio reviews, and to recruiters or clients without requiring login or database interaction.

## Included demo areas
- Dashboard
- Health Profile
- Medications
- Appointments
- Labs
- Vitals
- Symptoms
- Vaccinations
- Doctors
- Documents
- Care Team
- AI Insights
- Alerts
- Timeline
- Reminders
- Review Queue
- Summary
- Exports
- Device Connection
- Jobs
- Ops
- Security
- Admin

## Testing
- [x] npm run typecheck
- [x] npm run lint
- [x] npm run test:run
- [ ] open `/`
- [ ] click the landing page Demo button
- [ ] open `/demo`
- [ ] navigate across demo pages
- [ ] confirm no-login public demo flow works