### PR TITLE
Fix 20: finish demo lint cleanup and polish

### DIFF
--- a/app/demo/admin/page.tsx
+++ b/app/demo/admin/page.tsx
@@ -3,25 +3,32 @@ import { demoAdmin } from "@/lib/demo-data";
 
 export default function DemoAdminPage() {
   const rosterHeaders = ["User", "Role", "Status", "Sessions", "Alerts", "Documents"];
-  const rosterRows = demoAdmin.roster.map((item) => [
-    item.name,
-    item.role,
-    item.status,
-    String(item.sessions),
-    String(item.alerts),
-    String(item.documents),
-  ]);
+  const rosterRows = demoAdmin.roster.map((item) => ({
+    key: item.name,
+    cells: [
+      item.name,
+      item.role,
+      item.status,
+      String(item.sessions),
+      String(item.alerts),
+      String(item.documents),
+    ],
+  }));
   const auditHeaders = ["Source", "Message", "When"];
-  const auditRows = demoAdmin.audit.map((item) => [item.source, item.message, item.at]);
+  const auditRows = demoAdmin.audit.map((item, index) => ({ key: `${item.source}-${index}`, cells: [item.source, item.message, item.at] }));
+
   return (
     <div className="space-y-6">
-      <DemoHeader title="Admin Workspace" description="User oversight, moderation actions, audit visibility, and platform-level review." />
+      <DemoHeader
+        title="Admin Workspace"
+        description="See how admins can review accounts, watch platform activity, and keep an eye on operational health from one place."
+      />
       <MetricGrid items={demoAdmin.metrics} />
       <div className="grid gap-6 xl:grid-cols-[1.15fr_0.85fr]">
-        <DemoSection title="User roster">
+        <DemoSection title="User roster" description="A quick read on account status, access footprint, and review signals.">
           <SimpleTable headers={rosterHeaders} rows={rosterRows} />
         </DemoSection>
-        <DemoSection title="Audit feed">
+        <DemoSection title="Recent admin activity" description="A small sample of audit events that help explain what changed and when.">
           <SimpleTable headers={auditHeaders} rows={auditRows} />
         </DemoSection>
       </div>

--- a/app/demo/ai-insights/page.tsx
+++ b/app/demo/ai-insights/page.tsx
@@ -1,4 +1,4 @@
-import { BulletList, DemoHeader, DemoSection, MetricGrid, StatCards, ToneBadge } from "@/components/demo-primitives";
+import { BulletList, DemoHeader, DemoSection, MetricGrid, StatCards } from "@/components/demo-primitives";
 import { demoAiInsights } from "@/lib/demo-data";
 
 export default function DemoAiInsightsPage() {

--- a/app/demo/alerts/page.tsx
+++ b/app/demo/alerts/page.tsx
@@ -3,24 +3,27 @@ import { demoAlerts } from "@/lib/demo-data";
 
 export default function DemoAlertsPage() {
   const eventHeaders = ["Title", "Severity", "Status", "Category", "Source", "Created"];
-  const eventRows = demoAlerts.events.map((item) => [
-    item.title,
-    item.severity,
-    item.status,
-    item.category,
-    item.source,
-    item.createdAt,
-  ]);
+  const eventRows = demoAlerts.events.map((item, index) => ({
+    key: `${item.title}-${index}`,
+    cells: [item.title, item.severity, item.status, item.category, item.source, item.createdAt],
+  }));
   const ruleHeaders = ["Rule", "Category", "Severity", "Status"];
-  const ruleRows = demoAlerts.rules.map((item) => [item.name, item.category, item.severity, item.status]);
+  const ruleRows = demoAlerts.rules.map((item, index) => ({
+    key: `${item.name}-${index}`,
+    cells: [item.name, item.category, item.severity, item.status],
+  }));
+
   return (
     <div className="space-y-6">
-      <DemoHeader title="Alert Center" description="Threshold rules, event statuses, categories, and review context." />
+      <DemoHeader
+        title="Alert Center"
+        description="Review active events, see what triggered them, and understand how rules support follow-up across the record."
+      />
       <div className="grid gap-6 xl:grid-cols-2">
-        <DemoSection title="Alert events">
+        <DemoSection title="Alert events" description="Events surfaced from symptoms, labs, reminders, and monitoring logic.">
           <SimpleTable headers={eventHeaders} rows={eventRows} />
         </DemoSection>
-        <DemoSection title="Alert rules">
+        <DemoSection title="Rule library" description="Sample threshold rules that shape the alerting flow.">
           <SimpleTable headers={ruleHeaders} rows={ruleRows} />
         </DemoSection>
       </div>

--- a/app/demo/appointments/page.tsx
+++ b/app/demo/appointments/page.tsx
@@ -3,11 +3,18 @@ import { demoAppointments } from "@/lib/demo-data";
 
 export default function DemoAppointmentsPage() {
   const headers = ["Visit", "When", "Location", "Status", "Doctor", "Notes"];
-  const rows = demoAppointments.map((item) => [item.title, item.when, item.location, item.status, item.doctor, item.note]);
+  const rows = demoAppointments.map((item, index) => ({
+    key: `${item.title}-${index}`,
+    cells: [item.title, item.when, item.location, item.status, item.doctor, item.note],
+  }));
+
   return (
     <div className="space-y-6">
-      <DemoHeader title="Appointments" description="Upcoming and completed visits with clinic context, status, and follow-up notes." />
-      <DemoSection title="Appointment timeline">
+      <DemoHeader
+        title="Appointments"
+        description="A simple view of upcoming visits, completed check-ins, and the notes that help keep care organized."
+      />
+      <DemoSection title="Appointment timeline" description="Each entry shows the clinic, provider, and follow-up context tied to the visit.">
         <SimpleTable headers={headers} rows={rows} />
       </DemoSection>
     </div>

--- a/app/demo/care-team/page.tsx
+++ b/app/demo/care-team/page.tsx
@@ -3,17 +3,27 @@ import { demoCareTeam } from "@/lib/demo-data";
 
 export default function DemoCareTeamPage() {
   const memberHeaders = ["Name", "Role", "Access", "Status"];
-  const memberRows = demoCareTeam.members.map((item) => [item.name, item.role, item.access, item.status]);
+  const memberRows = demoCareTeam.members.map((item, index) => ({
+    key: `${item.name}-${index}`,
+    cells: [item.name, item.role, item.access, item.status],
+  }));
   const inviteHeaders = ["Recipient", "Role", "Sent", "Delivery", "Status"];
-  const inviteRows = demoCareTeam.invites.map((item) => [item.recipient, item.role, item.sentAt, item.delivery, item.status]);
+  const inviteRows = demoCareTeam.invites.map((item, index) => ({
+    key: `${item.recipient}-${index}`,
+    cells: [item.recipient, item.role, item.sentAt, item.delivery, item.status],
+  }));
+
   return (
     <div className="space-y-6">
-      <DemoHeader title="Care Team" description="Shared access, pending invites, and role-based collaboration across patient care." />
+      <DemoHeader
+        title="Care Team"
+        description="Show how family members and clinicians can be invited into the record with the right level of access."
+      />
       <div className="grid gap-6 xl:grid-cols-2">
-        <DemoSection title="Active members">
+        <DemoSection title="Active members" description="People who currently have access to the patient workspace.">
           <SimpleTable headers={memberHeaders} rows={memberRows} />
         </DemoSection>
-        <DemoSection title="Pending invites">
+        <DemoSection title="Pending invites" description="Invite status, delivery state, and role selection in one glance.">
           <SimpleTable headers={inviteHeaders} rows={inviteRows} />
         </DemoSection>
       </div>

--- a/app/demo/device-connection/page.tsx
+++ b/app/demo/device-connection/page.tsx
@@ -3,11 +3,18 @@ import { demoDevices } from "@/lib/demo-data";
 
 export default function DemoDeviceConnectionPage() {
   const headers = ["Provider", "Status", "Last sync", "Readings", "Notes"];
-  const rows = demoDevices.map((item) => [item.provider, item.status, item.lastSync, item.readings, item.note ?? "—"]);
+  const rows = demoDevices.map((item, index) => ({
+    key: `${item.provider}-${index}`,
+    cells: [item.provider, item.status, item.lastSync, item.readings, item.note ?? "—"],
+  }));
+
   return (
     <div className="space-y-6">
-      <DemoHeader title="Device Connections" description="Connected apps and devices that feed VitaVault vitals and sync workflows." />
-      <DemoSection title="Connection status">
+      <DemoHeader
+        title="Device Connections"
+        description="Preview how connected apps and wearables feed data into VitaVault without making the page feel overly technical."
+      />
+      <DemoSection title="Connection status" description="A quick view of sync health, reading coverage, and where attention might be needed.">
         <SimpleTable headers={headers} rows={rows} />
       </DemoSection>
     </div>

--- a/app/demo/documents/page.tsx
+++ b/app/demo/documents/page.tsx
@@ -3,11 +3,18 @@ import { demoDocuments } from "@/lib/demo-data";
 
 export default function DemoDocumentsPage() {
   const headers = ["Document", "Type", "Linked to", "Access", "Size"];
-  const rows = demoDocuments.map((item) => [item.name, item.type, item.linkedTo, item.access, item.size]);
+  const rows = demoDocuments.map((item, index) => ({
+    key: `${item.name}-${index}`,
+    cells: [item.name, item.type, item.linkedTo, item.access, item.size],
+  }));
+
   return (
     <div className="space-y-6">
-      <DemoHeader title="Documents" description="Protected document delivery, record linking, and clinically useful file organization." />
-      <DemoSection title="Document library">
+      <DemoHeader
+        title="Documents"
+        description="Show how reports, scans, and uploaded files can stay organized while still feeling easy to browse."
+      />
+      <DemoSection title="Document library" description="Each file can be linked back to the part of the record where it matters most.">
         <SimpleTable headers={headers} rows={rows} />
       </DemoSection>
     </div>

--- a/app/demo/exports/page.tsx
+++ b/app/demo/exports/page.tsx
@@ -3,11 +3,18 @@ import { demoExports } from "@/lib/demo-data";
 
 export default function DemoExportsPage() {
   const headers = ["Export", "Format", "Status", "Notes"];
-  const rows = demoExports.map((item) => [item.name, item.format, item.status, item.note]);
+  const rows = demoExports.map((item, index) => ({
+    key: `${item.name}-${index}`,
+    cells: [item.name, item.format, item.status, item.note],
+  }));
+
   return (
     <div className="space-y-6">
-      <DemoHeader title="Exports" description="Business-friendly export formats for summaries, records, and operational review." />
-      <DemoSection title="Available exports">
+      <DemoHeader
+        title="Exports"
+        description="Preview the kinds of record and reporting exports that make VitaVault easier to share and review outside the app."
+      />
+      <DemoSection title="Available exports" description="A sample of patient-facing and admin-facing export flows.">
         <SimpleTable headers={headers} rows={rows} />
       </DemoSection>
     </div>

--- a/app/demo/jobs/page.tsx
+++ b/app/demo/jobs/page.tsx
@@ -3,11 +3,18 @@ import { demoJobs } from "@/lib/demo-data";
 
 export default function DemoJobsPage() {
   const headers = ["Job", "Queue", "Status", "When"];
-  const rows = demoJobs.map((item) => [item.job, item.queue, item.status, item.at]);
+  const rows = demoJobs.map((item, index) => ({
+    key: `${item.job}-${index}`,
+    cells: [item.job, item.queue, item.status, item.at],
+  }));
+
   return (
     <div className="space-y-6">
-      <DemoHeader title="Jobs" description="Background processing visibility for alert scans, reminders, and sync workflows." />
-      <DemoSection title="Recent job runs">
+      <DemoHeader
+        title="Jobs"
+        description="A light operational view of background work like reminders, alert scans, and other scheduled processes."
+      />
+      <DemoSection title="Recent job runs" description="Shows the kind of queue visibility an admin or operator would expect.">
         <SimpleTable headers={headers} rows={rows} />
       </DemoSection>
     </div>

--- a/app/demo/labs/page.tsx
+++ b/app/demo/labs/page.tsx
@@ -3,11 +3,18 @@ import { demoLabs } from "@/lib/demo-data";
 
 export default function DemoLabsPage() {
   const headers = ["Test", "Value", "Trend", "Status", "Collected", "Lab"];
-  const rows = demoLabs.map((item) => [item.test, item.value, item.trend, item.status, item.collectedAt, item.lab]);
+  const rows = demoLabs.map((item, index) => ({
+    key: `${item.test}-${index}`,
+    cells: [item.test, item.value, item.trend, item.status, item.collectedAt, item.lab],
+  }));
+
   return (
     <div className="space-y-6">
-      <DemoHeader title="Labs" description="Lab trends, status indicators, and uploaded result context." />
-      <DemoSection title="Latest lab set">
+      <DemoHeader
+        title="Labs"
+        description="A more approachable lab view that still shows trends, status, and collection context clearly."
+      />
+      <DemoSection title="Latest lab set" description="Good for explaining how trends and exception handling might appear in the live app.">
         <SimpleTable headers={headers} rows={rows} />
       </DemoSection>
     </div>

--- a/app/demo/medications/page.tsx
+++ b/app/demo/medications/page.tsx
@@ -3,20 +3,27 @@ import { demoMedications } from "@/lib/demo-data";
 
 export default function DemoMedicationsPage() {
   const headers = ["Medication", "Dosage", "Frequency", "Times", "Status", "Doctor", "Adherence", "Instructions"];
-  const rows = demoMedications.map((item) => [
-    item.name,
-    item.dosage,
-    item.frequency,
-    item.times.join(", "),
-    item.status,
-    item.doctor,
-    item.adherence,
-    item.instructions,
-  ]);
+  const rows = demoMedications.map((item, index) => ({
+    key: `${item.name}-${index}`,
+    cells: [
+      item.name,
+      item.dosage,
+      item.frequency,
+      item.times.join(", "),
+      item.status,
+      item.doctor,
+      item.adherence,
+      item.instructions,
+    ],
+  }));
+
   return (
     <div className="space-y-6">
-      <DemoHeader title="Medications" description="Schedules, adherence signals, linked doctors, and patient-facing instructions." />
-      <DemoSection title="Active medication plan">
+      <DemoHeader
+        title="Medications"
+        description="Give visitors a clear look at schedules, adherence, and patient instructions without needing to sign in."
+      />
+      <DemoSection title="Active medication plan" description="This sample mirrors the structure of the real medication workspace in a read-only format.">
         <SimpleTable headers={headers} rows={rows} />
       </DemoSection>
     </div>

--- a/app/demo/ops/page.tsx
+++ b/app/demo/ops/page.tsx
@@ -3,12 +3,19 @@ import { demoOps } from "@/lib/demo-data";
 
 export default function DemoOpsPage() {
   const readinessHeaders = ["Check", "Status"];
-  const readinessRows = demoOps.readiness.map((item) => [item.label, item.status]);
+  const readinessRows = demoOps.readiness.map((item) => ({
+    key: item.label,
+    cells: [item.label, item.status],
+  }));
+
   return (
     <div className="space-y-6">
-      <DemoHeader title="Operations" description="Readiness checks and high-level operational monitoring for delivery and sync workflows." />
+      <DemoHeader
+        title="Operations"
+        description="A cleaner operations view that highlights readiness and workflow health without feeling like an internal debug screen."
+      />
       <MetricGrid items={demoOps.metrics} />
-      <DemoSection title="Environment readiness">
+      <DemoSection title="Environment readiness" description="Helpful for showing how the app surfaces checks and delivery dependencies to operators.">
         <SimpleTable headers={readinessHeaders} rows={readinessRows} />
       </DemoSection>
     </div>

--- a/app/demo/reminders/page.tsx
+++ b/app/demo/reminders/page.tsx
@@ -3,11 +3,18 @@ import { demoReminders } from "@/lib/demo-data";
 
 export default function DemoRemindersPage() {
   const headers = ["Reminder", "When", "Channel", "State"];
-  const rows = demoReminders.map((item) => [item.title, item.when, item.channel, item.state]);
+  const rows = demoReminders.map((item, index) => ({
+    key: `${item.title}-${index}`,
+    cells: [item.title, item.when, item.channel, item.state],
+  }));
+
   return (
     <div className="space-y-6">
-      <DemoHeader title="Reminders" description="Scheduled reminders, delivery channels, and dispatch state across meds and follow-ups." />
-      <DemoSection title="Reminder queue">
+      <DemoHeader
+        title="Reminders"
+        description="A read-only look at how reminder timing, delivery channels, and patient follow-up can be managed."
+      />
+      <DemoSection title="Reminder queue" description="Shows the rhythm of medication prompts and care follow-ups in one place.">
         <SimpleTable headers={headers} rows={rows} />
       </DemoSection>
     </div>

--- a/app/demo/review-queue/page.tsx
+++ b/app/demo/review-queue/page.tsx
@@ -3,11 +3,18 @@ import { demoReviewQueue } from "@/lib/demo-data";
 
 export default function DemoReviewQueuePage() {
   const headers = ["Item", "Source", "Tone", "Owner", "Status"];
-  const rows = demoReviewQueue.map((item) => [item.item, item.source, item.tone, item.owner, item.status]);
+  const rows = demoReviewQueue.map((item, index) => ({
+    key: `${item.item}-${index}`,
+    cells: [item.item, item.source, item.tone, item.owner, item.status],
+  }));
+
   return (
     <div className="space-y-6">
-      <DemoHeader title="Review Queue" description="Items surfaced for clinical follow-up, caregiver action, and admin handoff." />
-      <DemoSection title="Review workload">
+      <DemoHeader
+        title="Review Queue"
+        description="A straightforward view of the items that need attention, follow-up, or escalation across the record."
+      />
+      <DemoSection title="Review workload" description="Useful for explaining how the app brings alerts, reminders, and records together for action.">
         <SimpleTable headers={headers} rows={rows} />
       </DemoSection>
     </div>

--- a/app/demo/security/page.tsx
+++ b/app/demo/security/page.tsx
@@ -3,14 +3,21 @@ import { demoSecurity } from "@/lib/demo-data";
 
 export default function DemoSecurityPage() {
   const sessionHeaders = ["Device", "Created", "Last used", "Expires", "State"];
-  const sessionRows = demoSecurity.sessions.map((item) => [item.device, item.createdAt, item.lastUsed, item.expires, item.state]);
+  const sessionRows = demoSecurity.sessions.map((item, index) => ({
+    key: `${item.device}-${index}`,
+    cells: [item.device, item.createdAt, item.lastUsed, item.expires, item.state],
+  }));
+
   return (
     <div className="space-y-6">
-      <DemoHeader title="Security Center" description="Account posture, mobile session visibility, and controlled access surfaces." />
-      <DemoSection title="Security posture">
+      <DemoHeader
+        title="Security Center"
+        description="Show account posture, mobile session visibility, and recovery surfaces in a way that feels calm and trustworthy."
+      />
+      <DemoSection title="Security posture" description="A simple summary of the account controls that matter most.">
         <KeyValueList items={demoSecurity.posture} />
       </DemoSection>
-      <DemoSection title="Session inventory">
+      <DemoSection title="Session inventory" description="A sample list of mobile and device sessions that would normally be revocable by the account owner.">
         <SimpleTable headers={sessionHeaders} rows={sessionRows} />
       </DemoSection>
     </div>

--- a/app/demo/symptoms/page.tsx
+++ b/app/demo/symptoms/page.tsx
@@ -3,11 +3,18 @@ import { demoSymptoms } from "@/lib/demo-data";
 
 export default function DemoSymptomsPage() {
   const headers = ["Symptom", "Severity", "Status", "Logged", "Notes"];
-  const rows = demoSymptoms.map((item) => [item.name, item.severity, item.status, item.loggedAt, item.note]);
+  const rows = demoSymptoms.map((item, index) => ({
+    key: `${item.name}-${index}`,
+    cells: [item.name, item.severity, item.status, item.loggedAt, item.note],
+  }));
+
   return (
     <div className="space-y-6">
-      <DemoHeader title="Symptoms" description="Symptom tracking feeds alerts, review queues, and care-team follow-up." />
-      <DemoSection title="Logged symptoms">
+      <DemoHeader
+        title="Symptoms"
+        description="A simple symptom log that still makes it clear how entries can support alerts, review, and caregiver follow-up."
+      />
+      <DemoSection title="Logged symptoms" description="Each entry shows severity, status, and enough context to understand the next step.">
         <SimpleTable headers={headers} rows={rows} />
       </DemoSection>
     </div>

--- a/app/demo/vaccinations/page.tsx
+++ b/app/demo/vaccinations/page.tsx
@@ -3,11 +3,18 @@ import { demoVaccinations } from "@/lib/demo-data";
 
 export default function DemoVaccinationsPage() {
   const headers = ["Vaccine", "Date", "Provider", "Status"];
-  const rows = demoVaccinations.map((item) => [item.name, item.date, item.provider, item.status]);
+  const rows = demoVaccinations.map((item, index) => ({
+    key: `${item.name}-${index}`,
+    cells: [item.name, item.date, item.provider, item.status],
+  }));
+
   return (
     <div className="space-y-6">
-      <DemoHeader title="Vaccinations" description="Immunization history and preventive gaps in one place." />
-      <DemoSection title="Vaccination records">
+      <DemoHeader
+        title="Vaccinations"
+        description="A cleaner preventive-care view that helps the record feel useful even in a quick public walkthrough."
+      />
+      <DemoSection title="Vaccination records" description="Shows a sample immunization history and the kind of status visibility the product can provide.">
         <SimpleTable headers={headers} rows={rows} />
       </DemoSection>
     </div>

--- a/components/demo-primitives.tsx
+++ b/components/demo-primitives.tsx
@@ -86,7 +86,7 @@ export function Badge({ children }: { children: ReactNode }) {
   return <span className="inline-flex rounded-full border border-border/60 bg-background/70 px-2.5 py-1 text-xs font-medium">{children}</span>;
 }
 
-export function SimpleTable({ headers, rows }: { headers: string[]; rows: ReactNode[][] }) {
+export function SimpleTable({ headers, rows }: { headers: string[]; rows: { key: string; cells: ReactNode[] }[] }) {
   return (
     <div className="overflow-x-auto">
       <table className="min-w-full text-sm">
@@ -98,10 +98,10 @@ export function SimpleTable({ headers, rows }: { headers: string[]; rows: ReactN
           </tr>
         </thead>
         <tbody>
-          {rows.map((row, rowIndex) => (
-            <tr key={rowIndex} className="border-b border-border/40 last:border-0">
-              {row.map((cell, cellIndex) => (
-                <td key={`${rowIndex}-${cellIndex}`} className="px-3 py-3 align-top">{cell}</td>
+          {rows.map((row) => (
+            <tr key={row.key} className="border-b border-border/40 last:border-0">
+              {row.cells.map((cell, cellIndex) => (
+                <td key={`${row.key}-${cellIndex}`} className="px-3 py-3 align-top">{cell}</td>
               ))}
             </tr>
           ))}


### PR DESCRIPTION
## Summary
- resolved the remaining demo lint errors
- updated demo tables to use keyed row objects
- removed unused imports in affected demo pages
- tightened wording on the cleaned demo views

## Why this matters
The app was already stable, but the demo layer still had leftover lint issues. This finishes the cleanup so the public showcase stays clean and easier to maintain.

## Testing
- [x] npm run lint
- [x] npm run test:run
- [x] open /demo
- [ ] verify the affected demo pages still render correctly