### PR TITLE
Add first-time onboarding wizard

### DIFF
--- a/app/onboarding/actions.ts
+++ b/app/onboarding/actions.ts
@@ -1,0 +1,83 @@
+"use server";
+
+import type { Sex } from "@prisma/client";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { db } from "@/lib/db";
+import { requireUser } from "@/lib/session";
+import { healthProfileSchema } from "@/lib/validations";
+
+export async function saveOnboardingProfile(formData: FormData) {
+  const user = await requireUser();
+
+  const rawSex = String(formData.get("sex") || "").trim();
+  const rawBloodType = String(formData.get("bloodType") || "").trim();
+  const rawDateOfBirth = String(formData.get("dateOfBirth") || "").trim();
+  const rawHeightCm = String(formData.get("heightCm") || "").trim();
+  const rawWeightKg = String(formData.get("weightKg") || "").trim();
+
+  const parsed = healthProfileSchema.safeParse({
+    fullName: String(formData.get("fullName") || user.name || "").trim(),
+    dateOfBirth: rawDateOfBirth || undefined,
+    sex: rawSex || undefined,
+    bloodType: rawBloodType || undefined,
+    heightCm: rawHeightCm || undefined,
+    weightKg: rawWeightKg || undefined,
+    emergencyContactName:
+      String(formData.get("emergencyContactName") || "").trim() || undefined,
+    emergencyContactPhone:
+      String(formData.get("emergencyContactPhone") || "").trim() || undefined,
+    chronicConditions:
+      String(formData.get("chronicConditions") || "").trim() || undefined,
+    allergiesSummary:
+      String(formData.get("allergiesSummary") || "").trim() || undefined,
+    notes: String(formData.get("notes") || "").trim() || undefined,
+  });
+
+  if (!parsed.success) {
+    throw new Error(
+      parsed.error.issues[0]?.message ?? "Invalid onboarding profile data."
+    );
+  }
+
+  await db.healthProfile.upsert({
+    where: { userId: user.id },
+    update: {
+      fullName: parsed.data.fullName.trim(),
+      dateOfBirth: parsed.data.dateOfBirth ? new Date(parsed.data.dateOfBirth) : null,
+      sex: (parsed.data.sex as Sex | undefined) ?? null,
+      bloodType: parsed.data.bloodType?.trim() || null,
+      heightCm: parsed.data.heightCm != null ? Number(parsed.data.heightCm) : null,
+      weightKg: parsed.data.weightKg != null ? Number(parsed.data.weightKg) : null,
+      emergencyContactName: parsed.data.emergencyContactName?.trim() || null,
+      emergencyContactPhone: parsed.data.emergencyContactPhone?.trim() || null,
+      chronicConditions: parsed.data.chronicConditions?.trim() || null,
+      allergiesSummary: parsed.data.allergiesSummary?.trim() || null,
+      notes: parsed.data.notes?.trim() || null,
+    },
+    create: {
+      userId: user.id,
+      fullName: parsed.data.fullName.trim(),
+      dateOfBirth: parsed.data.dateOfBirth ? new Date(parsed.data.dateOfBirth) : null,
+      sex: (parsed.data.sex as Sex | undefined) ?? null,
+      bloodType: parsed.data.bloodType?.trim() || null,
+      heightCm: parsed.data.heightCm != null ? Number(parsed.data.heightCm) : null,
+      weightKg: parsed.data.weightKg != null ? Number(parsed.data.weightKg) : null,
+      emergencyContactName: parsed.data.emergencyContactName?.trim() || null,
+      emergencyContactPhone: parsed.data.emergencyContactPhone?.trim() || null,
+      chronicConditions: parsed.data.chronicConditions?.trim() || null,
+      allergiesSummary: parsed.data.allergiesSummary?.trim() || null,
+      notes: parsed.data.notes?.trim() || null,
+    },
+  });
+
+  revalidatePath("/onboarding");
+  revalidatePath("/dashboard");
+  revalidatePath("/health-profile");
+
+  redirect("/dashboard");
+}
+
+export async function skipOnboarding() {
+  redirect("/dashboard");
+}

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,0 +1,263 @@
+import Link from "next/link";
+import {
+  ArrowRight,
+  CheckCircle2,
+  ClipboardCheck,
+  HeartPulse,
+  LifeBuoy,
+  ShieldCheck,
+  UserRound,
+} from "lucide-react";
+import { AppShell } from "@/components/app-shell";
+import { PageHeader, StatusPill } from "@/components/common";
+import { PageTransition, StaggerGroup, StaggerItem } from "@/components/page-transition";
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+  Select,
+  Textarea,
+} from "@/components/ui";
+import { db } from "@/lib/db";
+import { requireUser } from "@/lib/session";
+import { formatDateInput, getOnboardingProgress } from "@/lib/onboarding";
+import { saveOnboardingProfile, skipOnboarding } from "./actions";
+
+const stepCards = [
+  {
+    title: "Baseline identity",
+    description: "Set the record owner and demographic context used in summaries.",
+    icon: UserRound,
+  },
+  {
+    title: "Safety details",
+    description: "Capture allergies, chronic conditions, and emergency contacts.",
+    icon: ShieldCheck,
+  },
+  {
+    title: "Care context",
+    description: "Add notes that help future exports and care-team collaboration.",
+    icon: HeartPulse,
+  },
+];
+
+export default async function OnboardingPage() {
+  const user = await requireUser();
+  const profile = await db.healthProfile.findUnique({ where: { userId: user.id } });
+  const progress = getOnboardingProgress(profile);
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-7xl space-y-6 p-6">
+        <PageTransition>
+          <PageHeader
+            title="Set up your VitaVault"
+            description="Complete the core patient profile once so your dashboard, summaries, care-team sharing, and future reports have reliable context."
+            action={
+              <div className="flex flex-wrap gap-2">
+                <Badge>{progress.percentage}% onboarding complete</Badge>
+                <StatusPill tone={progress.percentage >= 75 ? "success" : "warning"}>
+                  {progress.complete}/{progress.total} setup groups ready
+                </StatusPill>
+              </div>
+            }
+          />
+        </PageTransition>
+
+        <PageTransition delay={0.04}>
+          <Card className="overflow-hidden">
+            <div className="grid gap-0 lg:grid-cols-[1.4fr_0.9fr]">
+              <div className="p-6">
+                <div className="flex items-center gap-3">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-3xl bg-primary/10 text-primary">
+                    <ClipboardCheck className="h-5 w-5" />
+                  </div>
+                  <div>
+                    <p className="text-lg font-semibold tracking-tight">First-run health setup</p>
+                    <p className="text-sm text-muted-foreground">
+                      A guided setup layer for the existing health-profile model.
+                    </p>
+                  </div>
+                </div>
+
+                <div className="mt-6 grid gap-3 md:grid-cols-3">
+                  {stepCards.map((step) => {
+                    const Icon = step.icon;
+                    return (
+                      <div key={step.title} className="rounded-3xl border border-border/60 bg-background/50 p-4">
+                        <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                          <Icon className="h-4 w-4" />
+                        </div>
+                        <p className="mt-3 text-sm font-semibold">{step.title}</p>
+                        <p className="mt-1 text-xs leading-5 text-muted-foreground">{step.description}</p>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div className="border-t border-border/60 bg-background/40 p-6 lg:border-l lg:border-t-0">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Readiness</p>
+                    <p className="mt-1 text-3xl font-semibold">{progress.percentage}%</p>
+                  </div>
+                  <LifeBuoy className="h-8 w-8 text-primary" />
+                </div>
+
+                <div className="mt-4 h-2 w-full rounded-full bg-muted/60">
+                  <div
+                    className="h-2 rounded-full bg-primary transition-all duration-500"
+                    style={{ width: `${progress.percentage}%` }}
+                  />
+                </div>
+
+                <div className="mt-5 space-y-3">
+                  {progress.checklist.map((item) => (
+                    <div key={item.key} className="flex gap-3 rounded-2xl border border-border/60 bg-background/50 p-3">
+                      <CheckCircle2 className={item.complete ? "mt-0.5 h-4 w-4 text-emerald-500" : "mt-0.5 h-4 w-4 text-muted-foreground"} />
+                      <div>
+                        <p className="text-sm font-medium">{item.title}</p>
+                        <p className="mt-1 text-xs leading-5 text-muted-foreground">{item.description}</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </Card>
+        </PageTransition>
+
+        <form action={saveOnboardingProfile} className="space-y-6">
+          <StaggerGroup delay={0.07}>
+            <div className="grid gap-6 xl:grid-cols-2">
+              <StaggerItem>
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Step 1 — Identity basics</CardTitle>
+                    <CardDescription className="mt-1">
+                      These fields appear in patient summaries, exports, and shared care views.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="grid gap-4 md:grid-cols-2">
+                    <div className="space-y-2 md:col-span-2">
+                      <Label>Full name</Label>
+                      <Input name="fullName" defaultValue={profile?.fullName ?? user.name ?? ""} placeholder="Juan Dela Cruz" required />
+                    </div>
+                    <div className="space-y-2">
+                      <Label>Date of birth</Label>
+                      <Input name="dateOfBirth" type="date" defaultValue={formatDateInput(profile?.dateOfBirth)} />
+                    </div>
+                    <div className="space-y-2">
+                      <Label>Sex</Label>
+                      <Select name="sex" defaultValue={profile?.sex ?? ""}>
+                        <option value="">Select</option>
+                        <option value="MALE">Male</option>
+                        <option value="FEMALE">Female</option>
+                        <option value="OTHER">Other</option>
+                        <option value="PREFER_NOT_TO_SAY">Prefer not to say</option>
+                      </Select>
+                    </div>
+                    <div className="space-y-2">
+                      <Label>Blood type</Label>
+                      <Input name="bloodType" defaultValue={profile?.bloodType ?? ""} placeholder="B+" />
+                    </div>
+                    <div className="space-y-2">
+                      <Label>Height</Label>
+                      <Input name="heightCm" type="number" step="0.1" defaultValue={profile?.heightCm ?? ""} placeholder="170" />
+                    </div>
+                    <div className="space-y-2">
+                      <Label>Weight</Label>
+                      <Input name="weightKg" type="number" step="0.1" defaultValue={profile?.weightKg ?? ""} placeholder="70" />
+                    </div>
+                  </CardContent>
+                </Card>
+              </StaggerItem>
+
+              <StaggerItem>
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Step 2 — Emergency and safety</CardTitle>
+                    <CardDescription className="mt-1">
+                      Add the details that matter during doctor visits, urgent reviews, and shared access.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="grid gap-4 md:grid-cols-2">
+                    <div className="space-y-2">
+                      <Label>Emergency contact name</Label>
+                      <Input name="emergencyContactName" defaultValue={profile?.emergencyContactName ?? ""} placeholder="Maria Dela Cruz" />
+                    </div>
+                    <div className="space-y-2">
+                      <Label>Emergency contact phone</Label>
+                      <Input name="emergencyContactPhone" defaultValue={profile?.emergencyContactPhone ?? ""} placeholder="0917 000 0000" />
+                    </div>
+                    <div className="space-y-2 md:col-span-2">
+                      <Label>Allergies</Label>
+                      <Textarea name="allergiesSummary" defaultValue={profile?.allergiesSummary ?? ""} rows={4} placeholder="Penicillin, shellfish, latex, or none known" />
+                    </div>
+                    <div className="space-y-2 md:col-span-2">
+                      <Label>Chronic conditions</Label>
+                      <Textarea name="chronicConditions" defaultValue={profile?.chronicConditions ?? ""} rows={4} placeholder="Hypertension, diabetes, asthma, or none known" />
+                    </div>
+                  </CardContent>
+                </Card>
+              </StaggerItem>
+            </div>
+          </StaggerGroup>
+
+          <PageTransition delay={0.1}>
+            <Card>
+              <CardHeader>
+                <CardTitle>Step 3 — Care context</CardTitle>
+                <CardDescription className="mt-1">
+                  Optional notes help make exports, AI summaries, and care-team handoffs more useful.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-2">
+                  <Label>Profile notes</Label>
+                  <Textarea
+                    name="notes"
+                    defaultValue={profile?.notes ?? ""}
+                    rows={5}
+                    placeholder="Preferred clinic, care preferences, important medical background, or reminders for future visits."
+                  />
+                </div>
+
+                <div className="flex flex-col gap-3 border-t border-border/60 pt-5 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <p className="text-sm font-medium">Ready to continue?</p>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      Saving this setup updates your main health profile and returns you to the dashboard.
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Button formAction={skipOnboarding} type="submit" variant="outline">
+                      Skip for now
+                    </Button>
+                    <Link
+                      href="/health-profile"
+                      className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium transition-all hover:bg-muted/60"
+                    >
+                      Open full profile
+                    </Link>
+                    <Button type="submit">
+                      Save and go to dashboard
+                      <ArrowRight className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </PageTransition>
+        </form>
+      </div>
+    </AppShell>
+  );
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -7,7 +7,7 @@ export default async function SignupPage({
 }) {
   const params = (await searchParams) ?? {};
   const callbackUrl =
-    typeof params.callbackUrl === "string" ? params.callbackUrl : undefined;
+    typeof params.callbackUrl === "string" ? params.callbackUrl : "/onboarding";
 
   return <SignupForm callbackUrl={callbackUrl} />;
 }

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -146,7 +146,7 @@ export function AppShell({ children }: AppShellProps) {
     const pick = (hrefs: string[]) =>
       hrefs.map((h) => routeMap.get(h)).filter(Boolean) as AppRouteItem[];
 
-    const overview = pick(["/dashboard"]);
+    const overview = pick(["/dashboard", "/onboarding"]);
     const collaboration = pick([
       "/ai-insights",
       "/care-team",

--- a/docs/PATCH_03_ONBOARDING_WIZARD.md
+++ b/docs/PATCH_03_ONBOARDING_WIZARD.md
@@ -1,0 +1,31 @@
+# Patch 03 — First-Time Onboarding Wizard
+
+## Purpose
+
+This patch adds a first-run onboarding experience that turns the existing health-profile form into a more guided product workflow.
+
+## What changed
+
+- Added `/onboarding` as a protected authenticated page.
+- Added a guided setup layout with readiness scoring and checklist groups.
+- Added onboarding server actions for saving profile setup and skipping setup.
+- Reused the existing `HealthProfile` model, so no Prisma migration is required.
+- Added shared onboarding helpers for progress calculation and date formatting.
+- Updated signup so new users land on `/onboarding` by default when no callback URL is provided.
+- Added Onboarding to the app shell navigation.
+
+## Files changed
+
+- `app/onboarding/page.tsx`
+- `app/onboarding/actions.ts`
+- `lib/onboarding.ts`
+- `app/signup/page.tsx`
+- `lib/app-routes.ts`
+- `components/app-shell.tsx`
+- `docs/PATCH_03_ONBOARDING_WIZARD.md`
+
+## Notes
+
+This patch intentionally avoids adding an `onboardingCompletedAt` database field. Completion is inferred from existing health-profile readiness. That keeps the patch easy to review and safe to merge.
+
+A future patch can add a dedicated onboarding status field if the product needs stricter first-run enforcement.

--- a/lib/app-routes.ts
+++ b/lib/app-routes.ts
@@ -8,6 +8,7 @@ import {
   FileHeart,
   HeartPulse,
   LayoutDashboard,
+  ClipboardCheck,
   Pill,
   ShieldPlus,
   ShieldCheck,
@@ -32,6 +33,12 @@ export const primaryRoutes: AppRouteItem[] = [
     href: "/dashboard",
     description: "Command center for your health workspace",
     icon: LayoutDashboard,
+  },
+  {
+    title: "Onboarding",
+    href: "/onboarding",
+    description: "Guided first-run health setup",
+    icon: ClipboardCheck,
   },
   {
     title: "AI Insights",

--- a/lib/onboarding.ts
+++ b/lib/onboarding.ts
@@ -1,0 +1,84 @@
+export type OnboardingChecklistItem = {
+  key: string;
+  title: string;
+  description: string;
+  complete: boolean;
+};
+
+export type OnboardingProfile = {
+  fullName?: string | null;
+  dateOfBirth?: Date | null;
+  sex?: string | null;
+  bloodType?: string | null;
+  heightCm?: number | null;
+  weightKg?: number | null;
+  emergencyContactName?: string | null;
+  emergencyContactPhone?: string | null;
+  chronicConditions?: string | null;
+  allergiesSummary?: string | null;
+  notes?: string | null;
+} | null;
+
+function hasValue(value: unknown) {
+  if (value === null || value === undefined) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  return true;
+}
+
+export function getOnboardingChecklist(profile: OnboardingProfile): OnboardingChecklistItem[] {
+  return [
+    {
+      key: "identity",
+      title: "Identity basics",
+      description: "Name, birth date, sex, and blood type are used across summaries and reports.",
+      complete: Boolean(
+        hasValue(profile?.fullName) &&
+          hasValue(profile?.dateOfBirth) &&
+          hasValue(profile?.sex) &&
+          hasValue(profile?.bloodType)
+      ),
+    },
+    {
+      key: "baseline",
+      title: "Physical baseline",
+      description: "Height and weight help make future vitals, trends, and exports more useful.",
+      complete: Boolean(hasValue(profile?.heightCm) && hasValue(profile?.weightKg)),
+    },
+    {
+      key: "safety",
+      title: "Safety context",
+      description: "Allergies and chronic conditions provide context for caregivers and doctor visits.",
+      complete: Boolean(hasValue(profile?.allergiesSummary) || hasValue(profile?.chronicConditions)),
+    },
+    {
+      key: "emergency",
+      title: "Emergency contact",
+      description: "A named emergency contact makes the patient summary and future emergency card stronger.",
+      complete: Boolean(
+        hasValue(profile?.emergencyContactName) && hasValue(profile?.emergencyContactPhone)
+      ),
+    },
+  ];
+}
+
+export function getOnboardingProgress(profile: OnboardingProfile) {
+  const checklist = getOnboardingChecklist(profile);
+  const complete = checklist.filter((item) => item.complete).length;
+  const total = checklist.length;
+
+  return {
+    checklist,
+    complete,
+    total,
+    percentage: total > 0 ? Math.round((complete / total) * 100) : 0,
+  };
+}
+
+export function formatDateInput(date: Date | null | undefined) {
+  if (!date) return "";
+  const d = new Date(date);
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  const year = d.getFullYear();
+  return `${year}-${month}-${day}`;
+}


### PR DESCRIPTION
This PR adds a guided first-time onboarding flow for VitaVault.

Changes:
- Adds a protected /onboarding page
- Adds onboarding readiness scoring and checklist groups
- Adds guided profile setup sections for identity, baseline, emergency contact, allergies, chronic conditions, and notes
- Adds onboarding server actions for saving setup data
- Reuses the existing HealthProfile model, so no database migration is required
- Sends new signups to /onboarding by default
- Adds Onboarding to the app sidebar navigation
- Adds patch documentation for the onboarding feature