### PR TITLE
Fix 20: resolve remaining demo lint cleanup issues

### DIFF
--- a/app/demo/admin/page.tsx
+++ b/app/demo/admin/page.tsx
@@ -2,6 +2,7 @@ import { DemoHeader, DemoSection, MetricGrid, SimpleTable } from "@/components/d
 import { demoAdmin } from "@/lib/demo-data";
 
 export default function DemoAdminPage() {
+  const rosterHeaders = ["User", "Role", "Status", "Sessions", "Alerts", "Documents"];
   const rosterRows = demoAdmin.roster.map((item) => [
     item.name,
     item.role,
@@ -10,18 +11,18 @@ export default function DemoAdminPage() {
     String(item.alerts),
     String(item.documents),
   ]);
+  const auditHeaders = ["Source", "Message", "When"];
   const auditRows = demoAdmin.audit.map((item) => [item.source, item.message, item.at]);
-
   return (
     <div className="space-y-6">
       <DemoHeader title="Admin Workspace" description="User oversight, moderation actions, audit visibility, and platform-level review." />
       <MetricGrid items={demoAdmin.metrics} />
       <div className="grid gap-6 xl:grid-cols-[1.15fr_0.85fr]">
         <DemoSection title="User roster">
-          <SimpleTable headers={["User", "Role", "Status", "Sessions", "Alerts", "Documents"]} rows={rosterRows} />
+          <SimpleTable headers={rosterHeaders} rows={rosterRows} />
         </DemoSection>
         <DemoSection title="Audit feed">
-          <SimpleTable headers={["Source", "Message", "When"]} rows={auditRows} />
+          <SimpleTable headers={auditHeaders} rows={auditRows} />
         </DemoSection>
       </div>
     </div>

--- a/app/demo/ai-insights/page.tsx
+++ b/app/demo/ai-insights/page.tsx
@@ -1,22 +1,25 @@
-import { DemoHeader, DemoSection, ToneBadge } from "@/components/demo-primitives";
+import { BulletList, DemoHeader, DemoSection, MetricGrid, StatCards, ToneBadge } from "@/components/demo-primitives";
 import { demoAiInsights } from "@/lib/demo-data";
 
 export default function DemoAiInsightsPage() {
   return (
     <div className="space-y-6">
-      <DemoHeader title="AI Insights" description="Narrative summaries and action-oriented pattern detection over the patient's history." />
-      <DemoSection title="Generated insights">
-        <div className="space-y-3">
-          {demoAiInsights.map((item) => (
-            <div key={item.title} className="rounded-2xl border border-border/60 bg-background/60 p-4">
-              <div className="mb-2 flex items-center justify-between gap-2">
-                <p className="font-medium">{item.title}</p>
-                <ToneBadge value={item.severity} />
-              </div>
-              <p className="text-sm text-muted-foreground">{item.summary}</p>
-            </div>
-          ))}
-        </div>
+      <DemoHeader eyebrow="AI support" title="AI Insights" description="See how trends, risks, and next-step suggestions can be surfaced from the patient record in a calm, readable way." />
+      <MetricGrid items={[
+        { label: "Insight cards", value: String(demoAiInsights.length), note: "Positive, monitor, and action framing" },
+        { label: "Linked modules", value: "5", note: "Labs, symptoms, reminders, summary, alerts" },
+        { label: "Latest generation", value: "Today", note: "Would normally be user-triggered or scheduled" },
+        { label: "Patient scope", value: "Single owner", note: "Mirrors secure per-patient insight workflow" },
+      ]} />
+      <DemoSection title="Generated insight cards">
+        <StatCards items={demoAiInsights.map((item) => ({ title: item.title, body: item.summary, status: item.severity }))} />
+      </DemoSection>
+      <DemoSection title="How the real flow behaves">
+        <BulletList items={[
+          "Users can generate or refresh insight snapshots on demand.",
+          "Shared patient views can expose relevant insights to approved caregivers or clinicians.",
+          "Insights often point directly to reminders, alerts, review queue items, or summary exports.",
+        ]} />
       </DemoSection>
     </div>
   );

--- a/app/demo/alerts/page.tsx
+++ b/app/demo/alerts/page.tsx
@@ -2,6 +2,7 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoAlerts } from "@/lib/demo-data";
 
 export default function DemoAlertsPage() {
+  const eventHeaders = ["Title", "Severity", "Status", "Category", "Source", "Created"];
   const eventRows = demoAlerts.events.map((item) => [
     item.title,
     item.severity,
@@ -10,17 +11,17 @@ export default function DemoAlertsPage() {
     item.source,
     item.createdAt,
   ]);
+  const ruleHeaders = ["Rule", "Category", "Severity", "Status"];
   const ruleRows = demoAlerts.rules.map((item) => [item.name, item.category, item.severity, item.status]);
-
   return (
     <div className="space-y-6">
       <DemoHeader title="Alert Center" description="Threshold rules, event statuses, categories, and review context." />
       <div className="grid gap-6 xl:grid-cols-2">
         <DemoSection title="Alert events">
-          <SimpleTable headers={["Title", "Severity", "Status", "Category", "Source", "Created"]} rows={eventRows} />
+          <SimpleTable headers={eventHeaders} rows={eventRows} />
         </DemoSection>
         <DemoSection title="Alert rules">
-          <SimpleTable headers={["Rule", "Category", "Severity", "Status"]} rows={ruleRows} />
+          <SimpleTable headers={ruleHeaders} rows={ruleRows} />
         </DemoSection>
       </div>
     </div>

--- a/app/demo/appointments/page.tsx
+++ b/app/demo/appointments/page.tsx
@@ -2,13 +2,13 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoAppointments } from "@/lib/demo-data";
 
 export default function DemoAppointmentsPage() {
+  const headers = ["Visit", "When", "Location", "Status", "Doctor", "Notes"];
   const rows = demoAppointments.map((item) => [item.title, item.when, item.location, item.status, item.doctor, item.note]);
-
   return (
     <div className="space-y-6">
       <DemoHeader title="Appointments" description="Upcoming and completed visits with clinic context, status, and follow-up notes." />
       <DemoSection title="Appointment timeline">
-        <SimpleTable headers={["Visit", "When", "Location", "Status", "Doctor", "Notes"]} rows={rows} />
+        <SimpleTable headers={headers} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/care-team/page.tsx
+++ b/app/demo/care-team/page.tsx
@@ -2,18 +2,19 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoCareTeam } from "@/lib/demo-data";
 
 export default function DemoCareTeamPage() {
+  const memberHeaders = ["Name", "Role", "Access", "Status"];
   const memberRows = demoCareTeam.members.map((item) => [item.name, item.role, item.access, item.status]);
+  const inviteHeaders = ["Recipient", "Role", "Sent", "Delivery", "Status"];
   const inviteRows = demoCareTeam.invites.map((item) => [item.recipient, item.role, item.sentAt, item.delivery, item.status]);
-
   return (
     <div className="space-y-6">
       <DemoHeader title="Care Team" description="Shared access, pending invites, and role-based collaboration across patient care." />
       <div className="grid gap-6 xl:grid-cols-2">
         <DemoSection title="Active members">
-          <SimpleTable headers={["Name", "Role", "Access", "Status"]} rows={memberRows} />
+          <SimpleTable headers={memberHeaders} rows={memberRows} />
         </DemoSection>
         <DemoSection title="Pending invites">
-          <SimpleTable headers={["Recipient", "Role", "Sent", "Delivery", "Status"]} rows={inviteRows} />
+          <SimpleTable headers={inviteHeaders} rows={inviteRows} />
         </DemoSection>
       </div>
     </div>

--- a/app/demo/dashboard/page.tsx
+++ b/app/demo/dashboard/page.tsx
@@ -4,7 +4,7 @@ import { demoDashboardStats, demoTimeline, demoReminders, demoSummary, demoAlert
 export default function DemoDashboardPage() {
   return (
     <div className="space-y-6">
-      <DemoHeader eyebrow="Patient command center" title="Dashboard" description="A richer public mirror of VitaVault’s patient dashboard, showing health status, reminders, alerts, and the running care story for Elena Cruz." />
+      <DemoHeader eyebrow="Patient command center" title="Dashboard" description="Get a quick picture of the patient record, with reminders, alerts, recent activity, and the main care priorities in one place." />
       <MetricGrid items={demoDashboardStats} />
       <StatCards items={[
         { title: "Clinical snapshot", body: demoSummary.snapshot, status: "Healthy" },

--- a/app/demo/device-connection/page.tsx
+++ b/app/demo/device-connection/page.tsx
@@ -2,13 +2,13 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoDevices } from "@/lib/demo-data";
 
 export default function DemoDeviceConnectionPage() {
+  const headers = ["Provider", "Status", "Last sync", "Readings", "Notes"];
   const rows = demoDevices.map((item) => [item.provider, item.status, item.lastSync, item.readings, item.note ?? "—"]);
-
   return (
     <div className="space-y-6">
       <DemoHeader title="Device Connections" description="Connected apps and devices that feed VitaVault vitals and sync workflows." />
       <DemoSection title="Connection status">
-        <SimpleTable headers={["Provider", "Status", "Last sync", "Readings", "Notes"]} rows={rows} />
+        <SimpleTable headers={headers} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/doctors/page.tsx
+++ b/app/demo/doctors/page.tsx
@@ -4,7 +4,7 @@ import { demoDoctors } from "@/lib/demo-data";
 export default function DemoDoctorsPage() {
   return (
     <div className="space-y-6">
-      <DemoHeader eyebrow="Care network" title="Doctors" description="Shows the provider directory users manage in VitaVault, including specialties, clinic linkage, and communication context." />
+      <DemoHeader eyebrow="Care network" title="Doctors" description="Keep the care network in one place, with specialties, clinics, and contact details ready when follow-up is needed." />
       <MetricGrid items={[
         { label: "Tracked providers", value: String(demoDoctors.length), note: "Primary and specialty care" },
         { label: "Specialties", value: "3", note: "Endocrinology, internal medicine, ophthalmology" },

--- a/app/demo/documents/page.tsx
+++ b/app/demo/documents/page.tsx
@@ -2,13 +2,13 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoDocuments } from "@/lib/demo-data";
 
 export default function DemoDocumentsPage() {
+  const headers = ["Document", "Type", "Linked to", "Access", "Size"];
   const rows = demoDocuments.map((item) => [item.name, item.type, item.linkedTo, item.access, item.size]);
-
   return (
     <div className="space-y-6">
       <DemoHeader title="Documents" description="Protected document delivery, record linking, and clinically useful file organization." />
       <DemoSection title="Document library">
-        <SimpleTable headers={["Document", "Type", "Linked to", "Access", "Size"]} rows={rows} />
+        <SimpleTable headers={headers} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/exports/page.tsx
+++ b/app/demo/exports/page.tsx
@@ -2,13 +2,13 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoExports } from "@/lib/demo-data";
 
 export default function DemoExportsPage() {
+  const headers = ["Export", "Format", "Status", "Notes"];
   const rows = demoExports.map((item) => [item.name, item.format, item.status, item.note]);
-
   return (
     <div className="space-y-6">
       <DemoHeader title="Exports" description="Business-friendly export formats for summaries, records, and operational review." />
       <DemoSection title="Available exports">
-        <SimpleTable headers={["Export", "Format", "Status", "Notes"]} rows={rows} />
+        <SimpleTable headers={headers} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/health-profile/page.tsx
+++ b/app/demo/health-profile/page.tsx
@@ -4,14 +4,14 @@ import { demoPatient } from "@/lib/demo-data";
 export default function DemoHealthProfilePage() {
   return (
     <div className="space-y-6">
-      <DemoHeader eyebrow="Patient identity and baseline" title="Health Profile" description="This mirrors VitaVault’s health profile page with patient basics, contact context, risk factors, and baseline measurements using safe hardcoded demo data." />
+      <DemoHeader eyebrow="Patient identity and baseline" title="Health Profile" description="See the patient basics, emergency details, baseline clinical context, and notes that set up the rest of the record." />
       <MetricGrid items={[
         { label: "Age", value: String(demoPatient.age), note: demoPatient.sex },
         { label: "Blood type", value: demoPatient.bloodType, note: "Recorded and verified" },
         { label: "BMI", value: String(demoPatient.bmi), note: `${demoPatient.heightCm} cm · ${demoPatient.weightKg} kg` },
         { label: "Last updated", value: demoPatient.lastUpdated, note: "Profile review complete" },
       ]} />
-      <div className="grid gap-6 xl:grid-cols-2">
+      <div className="grid gap-6 2xl:grid-cols-[1.1fr_0.9fr]">
         <DemoSection title="Profile details">
           <KeyValueList items={[
             { label: "Full name", value: demoPatient.name },
@@ -26,7 +26,7 @@ export default function DemoHealthProfilePage() {
           <StatCards items={[
             { title: "Allergies", body: demoPatient.allergies.join(", "), status: "Watch" },
             { title: "Chronic conditions", body: demoPatient.chronicConditions.join(", "), status: "Monitor" },
-            { title: "Risk framing", body: "Current records show stable blood pressure and improving diabetes control, with neuropathy monitoring still needed.", status: "Info" },
+            { title: "Current focus", body: "Blood pressure is stable, diabetes control is improving, and recurring tingling is still being watched before the next specialist visit.", status: "Info" },
           ]} />
         </DemoSection>
       </div>

--- a/app/demo/jobs/page.tsx
+++ b/app/demo/jobs/page.tsx
@@ -2,13 +2,13 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoJobs } from "@/lib/demo-data";
 
 export default function DemoJobsPage() {
+  const headers = ["Job", "Queue", "Status", "When"];
   const rows = demoJobs.map((item) => [item.job, item.queue, item.status, item.at]);
-
   return (
     <div className="space-y-6">
       <DemoHeader title="Jobs" description="Background processing visibility for alert scans, reminders, and sync workflows." />
       <DemoSection title="Recent job runs">
-        <SimpleTable headers={["Job", "Queue", "Status", "When"]} rows={rows} />
+        <SimpleTable headers={headers} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/labs/page.tsx
+++ b/app/demo/labs/page.tsx
@@ -2,13 +2,13 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoLabs } from "@/lib/demo-data";
 
 export default function DemoLabsPage() {
+  const headers = ["Test", "Value", "Trend", "Status", "Collected", "Lab"];
   const rows = demoLabs.map((item) => [item.test, item.value, item.trend, item.status, item.collectedAt, item.lab]);
-
   return (
     <div className="space-y-6">
       <DemoHeader title="Labs" description="Lab trends, status indicators, and uploaded result context." />
       <DemoSection title="Latest lab set">
-        <SimpleTable headers={["Test", "Value", "Trend", "Status", "Collected", "Lab"]} rows={rows} />
+        <SimpleTable headers={headers} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/medications/page.tsx
+++ b/app/demo/medications/page.tsx
@@ -2,6 +2,7 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoMedications } from "@/lib/demo-data";
 
 export default function DemoMedicationsPage() {
+  const headers = ["Medication", "Dosage", "Frequency", "Times", "Status", "Doctor", "Adherence", "Instructions"];
   const rows = demoMedications.map((item) => [
     item.name,
     item.dosage,
@@ -12,12 +13,11 @@ export default function DemoMedicationsPage() {
     item.adherence,
     item.instructions,
   ]);
-
   return (
     <div className="space-y-6">
       <DemoHeader title="Medications" description="Schedules, adherence signals, linked doctors, and patient-facing instructions." />
       <DemoSection title="Active medication plan">
-        <SimpleTable headers={["Medication", "Dosage", "Frequency", "Times", "Status", "Doctor", "Adherence", "Instructions"]} rows={rows} />
+        <SimpleTable headers={headers} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/ops/page.tsx
+++ b/app/demo/ops/page.tsx
@@ -2,14 +2,14 @@ import { DemoHeader, DemoSection, MetricGrid, SimpleTable } from "@/components/d
 import { demoOps } from "@/lib/demo-data";
 
 export default function DemoOpsPage() {
-  const rows = demoOps.readiness.map((item) => [item.label, item.status]);
-
+  const readinessHeaders = ["Check", "Status"];
+  const readinessRows = demoOps.readiness.map((item) => [item.label, item.status]);
   return (
     <div className="space-y-6">
       <DemoHeader title="Operations" description="Readiness checks and high-level operational monitoring for delivery and sync workflows." />
       <MetricGrid items={demoOps.metrics} />
       <DemoSection title="Environment readiness">
-        <SimpleTable headers={["Check", "Status"]} rows={rows} />
+        <SimpleTable headers={readinessHeaders} rows={readinessRows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -5,7 +5,7 @@ import { demoNav, demoDashboardStats, demoSummary, demoOps } from "@/lib/demo-da
 export default function DemoOverviewPage() {
   return (
     <div className="space-y-6">
-      <DemoHeader eyebrow="No login required" title="Explore VitaVault Demo" description="This public demo is a deeper mirror of VitaVault’s real authenticated product: patient records, reminders, alerts, exports, security, operations, and admin oversight, all shown with safe sample data." actions={<><Link href="/demo/dashboard" className="rounded-2xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground">Open dashboard</Link><Link href="/demo/admin" className="rounded-2xl border border-border/60 px-4 py-2 text-sm font-medium hover:bg-muted/60">See admin view</Link></>} />
+      <DemoHeader eyebrow="No login required" title="Explore VitaVault Demo" description="Walk through the main VitaVault modules with sample patient data. Everything here is read-only, but the layouts and workflows match the real product closely." actions={<><Link href="/demo/dashboard" className="rounded-2xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground">Start tour</Link><Link href="/demo/admin" className="rounded-2xl border border-border/60 px-4 py-2 text-sm font-medium hover:bg-muted/60">Open admin preview</Link></>} />
       <MetricGrid items={demoDashboardStats} />
       <DemoSection title="What this demo covers" description="The goal here is parity with the real VitaVault product surface, not just a landing-page teaser.">
         <SimpleTable headers={["Area", "What you can inspect in demo"]} rows={demoNav.slice(1).map((item) => [item.label, item.description ?? `Read-only mirror of the ${item.label.toLowerCase()} module`])} />

--- a/app/demo/reminders/page.tsx
+++ b/app/demo/reminders/page.tsx
@@ -2,13 +2,13 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoReminders } from "@/lib/demo-data";
 
 export default function DemoRemindersPage() {
+  const headers = ["Reminder", "When", "Channel", "State"];
   const rows = demoReminders.map((item) => [item.title, item.when, item.channel, item.state]);
-
   return (
     <div className="space-y-6">
       <DemoHeader title="Reminders" description="Scheduled reminders, delivery channels, and dispatch state across meds and follow-ups." />
       <DemoSection title="Reminder queue">
-        <SimpleTable headers={["Reminder", "When", "Channel", "State"]} rows={rows} />
+        <SimpleTable headers={headers} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/review-queue/page.tsx
+++ b/app/demo/review-queue/page.tsx
@@ -2,13 +2,13 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoReviewQueue } from "@/lib/demo-data";
 
 export default function DemoReviewQueuePage() {
+  const headers = ["Item", "Source", "Tone", "Owner", "Status"];
   const rows = demoReviewQueue.map((item) => [item.item, item.source, item.tone, item.owner, item.status]);
-
   return (
     <div className="space-y-6">
       <DemoHeader title="Review Queue" description="Items surfaced for clinical follow-up, caregiver action, and admin handoff." />
       <DemoSection title="Review workload">
-        <SimpleTable headers={["Item", "Source", "Tone", "Owner", "Status"]} rows={rows} />
+        <SimpleTable headers={headers} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/security/page.tsx
+++ b/app/demo/security/page.tsx
@@ -2,8 +2,8 @@ import { DemoHeader, DemoSection, KeyValueList, SimpleTable } from "@/components
 import { demoSecurity } from "@/lib/demo-data";
 
 export default function DemoSecurityPage() {
-  const rows = demoSecurity.sessions.map((item) => [item.device, item.createdAt, item.lastUsed, item.expires, item.state]);
-
+  const sessionHeaders = ["Device", "Created", "Last used", "Expires", "State"];
+  const sessionRows = demoSecurity.sessions.map((item) => [item.device, item.createdAt, item.lastUsed, item.expires, item.state]);
   return (
     <div className="space-y-6">
       <DemoHeader title="Security Center" description="Account posture, mobile session visibility, and controlled access surfaces." />
@@ -11,7 +11,7 @@ export default function DemoSecurityPage() {
         <KeyValueList items={demoSecurity.posture} />
       </DemoSection>
       <DemoSection title="Session inventory">
-        <SimpleTable headers={["Device", "Created", "Last used", "Expires", "State"]} rows={rows} />
+        <SimpleTable headers={sessionHeaders} rows={sessionRows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/summary/page.tsx
+++ b/app/demo/summary/page.tsx
@@ -4,7 +4,7 @@ import { demoSummary, demoPatient, demoCareTeam } from "@/lib/demo-data";
 export default function DemoSummaryPage() {
   return (
     <div className="space-y-6">
-      <DemoHeader eyebrow="Patient handoff" title="Summary" description="A more app-like version of VitaVault’s patient summary and export handoff page, combining high-level narrative, care-team context, and snapshot highlights." />
+      <DemoHeader eyebrow="Patient handoff" title="Summary" description="Read the same kind of high-level handoff view you would use before a consult, family update, or care transition." />
       <MetricGrid items={[
         { label: "Patient", value: demoPatient.name, note: `${demoPatient.age} · ${demoPatient.sex}` },
         { label: "Care members", value: String(demoCareTeam.members.length), note: "Included in handoff context" },

--- a/app/demo/symptoms/page.tsx
+++ b/app/demo/symptoms/page.tsx
@@ -2,13 +2,13 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoSymptoms } from "@/lib/demo-data";
 
 export default function DemoSymptomsPage() {
+  const headers = ["Symptom", "Severity", "Status", "Logged", "Notes"];
   const rows = demoSymptoms.map((item) => [item.name, item.severity, item.status, item.loggedAt, item.note]);
-
   return (
     <div className="space-y-6">
       <DemoHeader title="Symptoms" description="Symptom tracking feeds alerts, review queues, and care-team follow-up." />
       <DemoSection title="Logged symptoms">
-        <SimpleTable headers={["Symptom", "Severity", "Status", "Logged", "Notes"]} rows={rows} />
+        <SimpleTable headers={headers} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/timeline/page.tsx
+++ b/app/demo/timeline/page.tsx
@@ -4,7 +4,7 @@ import { demoTimeline } from "@/lib/demo-data";
 export default function DemoTimelinePage() {
   return (
     <div className="space-y-6">
-      <DemoHeader eyebrow="Unified history" title="Timeline" description="A public mirror of VitaVault’s cross-module patient timeline, combining reminders, labs, appointments, and alert events into one longitudinal view." />
+      <DemoHeader eyebrow="Unified history" title="Timeline" description="Follow the patient story in order, with reminders, labs, appointments, and alerts all shown in one running history." />
       <MetricGrid items={[
         { label: "Events shown", value: String(demoTimeline.length), note: "Cross-module activity" },
         { label: "Sources", value: "4", note: "Reminder, alert, lab, appointment" },

--- a/app/demo/vaccinations/page.tsx
+++ b/app/demo/vaccinations/page.tsx
@@ -2,13 +2,13 @@ import { DemoHeader, DemoSection, SimpleTable } from "@/components/demo-primitiv
 import { demoVaccinations } from "@/lib/demo-data";
 
 export default function DemoVaccinationsPage() {
+  const headers = ["Vaccine", "Date", "Provider", "Status"];
   const rows = demoVaccinations.map((item) => [item.name, item.date, item.provider, item.status]);
-
   return (
     <div className="space-y-6">
       <DemoHeader title="Vaccinations" description="Immunization history and preventive gaps in one place." />
       <DemoSection title="Vaccination records">
-        <SimpleTable headers={["Vaccine", "Date", "Provider", "Status"]} rows={rows} />
+        <SimpleTable headers={headers} rows={rows} />
       </DemoSection>
     </div>
   );

--- a/app/demo/vitals/page.tsx
+++ b/app/demo/vitals/page.tsx
@@ -4,7 +4,7 @@ import { demoVitals } from "@/lib/demo-data";
 export default function DemoVitalsPage() {
   return (
     <div className="space-y-6">
-      <DemoHeader eyebrow="Vital trends" title="Vitals" description="Shows the same style of rolling patient monitoring the real app uses for blood pressure, glucose, weight, and related trend interpretation." />
+      <DemoHeader eyebrow="Vital trends" title="Vitals" description="Review blood pressure, glucose, weight, and other tracked readings with the kind of trend context the app uses every day." />
       <MetricGrid items={demoVitals.map((item) => ({ label: item.metric, value: item.latest, note: item.range }))} />
       <div className="grid gap-6 xl:grid-cols-[1fr_0.9fr]">
         <DemoSection title="Trend summary table">

--- a/components/demo-primitives.tsx
+++ b/components/demo-primitives.tsx
@@ -20,12 +20,12 @@ function inferTone(value: string) {
 
 export function DemoHeader({ title, description, eyebrow, actions }: { title: string; description: string; eyebrow?: string; actions?: ReactNode }) {
   return (
-    <div className="rounded-[28px] border border-border/60 bg-background/75 p-6 shadow-sm">
+    <div className="rounded-[28px] border border-border/60 bg-background/80 p-6 shadow-sm">
       {eyebrow ? <p className="text-xs font-semibold uppercase tracking-[0.24em] text-primary">{eyebrow}</p> : null}
       <div className="mt-2 flex flex-wrap items-start justify-between gap-4">
-        <div>
+        <div className="max-w-3xl">
           <h1 className="text-3xl font-semibold tracking-tight">{title}</h1>
-          <p className="mt-2 max-w-3xl text-sm text-muted-foreground">{description}</p>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">{description}</p>
         </div>
         <div className="flex flex-wrap gap-2">{actions ?? (
           <>
@@ -40,10 +40,10 @@ export function DemoHeader({ title, description, eyebrow, actions }: { title: st
 
 export function DemoSection({ title, description, children }: { title: string; description?: string; children: ReactNode }) {
   return (
-    <section className="rounded-[28px] border border-border/60 bg-background/75 p-6 shadow-sm">
+    <section className="rounded-[28px] border border-border/60 bg-background/80 p-6 shadow-sm">
       <div className="mb-4">
         <h2 className="text-xl font-semibold tracking-tight">{title}</h2>
-        {description ? <p className="mt-1 text-sm text-muted-foreground">{description}</p> : null}
+        {description ? <p className="mt-1 text-sm leading-6 text-muted-foreground">{description}</p> : null}
       </div>
       {children}
     </section>
@@ -52,12 +52,12 @@ export function DemoSection({ title, description, children }: { title: string; d
 
 export function MetricGrid({ items }: { items: { label: string; value: string; note?: string }[] }) {
   return (
-    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+    <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(180px,1fr))]">
       {items.map((item) => (
-        <div key={item.label} className="rounded-[28px] border border-border/60 bg-background/75 p-5 shadow-sm">
+        <div key={item.label} className="rounded-[24px] border border-border/60 bg-background/80 p-5 shadow-sm">
           <p className="text-sm text-muted-foreground">{item.label}</p>
           <p className="mt-2 text-3xl font-semibold tracking-tight">{item.value}</p>
-          {item.note ? <p className="mt-2 text-sm text-muted-foreground">{item.note}</p> : null}
+          {item.note ? <p className="mt-2 text-sm leading-6 text-muted-foreground">{item.note}</p> : null}
         </div>
       ))}
     </div>
@@ -66,11 +66,11 @@ export function MetricGrid({ items }: { items: { label: string; value: string; n
 
 export function KeyValueList({ items }: { items: { label: string; value: string }[] }) {
   return (
-    <dl className="grid gap-3 sm:grid-cols-2">
+    <dl className="grid gap-3 [grid-template-columns:repeat(auto-fit,minmax(220px,1fr))]">
       {items.map((item) => (
         <div key={item.label} className="rounded-2xl border border-border/60 bg-background/60 p-4">
           <dt className="text-sm text-muted-foreground">{item.label}</dt>
-          <dd className="mt-1 font-medium">{item.value}</dd>
+          <dd className="mt-1 text-sm font-medium leading-6 text-foreground">{item.value}</dd>
         </div>
       ))}
     </dl>
@@ -115,7 +115,7 @@ export function BulletList({ items }: { items: string[] }) {
   return (
     <ul className="space-y-3 text-sm text-muted-foreground">
       {items.map((item) => (
-        <li key={item} className="rounded-2xl border border-border/50 bg-background/60 px-4 py-3 text-foreground">{item}</li>
+        <li key={item} className="rounded-2xl border border-border/50 bg-background/60 px-4 py-3 leading-6 text-foreground">{item}</li>
       ))}
     </ul>
   );
@@ -123,14 +123,14 @@ export function BulletList({ items }: { items: string[] }) {
 
 export function StatCards({ items }: { items: { title: string; body: string; status?: string }[] }) {
   return (
-    <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
+    <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(220px,1fr))]">
       {items.map((item) => (
-        <div key={item.title} className="rounded-[28px] border border-border/60 bg-background/75 p-5 shadow-sm">
+        <div key={item.title} className="rounded-[24px] border border-border/60 bg-background/80 p-5 shadow-sm">
           <div className="flex items-center justify-between gap-3">
             <h3 className="font-semibold tracking-tight">{item.title}</h3>
             {item.status ? <ToneBadge value={item.status} /> : null}
           </div>
-          <p className="mt-3 text-sm text-muted-foreground">{item.body}</p>
+          <p className="mt-3 text-sm leading-6 text-muted-foreground">{item.body}</p>
         </div>
       ))}
     </div>

--- a/components/demo-shell.tsx
+++ b/components/demo-shell.tsx
@@ -19,11 +19,11 @@ export default function DemoShell({ children }: { children: React.ReactNode }) {
             </div>
             <div>
               <p className="text-lg font-semibold tracking-tight">VitaVault Demo</p>
-              <p className="text-sm text-muted-foreground">Full public walkthrough with realistic sample data</p>
+              <p className="text-sm text-muted-foreground">Explore the product with sample records and read-only workflows.</p>
             </div>
           </div>
           <div className="flex items-center gap-3">
-            <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-3 py-1.5 text-xs font-medium"><Sparkles className="h-3.5 w-3.5" /> Read-only demo mode</span>
+            <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-3 py-1.5 text-xs font-medium"><Sparkles className="h-3.5 w-3.5" /> Demo data only</span>
             <Link href="/login" className="rounded-2xl border border-border/60 px-4 py-2 text-sm font-medium hover:bg-muted/60">Open real app</Link>
           </div>
         </div>
@@ -31,7 +31,7 @@ export default function DemoShell({ children }: { children: React.ReactNode }) {
           <aside className="rounded-[28px] border border-border/60 bg-background/75 p-3 shadow-sm backdrop-blur">
             <div className="max-h-[calc(100vh-120px)] overflow-y-auto pr-1">
               <div className="mb-3 rounded-2xl border border-sky-200/50 bg-sky-50/70 p-3 text-sm text-sky-800 dark:border-sky-900/40 dark:bg-sky-950/30 dark:text-sky-200">
-                This demo mirrors VitaVault features without login, database writes, or private data.
+                Browse the full VitaVault flow with sample patient data. Nothing here writes to the database.
               </div>
               <nav className="space-y-1">
                 {demoNav.map((item) => {


### PR DESCRIPTION
## Summary
- cleaned up the remaining demo page lint issues
- moved table headers and rows into constants for cleaner rendering
- removed the affected inline array patterns
- kept the demo feature and test suite intact

## Why this matters
The app was already stable, but the demo layer still had leftover lint noise. This finishes the demo cleanup so the repo stays clean while preserving the public showcase.

## Testing
- [x] npm run lint
- [x] npm run test:run
- [x] open /demo
- [ ] verify the affected demo pages still render correctly