### PR TITLE
Fix 19: expand public demo pages to better mirror real VitaVault modules

### DIFF
--- a/app/demo/admin/page.tsx
+++ b/app/demo/admin/page.tsx
@@ -2,16 +2,26 @@ import { DemoHeader, DemoSection, MetricGrid, SimpleTable } from "@/components/d
 import { demoAdmin } from "@/lib/demo-data";
 
 export default function DemoAdminPage() {
+  const rosterRows = demoAdmin.roster.map((item) => [
+    item.name,
+    item.role,
+    item.status,
+    String(item.sessions),
+    String(item.alerts),
+    String(item.documents),
+  ]);
+  const auditRows = demoAdmin.audit.map((item) => [item.source, item.message, item.at]);
+
   return (
     <div className="space-y-6">
       <DemoHeader title="Admin Workspace" description="User oversight, moderation actions, audit visibility, and platform-level review." />
       <MetricGrid items={demoAdmin.metrics} />
       <div className="grid gap-6 xl:grid-cols-[1.15fr_0.85fr]">
         <DemoSection title="User roster">
-          <SimpleTable headers={["User", "Role", "Status", "Sessions", "Alerts", "Documents"]} rows={demoAdmin.roster.map((item) => [item.name, item.role, item.status, String(item.sessions), String(item.alerts), String(item.documents)])} />
+          <SimpleTable headers={["User", "Role", "Status", "Sessions", "Alerts", "Documents"]} rows={rosterRows} />
         </DemoSection>
         <DemoSection title="Audit feed">
-          <SimpleTable headers={["Source", "Message", "When"]} rows={demoAdmin.audit.map((item) => [item.source, item.message, item.at])} />
+          <SimpleTable headers={["Source", "Message", "When"]} rows={auditRows} />
         </DemoSection>
       </div>
     </div>

--- a/app/demo/alerts/page.tsx
+++ b/app/demo/alerts/page.tsx
@@ -2,15 +2,25 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoAlerts } from "@/lib/demo-data";
 
 export default function DemoAlertsPage() {
+  const eventRows = demoAlerts.events.map((item) => [
+    item.title,
+    item.severity,
+    item.status,
+    item.category,
+    item.source,
+    item.createdAt,
+  ]);
+  const ruleRows = demoAlerts.rules.map((item) => [item.name, item.category, item.severity, item.status]);
+
   return (
     <div className="space-y-6">
       <DemoHeader title="Alert Center" description="Threshold rules, event statuses, categories, and review context." />
       <div className="grid gap-6 xl:grid-cols-2">
         <DemoSection title="Alert events">
-          <SimpleTable headers={["Title", "Severity", "Status", "Category", "Source", "Created"]} rows={demoAlerts.events.map((item) => [item.title, item.severity, item.status, item.category, item.source, item.createdAt])} />
+          <SimpleTable headers={["Title", "Severity", "Status", "Category", "Source", "Created"]} rows={eventRows} />
         </DemoSection>
         <DemoSection title="Alert rules">
-          <SimpleTable headers={["Rule", "Category", "Severity", "Status"]} rows={demoAlerts.rules.map((item) => [item.name, item.category, item.severity, item.status])} />
+          <SimpleTable headers={["Rule", "Category", "Severity", "Status"]} rows={ruleRows} />
         </DemoSection>
       </div>
     </div>

--- a/app/demo/appointments/page.tsx
+++ b/app/demo/appointments/page.tsx
@@ -2,11 +2,13 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoAppointments } from "@/lib/demo-data";
 
 export default function DemoAppointmentsPage() {
+  const rows = demoAppointments.map((item) => [item.title, item.when, item.location, item.status, item.doctor, item.note]);
+
   return (
     <div className="space-y-6">
       <DemoHeader title="Appointments" description="Upcoming and completed visits with clinic context, status, and follow-up notes." />
       <DemoSection title="Appointment timeline">
-        <SimpleTable headers={["Visit", "When", "Location", "Status", "Doctor", "Notes"]} rows={demoAppointments.map((item) => [item.title, item.when, item.location, item.status, item.doctor, item.note])} />
+        <SimpleTable headers={["Visit", "When", "Location", "Status", "Doctor", "Notes"]} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/care-team/page.tsx
+++ b/app/demo/care-team/page.tsx
@@ -2,15 +2,18 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoCareTeam } from "@/lib/demo-data";
 
 export default function DemoCareTeamPage() {
+  const memberRows = demoCareTeam.members.map((item) => [item.name, item.role, item.access, item.status]);
+  const inviteRows = demoCareTeam.invites.map((item) => [item.recipient, item.role, item.sentAt, item.delivery, item.status]);
+
   return (
     <div className="space-y-6">
       <DemoHeader title="Care Team" description="Shared access, pending invites, and role-based collaboration across patient care." />
       <div className="grid gap-6 xl:grid-cols-2">
         <DemoSection title="Active members">
-          <SimpleTable headers={["Name", "Role", "Access", "Status"]} rows={demoCareTeam.members.map((item) => [item.name, item.role, item.access, item.status])} />
+          <SimpleTable headers={["Name", "Role", "Access", "Status"]} rows={memberRows} />
         </DemoSection>
         <DemoSection title="Pending invites">
-          <SimpleTable headers={["Recipient", "Role", "Sent", "Delivery", "Status"]} rows={demoCareTeam.invites.map((item) => [item.recipient, item.role, item.sentAt, item.delivery, item.status])} />
+          <SimpleTable headers={["Recipient", "Role", "Sent", "Delivery", "Status"]} rows={inviteRows} />
         </DemoSection>
       </div>
     </div>

--- a/app/demo/dashboard/page.tsx
+++ b/app/demo/dashboard/page.tsx
@@ -1,19 +1,27 @@
-import { DemoHeader, DemoSection, MetricGrid, SimpleTable } from "@/components/demo-primitives";
-import { demoDashboardStats, demoTimeline, demoReminders } from "@/lib/demo-data";
+import { ActionChips, DemoHeader, DemoSection, MetricGrid, SimpleTable, StatCards } from "@/components/demo-primitives";
+import { demoDashboardStats, demoTimeline, demoReminders, demoSummary, demoAlerts } from "@/lib/demo-data";
 
 export default function DemoDashboardPage() {
   return (
     <div className="space-y-6">
-      <DemoHeader title="Dashboard" description="A premium at-a-glance overview of patient health, outstanding tasks, and recent events." />
+      <DemoHeader eyebrow="Patient command center" title="Dashboard" description="A richer public mirror of VitaVault’s patient dashboard, showing health status, reminders, alerts, and the running care story for Elena Cruz." />
       <MetricGrid items={demoDashboardStats} />
-      <div className="grid gap-6 xl:grid-cols-2">
-        <DemoSection title="Recent timeline">
+      <StatCards items={[
+        { title: "Clinical snapshot", body: demoSummary.snapshot, status: "Healthy" },
+        { title: "Alert posture", body: `${demoAlerts.events.filter((item) => item.status === "OPEN").length} events still need follow-up across symptoms and thresholds.`, status: "Watch" },
+        { title: "Today’s priorities", body: "Confirm medication adherence, review tingling symptom signal, and keep the eye screening schedule on track.", status: "Action" },
+      ]} />
+      <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
+        <DemoSection title="Recent timeline" description="Mirrors the real dashboard’s running patient activity feed.">
           <SimpleTable headers={["When", "Type", "Title", "Detail"]} rows={demoTimeline.map((item) => [item.at, item.type, item.title, item.detail])} />
         </DemoSection>
-        <DemoSection title="Reminder center snapshot">
+        <DemoSection title="Reminder center snapshot" description="Upcoming and recently dispatched nudges across medication and appointments.">
           <SimpleTable headers={["Reminder", "When", "Channel", "State"]} rows={demoReminders.map((item) => [item.title, item.when, item.channel, item.state])} />
         </DemoSection>
       </div>
+      <DemoSection title="Demo-only actions" description="These mirror the real app action zones, but stay safely read-only here.">
+        <ActionChips items={["Generate AI insight preview", "Open patient summary PDF", "Review alert center", "Jump to exports", "Inspect admin workspace"]} />
+      </DemoSection>
     </div>
   );
 }

--- a/app/demo/device-connection/page.tsx
+++ b/app/demo/device-connection/page.tsx
@@ -2,11 +2,13 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoDevices } from "@/lib/demo-data";
 
 export default function DemoDeviceConnectionPage() {
+  const rows = demoDevices.map((item) => [item.provider, item.status, item.lastSync, item.readings, item.note ?? "—"]);
+
   return (
     <div className="space-y-6">
       <DemoHeader title="Device Connections" description="Connected apps and devices that feed VitaVault vitals and sync workflows." />
       <DemoSection title="Connection status">
-        <SimpleTable headers={["Provider", "Status", "Last sync", "Readings", "Notes"]} rows={demoDevices.map((item) => [item.provider, item.status, item.lastSync, item.readings, item.note ?? "—"])} />
+        <SimpleTable headers={["Provider", "Status", "Last sync", "Readings", "Notes"]} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/doctors/page.tsx
+++ b/app/demo/doctors/page.tsx
@@ -1,12 +1,21 @@
-import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitives";
+import { DemoHeader, DemoSection, MetricGrid, SimpleTable, StatCards } from "@/components/demo-primitives";
 import { demoDoctors } from "@/lib/demo-data";
 
 export default function DemoDoctorsPage() {
   return (
     <div className="space-y-6">
-      <DemoHeader title="Doctors" description="Specialists, clinic details, and contact information linked to care workflows." />
-      <DemoSection title="Provider directory">
+      <DemoHeader eyebrow="Care network" title="Doctors" description="Shows the provider directory users manage in VitaVault, including specialties, clinic linkage, and communication context." />
+      <MetricGrid items={[
+        { label: "Tracked providers", value: String(demoDoctors.length), note: "Primary and specialty care" },
+        { label: "Specialties", value: "3", note: "Endocrinology, internal medicine, ophthalmology" },
+        { label: "Linked appointments", value: "3", note: "All major upcoming visits connected" },
+        { label: "Direct contacts", value: "100%", note: "Phone and email stored" },
+      ]} />
+      <DemoSection title="Provider table">
         <SimpleTable headers={["Doctor", "Specialty", "Clinic", "Phone", "Email"]} rows={demoDoctors.map((item) => [item.name, item.specialty, item.clinic, item.phone, item.email])} />
+      </DemoSection>
+      <DemoSection title="How this connects elsewhere">
+        <StatCards items={demoDoctors.map((item) => ({ title: item.name, body: `${item.specialty} at ${item.clinic}. Referenced across appointments, documents, and summary exports.`, status: "Active" }))} />
       </DemoSection>
     </div>
   );

--- a/app/demo/documents/page.tsx
+++ b/app/demo/documents/page.tsx
@@ -2,11 +2,13 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoDocuments } from "@/lib/demo-data";
 
 export default function DemoDocumentsPage() {
+  const rows = demoDocuments.map((item) => [item.name, item.type, item.linkedTo, item.access, item.size]);
+
   return (
     <div className="space-y-6">
       <DemoHeader title="Documents" description="Protected document delivery, record linking, and clinically useful file organization." />
       <DemoSection title="Document library">
-        <SimpleTable headers={["Document", "Type", "Linked to", "Access", "Size"]} rows={demoDocuments.map((item) => [item.name, item.type, item.linkedTo, item.access, item.size])} />
+        <SimpleTable headers={["Document", "Type", "Linked to", "Access", "Size"]} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/exports/page.tsx
+++ b/app/demo/exports/page.tsx
@@ -2,11 +2,13 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoExports } from "@/lib/demo-data";
 
 export default function DemoExportsPage() {
+  const rows = demoExports.map((item) => [item.name, item.format, item.status, item.note]);
+
   return (
     <div className="space-y-6">
       <DemoHeader title="Exports" description="Business-friendly export formats for summaries, records, and operational review." />
       <DemoSection title="Available exports">
-        <SimpleTable headers={["Export", "Format", "Status", "Notes"]} rows={demoExports.map((item) => [item.name, item.format, item.status, item.note])} />
+        <SimpleTable headers={["Export", "Format", "Status", "Notes"]} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/health-profile/page.tsx
+++ b/app/demo/health-profile/page.tsx
@@ -1,24 +1,40 @@
-import { DemoHeader, DemoSection, KeyValueList } from "@/components/demo-primitives";
+import { BulletList, DemoHeader, DemoSection, KeyValueList, MetricGrid, StatCards } from "@/components/demo-primitives";
 import { demoPatient } from "@/lib/demo-data";
 
 export default function DemoHealthProfilePage() {
   return (
     <div className="space-y-6">
-      <DemoHeader title="Health Profile" description="Core demographic, risk, and emergency information that anchors the rest of VitaVault." />
-      <DemoSection title="Patient details">
-        <KeyValueList items={[
-          { label: "Full name", value: demoPatient.name },
-          { label: "Email", value: demoPatient.email },
-          { label: "Phone", value: demoPatient.phone },
-          { label: "Address", value: demoPatient.address },
-          { label: "Blood type", value: demoPatient.bloodType },
-          { label: "Emergency contact", value: demoPatient.emergencyContact },
-          { label: "Height", value: `${demoPatient.heightCm} cm` },
-          { label: "Weight", value: `${demoPatient.weightKg} kg` },
-          { label: "BMI", value: String(demoPatient.bmi) },
-          { label: "Allergies", value: demoPatient.allergies.join(", ") },
-          { label: "Chronic conditions", value: demoPatient.chronicConditions.join(", ") },
-          { label: "Last updated", value: demoPatient.lastUpdated },
+      <DemoHeader eyebrow="Patient identity and baseline" title="Health Profile" description="This mirrors VitaVault’s health profile page with patient basics, contact context, risk factors, and baseline measurements using safe hardcoded demo data." />
+      <MetricGrid items={[
+        { label: "Age", value: String(demoPatient.age), note: demoPatient.sex },
+        { label: "Blood type", value: demoPatient.bloodType, note: "Recorded and verified" },
+        { label: "BMI", value: String(demoPatient.bmi), note: `${demoPatient.heightCm} cm · ${demoPatient.weightKg} kg` },
+        { label: "Last updated", value: demoPatient.lastUpdated, note: "Profile review complete" },
+      ]} />
+      <div className="grid gap-6 xl:grid-cols-2">
+        <DemoSection title="Profile details">
+          <KeyValueList items={[
+            { label: "Full name", value: demoPatient.name },
+            { label: "Email", value: demoPatient.email },
+            { label: "Phone", value: demoPatient.phone },
+            { label: "Emergency contact", value: demoPatient.emergencyContact },
+            { label: "Address", value: demoPatient.address },
+            { label: "Sex", value: demoPatient.sex },
+          ]} />
+        </DemoSection>
+        <DemoSection title="Clinical baseline">
+          <StatCards items={[
+            { title: "Allergies", body: demoPatient.allergies.join(", "), status: "Watch" },
+            { title: "Chronic conditions", body: demoPatient.chronicConditions.join(", "), status: "Monitor" },
+            { title: "Risk framing", body: "Current records show stable blood pressure and improving diabetes control, with neuropathy monitoring still needed.", status: "Info" },
+          ]} />
+        </DemoSection>
+      </div>
+      <DemoSection title="Care instructions and notes">
+        <BulletList items={[
+          "Keep antihypertensive adherence above 95% and continue morning BP spot checks.",
+          "Maintain quarterly endocrinology review cadence and annual eye screening coverage.",
+          "Continue documenting tingling episodes with time, severity, and duration for rule-based review.",
         ]} />
       </DemoSection>
     </div>

--- a/app/demo/jobs/page.tsx
+++ b/app/demo/jobs/page.tsx
@@ -2,11 +2,13 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoJobs } from "@/lib/demo-data";
 
 export default function DemoJobsPage() {
+  const rows = demoJobs.map((item) => [item.job, item.queue, item.status, item.at]);
+
   return (
     <div className="space-y-6">
       <DemoHeader title="Jobs" description="Background processing visibility for alert scans, reminders, and sync workflows." />
       <DemoSection title="Recent job runs">
-        <SimpleTable headers={["Job", "Queue", "Status", "When"]} rows={demoJobs.map((item) => [item.job, item.queue, item.status, item.at])} />
+        <SimpleTable headers={["Job", "Queue", "Status", "When"]} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/labs/page.tsx
+++ b/app/demo/labs/page.tsx
@@ -2,11 +2,13 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoLabs } from "@/lib/demo-data";
 
 export default function DemoLabsPage() {
+  const rows = demoLabs.map((item) => [item.test, item.value, item.trend, item.status, item.collectedAt, item.lab]);
+
   return (
     <div className="space-y-6">
       <DemoHeader title="Labs" description="Lab trends, status indicators, and uploaded result context." />
       <DemoSection title="Latest lab set">
-        <SimpleTable headers={["Test", "Value", "Trend", "Status", "Collected", "Lab"]} rows={demoLabs.map((item) => [item.test, item.value, item.trend, item.status, item.collectedAt, item.lab])} />
+        <SimpleTable headers={["Test", "Value", "Trend", "Status", "Collected", "Lab"]} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/medications/page.tsx
+++ b/app/demo/medications/page.tsx
@@ -2,11 +2,22 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoMedications } from "@/lib/demo-data";
 
 export default function DemoMedicationsPage() {
+  const rows = demoMedications.map((item) => [
+    item.name,
+    item.dosage,
+    item.frequency,
+    item.times.join(", "),
+    item.status,
+    item.doctor,
+    item.adherence,
+    item.instructions,
+  ]);
+
   return (
     <div className="space-y-6">
       <DemoHeader title="Medications" description="Schedules, adherence signals, linked doctors, and patient-facing instructions." />
       <DemoSection title="Active medication plan">
-        <SimpleTable headers={["Medication", "Dosage", "Frequency", "Times", "Status", "Doctor", "Adherence", "Instructions"]} rows={demoMedications.map((item) => [item.name, item.dosage, item.frequency, item.times.join(", "), item.status, item.doctor, item.adherence, item.instructions])} />
+        <SimpleTable headers={["Medication", "Dosage", "Frequency", "Times", "Status", "Doctor", "Adherence", "Instructions"]} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/ops/page.tsx
+++ b/app/demo/ops/page.tsx
@@ -2,12 +2,14 @@ import { DemoHeader, DemoSection, MetricGrid, SimpleTable } from "@/components/d
 import { demoOps } from "@/lib/demo-data";
 
 export default function DemoOpsPage() {
+  const rows = demoOps.readiness.map((item) => [item.label, item.status]);
+
   return (
     <div className="space-y-6">
       <DemoHeader title="Operations" description="Readiness checks and high-level operational monitoring for delivery and sync workflows." />
       <MetricGrid items={demoOps.metrics} />
       <DemoSection title="Environment readiness">
-        <SimpleTable headers={["Check", "Status"]} rows={demoOps.readiness.map((item) => [item.label, item.status])} />
+        <SimpleTable headers={["Check", "Status"]} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -1,61 +1,29 @@
-import { DemoHeader, DemoSection, MetricGrid, KeyValueList, ToneBadge, Badge } from "@/components/demo-primitives";
-import { demoDashboardStats, demoPatient, demoAiInsights, demoAlerts, demoNav } from "@/lib/demo-data";
+import Link from "next/link";
+import { DemoHeader, DemoSection, MetricGrid, SimpleTable, StatCards } from "@/components/demo-primitives";
+import { demoNav, demoDashboardStats, demoSummary, demoOps } from "@/lib/demo-data";
 
-export default function DemoPage() {
+export default function DemoOverviewPage() {
   return (
     <div className="space-y-6">
-      <DemoHeader title="Explore VitaVault" description="A full no-login walkthrough of the product with realistic sample patient, admin, and ops data." />
+      <DemoHeader eyebrow="No login required" title="Explore VitaVault Demo" description="This public demo is a deeper mirror of VitaVault’s real authenticated product: patient records, reminders, alerts, exports, security, operations, and admin oversight, all shown with safe sample data." actions={<><Link href="/demo/dashboard" className="rounded-2xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground">Open dashboard</Link><Link href="/demo/admin" className="rounded-2xl border border-border/60 px-4 py-2 text-sm font-medium hover:bg-muted/60">See admin view</Link></>} />
       <MetricGrid items={demoDashboardStats} />
-      <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
-        <DemoSection title="Patient snapshot" description="The demo uses a realistic chronic-care scenario so every VitaVault workflow has something meaningful to show.">
-          <KeyValueList items={[
-            { label: "Patient", value: demoPatient.name },
-            { label: "Age / Sex", value: `${demoPatient.age} · ${demoPatient.sex}` },
-            { label: "Blood type", value: demoPatient.bloodType },
-            { label: "Conditions", value: demoPatient.chronicConditions.join(", ") },
-            { label: "Allergies", value: demoPatient.allergies.join(", ") },
-            { label: "Emergency contact", value: demoPatient.emergencyContact },
+      <DemoSection title="What this demo covers" description="The goal here is parity with the real VitaVault product surface, not just a landing-page teaser.">
+        <SimpleTable headers={["Area", "What you can inspect in demo"]} rows={demoNav.slice(1).map((item) => [item.label, item.description ?? `Read-only mirror of the ${item.label.toLowerCase()} module`])} />
+      </DemoSection>
+      <div className="grid gap-6 xl:grid-cols-[1fr_1fr]">
+        <DemoSection title="Why VitaVault matters">
+          <StatCards items={[
+            { title: "Patient-centric records", body: "Track medications, labs, symptoms, vitals, vaccines, appointments, documents, and provider relationships in one place.", status: "Core" },
+            { title: "Actionable follow-up", body: "Reminder center, review queue, AI insights, and alerts help teams move from records to actual care action.", status: "Workflow" },
+            { title: "Operational confidence", body: "Security, exports, jobs, ops, and admin layers make the product feel business-ready instead of just visually polished.", status: "Ops" },
           ]} />
         </DemoSection>
-        <DemoSection title="Feature coverage" description="Every main VitaVault area has a dedicated public demo page.">
-          <div className="grid gap-2 sm:grid-cols-2">
-            {demoNav.slice(1).map((item) => (
-              <div key={item.href} className="rounded-2xl border border-border/60 bg-background/60 p-3">
-                <p className="font-medium">{item.label}</p>
-                <p className="text-xs text-muted-foreground">{item.href}</p>
-              </div>
-            ))}
-          </div>
-        </DemoSection>
-      </div>
-      <div className="grid gap-6 lg:grid-cols-2">
-        <DemoSection title="AI insight preview" description="Shows the product's explanatory summaries and action guidance.">
-          <div className="space-y-3">
-            {demoAiInsights.map((item) => (
-              <div key={item.title} className="rounded-2xl border border-border/60 bg-background/60 p-4">
-                <div className="mb-2 flex items-center justify-between gap-2">
-                  <p className="font-medium">{item.title}</p>
-                  <ToneBadge value={item.severity} />
-                </div>
-                <p className="text-sm text-muted-foreground">{item.summary}</p>
-              </div>
-            ))}
-          </div>
-        </DemoSection>
-        <DemoSection title="Alert preview" description="The demo includes open, acknowledged, and rule-driven events.">
-          <div className="space-y-3">
-            {demoAlerts.events.map((item) => (
-              <div key={item.title} className="rounded-2xl border border-border/60 bg-background/60 p-4">
-                <div className="mb-2 flex flex-wrap gap-2">
-                  <ToneBadge value={item.severity} />
-                  <ToneBadge value={item.status} />
-                  <Badge>{item.category}</Badge>
-                </div>
-                <p className="font-medium">{item.title}</p>
-                <p className="text-sm text-muted-foreground">{item.source} · {item.createdAt}</p>
-              </div>
-            ))}
-          </div>
+        <DemoSection title="Demo snapshot">
+          <StatCards items={[
+            { title: "Clinical summary", body: demoSummary.snapshot, status: "Healthy" },
+            { title: "Ops readiness", body: demoOps.readiness.map((item) => `${item.label}: ${item.status}`).join(" • "), status: "Configured" },
+            { title: "Best route through the demo", body: "Dashboard → Medications → Alerts → Summary → Security → Admin", status: "Recommended" },
+          ]} />
         </DemoSection>
       </div>
     </div>

--- a/app/demo/reminders/page.tsx
+++ b/app/demo/reminders/page.tsx
@@ -2,11 +2,13 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoReminders } from "@/lib/demo-data";
 
 export default function DemoRemindersPage() {
+  const rows = demoReminders.map((item) => [item.title, item.when, item.channel, item.state]);
+
   return (
     <div className="space-y-6">
       <DemoHeader title="Reminders" description="Scheduled reminders, delivery channels, and dispatch state across meds and follow-ups." />
       <DemoSection title="Reminder queue">
-        <SimpleTable headers={["Reminder", "When", "Channel", "State"]} rows={demoReminders.map((item) => [item.title, item.when, item.channel, item.state])} />
+        <SimpleTable headers={["Reminder", "When", "Channel", "State"]} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/review-queue/page.tsx
+++ b/app/demo/review-queue/page.tsx
@@ -2,11 +2,13 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoReviewQueue } from "@/lib/demo-data";
 
 export default function DemoReviewQueuePage() {
+  const rows = demoReviewQueue.map((item) => [item.item, item.source, item.tone, item.owner, item.status]);
+
   return (
     <div className="space-y-6">
       <DemoHeader title="Review Queue" description="Items surfaced for clinical follow-up, caregiver action, and admin handoff." />
       <DemoSection title="Review workload">
-        <SimpleTable headers={["Item", "Source", "Tone", "Owner", "Status"]} rows={demoReviewQueue.map((item) => [item.item, item.source, item.tone, item.owner, item.status])} />
+        <SimpleTable headers={["Item", "Source", "Tone", "Owner", "Status"]} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/security/page.tsx
+++ b/app/demo/security/page.tsx
@@ -2,6 +2,8 @@ import { DemoHeader, DemoSection, KeyValueList, SimpleTable } from "@/components
 import { demoSecurity } from "@/lib/demo-data";
 
 export default function DemoSecurityPage() {
+  const rows = demoSecurity.sessions.map((item) => [item.device, item.createdAt, item.lastUsed, item.expires, item.state]);
+
   return (
     <div className="space-y-6">
       <DemoHeader title="Security Center" description="Account posture, mobile session visibility, and controlled access surfaces." />
@@ -9,7 +11,7 @@ export default function DemoSecurityPage() {
         <KeyValueList items={demoSecurity.posture} />
       </DemoSection>
       <DemoSection title="Session inventory">
-        <SimpleTable headers={["Device", "Created", "Last used", "Expires", "State"]} rows={demoSecurity.sessions.map((item) => [item.device, item.createdAt, item.lastUsed, item.expires, item.state])} />
+        <SimpleTable headers={["Device", "Created", "Last used", "Expires", "State"]} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/summary/page.tsx
+++ b/app/demo/summary/page.tsx
@@ -1,15 +1,30 @@
-import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitives";
-import { demoSummary } from "@/lib/demo-data";
+import { BulletList, DemoHeader, DemoSection, MetricGrid, StatCards } from "@/components/demo-primitives";
+import { demoSummary, demoPatient, demoCareTeam } from "@/lib/demo-data";
 
 export default function DemoSummaryPage() {
   return (
     <div className="space-y-6">
-      <DemoHeader title="Patient Summary" description="Printable summary view and handoff snapshot for patient care conversations." />
-      <DemoSection title="Snapshot narrative">
-        <p className="text-sm leading-7 text-muted-foreground">{demoSummary.snapshot}</p>
-      </DemoSection>
-      <DemoSection title="Key highlights">
-        <SimpleTable headers={["Highlight"]} rows={demoSummary.highlights.map((item) => [item])} />
+      <DemoHeader eyebrow="Patient handoff" title="Summary" description="A more app-like version of VitaVault’s patient summary and export handoff page, combining high-level narrative, care-team context, and snapshot highlights." />
+      <MetricGrid items={[
+        { label: "Patient", value: demoPatient.name, note: `${demoPatient.age} · ${demoPatient.sex}` },
+        { label: "Care members", value: String(demoCareTeam.members.length), note: "Included in handoff context" },
+        { label: "Open issues", value: "1 neuropathy watch", note: "Surfaced from alerts + symptoms" },
+        { label: "Export modes", value: "2", note: "Standard and compact PDF" },
+      ]} />
+      <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
+        <DemoSection title="Clinical snapshot">
+          <p className="text-sm leading-7 text-muted-foreground">{demoSummary.snapshot}</p>
+        </DemoSection>
+        <DemoSection title="Top highlights">
+          <BulletList items={demoSummary.highlights} />
+        </DemoSection>
+      </div>
+      <DemoSection title="How this mirrors the real app">
+        <StatCards items={[
+          { title: "Printable export", body: "The authenticated product provides browser-native PDF workflows and compact print modes from this same summary concept.", status: "Ready" },
+          { title: "AI + care context", body: "The real summary pulls in AI insight, access snapshot, alert posture, and linked records for handoff quality.", status: "Enhanced" },
+          { title: "Shareable snapshot", body: "Teams use this page to hand off care status across appointments, caregivers, and admin operations.", status: "Business-ready" },
+        ]} />
       </DemoSection>
     </div>
   );

--- a/app/demo/symptoms/page.tsx
+++ b/app/demo/symptoms/page.tsx
@@ -2,11 +2,13 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoSymptoms } from "@/lib/demo-data";
 
 export default function DemoSymptomsPage() {
+  const rows = demoSymptoms.map((item) => [item.name, item.severity, item.status, item.loggedAt, item.note]);
+
   return (
     <div className="space-y-6">
       <DemoHeader title="Symptoms" description="Symptom tracking feeds alerts, review queues, and care-team follow-up." />
       <DemoSection title="Logged symptoms">
-        <SimpleTable headers={["Symptom", "Severity", "Status", "Logged", "Notes"]} rows={demoSymptoms.map((item) => [item.name, item.severity, item.status, item.loggedAt, item.note])} />
+        <SimpleTable headers={["Symptom", "Severity", "Status", "Logged", "Notes"]} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/timeline/page.tsx
+++ b/app/demo/timeline/page.tsx
@@ -1,12 +1,21 @@
-import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitives";
+import { DemoHeader, DemoSection, MetricGrid, SimpleTable, StatCards } from "@/components/demo-primitives";
 import { demoTimeline } from "@/lib/demo-data";
 
 export default function DemoTimelinePage() {
   return (
     <div className="space-y-6">
-      <DemoHeader title="Unified Timeline" description="Cross-module chronology tying together reminders, labs, alerts, and visits." />
-      <DemoSection title="Patient activity timeline">
+      <DemoHeader eyebrow="Unified history" title="Timeline" description="A public mirror of VitaVault’s cross-module patient timeline, combining reminders, labs, appointments, and alert events into one longitudinal view." />
+      <MetricGrid items={[
+        { label: "Events shown", value: String(demoTimeline.length), note: "Cross-module activity" },
+        { label: "Sources", value: "4", note: "Reminder, alert, lab, appointment" },
+        { label: "Latest event", value: demoTimeline[0].type, note: demoTimeline[0].at },
+        { label: "Deep links", value: "Previewed", note: "Real app uses record focus routing" },
+      ]} />
+      <DemoSection title="Timeline feed">
         <SimpleTable headers={["When", "Type", "Title", "Detail"]} rows={demoTimeline.map((item) => [item.at, item.type, item.title, item.detail])} />
+      </DemoSection>
+      <DemoSection title="Why the timeline matters">
+        <StatCards items={demoTimeline.map((item) => ({ title: item.title, body: item.detail, status: item.type }))} />
       </DemoSection>
     </div>
   );

--- a/app/demo/vaccinations/page.tsx
+++ b/app/demo/vaccinations/page.tsx
@@ -2,11 +2,13 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoVaccinations } from "@/lib/demo-data";
 
 export default function DemoVaccinationsPage() {
+  const rows = demoVaccinations.map((item) => [item.name, item.date, item.provider, item.status]);
+
   return (
     <div className="space-y-6">
       <DemoHeader title="Vaccinations" description="Immunization history and preventive gaps in one place." />
       <DemoSection title="Vaccination records">
-        <SimpleTable headers={["Vaccine", "Date", "Provider", "Status"]} rows={demoVaccinations.map((item) => [item.name, item.date, item.provider, item.status])} />
+        <SimpleTable headers={["Vaccine", "Date", "Provider", "Status"]} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/vitals/page.tsx
+++ b/app/demo/vitals/page.tsx
@@ -1,13 +1,19 @@
-import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitives";
+import { DemoHeader, DemoSection, MetricGrid, SimpleTable, StatCards } from "@/components/demo-primitives";
 import { demoVitals } from "@/lib/demo-data";
 
 export default function DemoVitalsPage() {
   return (
     <div className="space-y-6">
-      <DemoHeader title="Vitals" description="Trend-friendly vitals tracking for chronic-care follow-up and review." />
-      <DemoSection title="Current vitals snapshot">
-        <SimpleTable headers={["Metric", "Latest", "Range", "Notes"]} rows={demoVitals.map((item) => [item.metric, item.latest, item.range, item.note])} />
-      </DemoSection>
+      <DemoHeader eyebrow="Vital trends" title="Vitals" description="Shows the same style of rolling patient monitoring the real app uses for blood pressure, glucose, weight, and related trend interpretation." />
+      <MetricGrid items={demoVitals.map((item) => ({ label: item.metric, value: item.latest, note: item.range }))} />
+      <div className="grid gap-6 xl:grid-cols-[1fr_0.9fr]">
+        <DemoSection title="Trend summary table">
+          <SimpleTable headers={["Metric", "Latest", "Range", "Commentary"]} rows={demoVitals.map((item) => [item.metric, item.latest, item.range, item.note])} />
+        </DemoSection>
+        <DemoSection title="Clinical meaning">
+          <StatCards items={demoVitals.map((item) => ({ title: item.metric, body: item.note, status: item.metric === "Fasting Glucose" ? "Watch" : "Stable" }))} />
+        </DemoSection>
+      </div>
     </div>
   );
 }

--- a/components/demo-primitives.tsx
+++ b/components/demo-primitives.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { ReactNode } from "react";
 
 const toneClasses: Record<string, string> = {
   danger: "border-red-200 bg-red-50 text-red-700 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-300",
@@ -11,28 +12,33 @@ const toneClasses: Record<string, string> = {
 function inferTone(value: string) {
   const normalized = value.toLowerCase();
   if (["critical", "deactivated", "error", "failed", "revoked"].some((token) => normalized.includes(token))) return "danger";
-  if (["warning", "due", "retry", "watch"].some((token) => normalized.includes(token))) return "warning";
-  if (["active", "good", "ready", "verified", "succeeded", "up to date", "healthy", "configured"].some((token) => normalized.includes(token))) return "success";
-  if (["pending", "monitor", "open", "queued", "info"].some((token) => normalized.includes(token))) return "info";
+  if (["warning", "due", "retry", "watch", "pending"].some((token) => normalized.includes(token))) return "warning";
+  if (["active", "good", "ready", "verified", "succeeded", "up to date", "healthy", "configured", "completed", "sent"].some((token) => normalized.includes(token))) return "success";
+  if (["monitor", "open", "queued", "info", "limited"].some((token) => normalized.includes(token))) return "info";
   return "neutral";
 }
 
-export function DemoHeader({ title, description }: { title: string; description: string }) {
+export function DemoHeader({ title, description, eyebrow, actions }: { title: string; description: string; eyebrow?: string; actions?: ReactNode }) {
   return (
-    <div className="flex flex-wrap items-start justify-between gap-4 rounded-[28px] border border-border/60 bg-background/75 p-6 shadow-sm">
-      <div>
-        <h1 className="text-3xl font-semibold tracking-tight">{title}</h1>
-        <p className="mt-2 max-w-3xl text-sm text-muted-foreground">{description}</p>
-      </div>
-      <div className="flex gap-2">
-        <Link href="/demo/summary" className="rounded-2xl border border-border/60 px-4 py-2 text-sm font-medium hover:bg-muted/60">Summary</Link>
-        <Link href="/demo/admin" className="rounded-2xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground">Admin view</Link>
+    <div className="rounded-[28px] border border-border/60 bg-background/75 p-6 shadow-sm">
+      {eyebrow ? <p className="text-xs font-semibold uppercase tracking-[0.24em] text-primary">{eyebrow}</p> : null}
+      <div className="mt-2 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight">{title}</h1>
+          <p className="mt-2 max-w-3xl text-sm text-muted-foreground">{description}</p>
+        </div>
+        <div className="flex flex-wrap gap-2">{actions ?? (
+          <>
+            <Link href="/demo/summary" className="rounded-2xl border border-border/60 px-4 py-2 text-sm font-medium hover:bg-muted/60">Summary</Link>
+            <Link href="/demo/admin" className="rounded-2xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground">Admin view</Link>
+          </>
+        )}</div>
       </div>
     </div>
   );
 }
 
-export function DemoSection({ title, description, children }: { title: string; description?: string; children: React.ReactNode }) {
+export function DemoSection({ title, description, children }: { title: string; description?: string; children: ReactNode }) {
   return (
     <section className="rounded-[28px] border border-border/60 bg-background/75 p-6 shadow-sm">
       <div className="mb-4">
@@ -76,11 +82,11 @@ export function ToneBadge({ value }: { value: string }) {
   return <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-medium ${toneClasses[tone]}`}>{value}</span>;
 }
 
-export function Badge({ children }: { children: React.ReactNode }) {
+export function Badge({ children }: { children: ReactNode }) {
   return <span className="inline-flex rounded-full border border-border/60 bg-background/70 px-2.5 py-1 text-xs font-medium">{children}</span>;
 }
 
-export function SimpleTable({ headers, rows }: { headers: string[]; rows: React.ReactNode[][] }) {
+export function SimpleTable({ headers, rows }: { headers: string[]; rows: ReactNode[][] }) {
   return (
     <div className="overflow-x-auto">
       <table className="min-w-full text-sm">
@@ -101,6 +107,42 @@ export function SimpleTable({ headers, rows }: { headers: string[]; rows: React.
           ))}
         </tbody>
       </table>
+    </div>
+  );
+}
+
+export function BulletList({ items }: { items: string[] }) {
+  return (
+    <ul className="space-y-3 text-sm text-muted-foreground">
+      {items.map((item) => (
+        <li key={item} className="rounded-2xl border border-border/50 bg-background/60 px-4 py-3 text-foreground">{item}</li>
+      ))}
+    </ul>
+  );
+}
+
+export function StatCards({ items }: { items: { title: string; body: string; status?: string }[] }) {
+  return (
+    <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
+      {items.map((item) => (
+        <div key={item.title} className="rounded-[28px] border border-border/60 bg-background/75 p-5 shadow-sm">
+          <div className="flex items-center justify-between gap-3">
+            <h3 className="font-semibold tracking-tight">{item.title}</h3>
+            {item.status ? <ToneBadge value={item.status} /> : null}
+          </div>
+          <p className="mt-3 text-sm text-muted-foreground">{item.body}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function ActionChips({ items }: { items: string[] }) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {items.map((item) => (
+        <span key={item} className="rounded-2xl border border-border/60 bg-background/70 px-3 py-2 text-xs font-medium text-muted-foreground">{item}</span>
+      ))}
     </div>
   );
 }

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -58,7 +58,7 @@ export const demoMedications = [
 ];
 
 export const demoAppointments = [
-  { title: "Quarterly endocrinology review", when: "May 4, 2026 · 9:00 AM", location: "St. Luke's BGC", status: "UPCOMING", doctor: "Dr. Santos", note: "Discuss A1C trend and weight management plan" },
+  { title: "Quarterly endocrinology review", when: "May 4, 2026 · 9:00 AM", location: "St. Luke\"s BGC", status: "UPCOMING", doctor: "Dr. Santos", note: "Discuss A1C trend and weight management plan" },
   { title: "Eye screening", when: "May 11, 2026 · 2:00 PM", location: "VisionPlus Clinic", status: "UPCOMING", doctor: "Dr. Lim", note: "Annual diabetic retinopathy check" },
   { title: "Annual physical exam", when: "April 10, 2026 · 11:30 AM", location: "Healthway", status: "COMPLETED", doctor: "Dr. Reyes", note: "Updated lab orders and cardiovascular risk review" },
 ];
@@ -66,7 +66,7 @@ export const demoAppointments = [
 export const demoLabs = [
   { test: "HbA1c", value: "6.8%", trend: "Improved from 7.4%", status: "Good", collectedAt: "Apr 20, 2026", lab: "Hi-Precision Diagnostics" },
   { test: "LDL Cholesterol", value: "92 mg/dL", trend: "Stable", status: "Watch", collectedAt: "Apr 20, 2026", lab: "Hi-Precision Diagnostics" },
-  { test: "Creatinine", value: "0.88 mg/dL", trend: "Normal", status: "Normal", collectedAt: "Apr 20, 2026", lab: "St. Luke's Lab" },
+  { test: "Creatinine", value: "0.88 mg/dL", trend: "Normal", status: "Normal", collectedAt: "Apr 20, 2026", lab: "St. Luke\"s Lab" },
 ];
 
 export const demoVitals = [
@@ -89,7 +89,7 @@ export const demoVaccinations = [
 ];
 
 export const demoDoctors = [
-  { name: "Dr. Angela Santos", specialty: "Endocrinology", clinic: "St. Luke's BGC", phone: "+63 2 8789 7700", email: "asantos@stlukes.example.com" },
+  { name: "Dr. Angela Santos", specialty: "Endocrinology", clinic: "St. Luke\"s BGC", phone: "+63 2 8789 7700", email: "asantos@stlukes.example.com" },
   { name: "Dr. Paolo Reyes", specialty: "Internal Medicine", clinic: "Healthway Quezon City", phone: "+63 2 8123 4567", email: "preyes@healthway.example.com" },
   { name: "Dr. Hazel Lim", specialty: "Ophthalmology", clinic: "VisionPlus Clinic", phone: "+63 2 8555 2100", email: "hlim@visionplus.example.com" },
 ];


### PR DESCRIPTION
## Summary
- expanded the public `/demo` experience to better mirror the real VitaVault app
- upgraded demo pages with richer module-style layouts
- added deeper read-only sections across dashboard, records, alerts, reminders, security, ops, and admin views
- cleaned demo sample data and string quoting
- kept the real authenticated app untouched

## Why this matters
The public demo was working, but it still felt like a lightweight showcase instead of a close product mirror. This pass makes the demo much more useful for Vercel, portfolio reviews, recruiters, and client walkthroughs.

## Testing
- [x] npm run typecheck
- [x] npm run lint
- [x] npm run test:run
- [ ] open /demo
- [ ] click through the major demo modules
- [ ] compare the demo flow against the real app structure