### PR TITLE
Add audit log and security activity center

### DIFF
--- a/app/audit-log/page.tsx
+++ b/app/audit-log/page.tsx
@@ -1,0 +1,323 @@
+import Link from "next/link";
+import {
+  Activity,
+  AlertTriangle,
+  ClipboardList,
+  Download,
+  Filter,
+  KeyRound,
+  ServerCog,
+  ShieldCheck,
+} from "lucide-react";
+import { AppShell } from "@/components/app-shell";
+import { EmptyState, PageHeader, StatusPill } from "@/components/common";
+import {
+  Badge,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Input,
+  Select,
+  Table,
+  TBody,
+  TD,
+  TH,
+  THead,
+  TR,
+} from "@/components/ui";
+import { getSecurityAuditCenterData, parseAuditFilters, type SecurityAuditEvent } from "@/lib/audit-log";
+import { requireUser } from "@/lib/session";
+
+function formatDateTime(value: Date) {
+  return new Date(value).toLocaleString();
+}
+
+function sourceLabel(source: SecurityAuditEvent["source"]) {
+  const labels: Record<SecurityAuditEvent["source"], string> = {
+    access: "Access",
+    alert: "Alert",
+    reminder: "Reminder",
+    job: "Job",
+    session: "Session",
+  };
+  return labels[source];
+}
+
+function sourceIcon(source: SecurityAuditEvent["source"]) {
+  const classes = "h-4 w-4 text-muted-foreground";
+  if (source === "access") return <ShieldCheck className={classes} />;
+  if (source === "alert") return <AlertTriangle className={classes} />;
+  if (source === "reminder") return <ClipboardList className={classes} />;
+  if (source === "job") return <ServerCog className={classes} />;
+  return <KeyRound className={classes} />;
+}
+
+function severityTone(severity: SecurityAuditEvent["severity"]) {
+  if (severity === "danger") return "danger" as const;
+  if (severity === "warning") return "warning" as const;
+  if (severity === "success") return "success" as const;
+  return "info" as const;
+}
+
+function buildExportText(events: SecurityAuditEvent[]) {
+  const header = ["Created At", "Source", "Severity", "Title", "Actor", "Owner", "Target", "Note"].join(",");
+  const rows = events.map((event) =>
+    [
+      event.createdAt.toISOString(),
+      sourceLabel(event.source),
+      event.severity,
+      event.title,
+      event.actor,
+      event.owner,
+      event.target,
+      event.note,
+    ]
+      .map((value) => `"${String(value).replaceAll('"', '""')}"`)
+      .join(",")
+  );
+
+  return [header, ...rows].join("\n");
+}
+
+export default async function AuditLogPage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = (await searchParams) ?? {};
+  const user = await requireUser();
+  const filters = parseAuditFilters(params);
+  const data = await getSecurityAuditCenterData(
+    { id: user.id!, role: user.role },
+    filters
+  );
+  const exportText = buildExportText(data.events);
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-7xl space-y-6 p-6">
+        <PageHeader
+          title="Audit Log"
+          description="Review care access changes, alert/reminder audit trails, worker job activity, and mobile/API session events from one security-focused view."
+          action={
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href="/security"
+                className="inline-flex items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 py-2.5 text-sm font-medium hover:bg-muted/50"
+              >
+                Security center
+              </Link>
+              <Link
+                href="/jobs"
+                className="inline-flex items-center justify-center rounded-2xl bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground shadow-sm hover:opacity-95"
+              >
+                Job runs
+              </Link>
+            </div>
+          }
+        />
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-6">
+          <Card className="xl:col-span-2">
+            <CardHeader>
+              <CardTitle>Visible events</CardTitle>
+              <CardDescription>After current filters are applied.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p className="text-4xl font-semibold">{data.summary.totalEvents}</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                {data.isAdmin ? "Admin-wide operational visibility" : "Limited to your workspace"}
+              </p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>High risk</CardTitle>
+              <CardDescription>Critical/failed events.</CardDescription>
+            </CardHeader>
+            <CardContent><p className="text-4xl font-semibold">{data.summary.dangerEvents}</p></CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Warnings</CardTitle>
+              <CardDescription>Needs review.</CardDescription>
+            </CardHeader>
+            <CardContent><p className="text-4xl font-semibold">{data.summary.warningEvents}</p></CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Open alerts</CardTitle>
+              <CardDescription>Unresolved alert events.</CardDescription>
+            </CardHeader>
+            <CardContent><p className="text-4xl font-semibold">{data.summary.openAlerts}</p></CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Failed jobs</CardTitle>
+              <CardDescription>Failed/retrying runs.</CardDescription>
+            </CardHeader>
+            <CardContent><p className="text-4xl font-semibold">{data.summary.failedJobs}</p></CardContent>
+          </Card>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+              <div>
+                <CardTitle>Filter audit activity</CardTitle>
+                <CardDescription className="mt-1">
+                  Narrow by event source, severity, or free-text search across title, actor, owner, target, and notes.
+                </CardDescription>
+              </div>
+              <form method="post" action={`data:text/csv;charset=utf-8,${encodeURIComponent(exportText)}`}>
+                <button
+                  type="submit"
+                  className="inline-flex items-center justify-center gap-2 rounded-2xl border border-border/70 bg-background/60 px-4 py-2.5 text-sm font-medium hover:bg-muted/50"
+                >
+                  <Download className="h-4 w-4" />
+                  Export visible CSV
+                </button>
+              </form>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <form className="grid gap-3 lg:grid-cols-[1fr_180px_180px_auto]" action="/audit-log">
+              <div className="space-y-2">
+                <label htmlFor="q" className="text-sm font-medium">Search</label>
+                <Input id="q" name="q" defaultValue={filters.q} placeholder="Search actions, actors, targets, or notes" />
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="source" className="text-sm font-medium">Source</label>
+                <Select id="source" name="source" defaultValue={filters.source}>
+                  <option value="all">All sources</option>
+                  <option value="access">Access</option>
+                  <option value="alert">Alert</option>
+                  <option value="reminder">Reminder</option>
+                  <option value="job">Job</option>
+                  <option value="session">Session</option>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="severity" className="text-sm font-medium">Severity</label>
+                <Select id="severity" name="severity" defaultValue={filters.severity}>
+                  <option value="all">All severities</option>
+                  <option value="danger">Danger</option>
+                  <option value="warning">Warning</option>
+                  <option value="success">Success</option>
+                  <option value="info">Info</option>
+                </Select>
+              </div>
+              <div className="flex items-end">
+                <button
+                  type="submit"
+                  className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-2xl bg-primary px-4 text-sm font-medium text-primary-foreground shadow-sm hover:opacity-95 lg:w-auto"
+                >
+                  <Filter className="h-4 w-4" />
+                  Apply filters
+                </button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+
+        <div className="grid gap-6 xl:grid-cols-[1.25fr_0.75fr]">
+          <Card>
+            <CardHeader>
+              <CardTitle>Unified audit feed</CardTitle>
+              <CardDescription>
+                Most recent access, alert, reminder, job, and mobile session events.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {data.events.length ? (
+                <div className="overflow-x-auto">
+                  <Table>
+                    <THead>
+                      <TR>
+                        <TH>Event</TH>
+                        <TH>Actor / Owner</TH>
+                        <TH>Target</TH>
+                        <TH>When</TH>
+                      </TR>
+                    </THead>
+                    <TBody>
+                      {data.events.map((event) => (
+                        <TR key={event.id}>
+                          <TD>
+                            <div className="space-y-2">
+                              <div className="flex flex-wrap items-center gap-2">
+                                <Badge className="gap-2">{sourceIcon(event.source)}{sourceLabel(event.source)}</Badge>
+                                <StatusPill tone={severityTone(event.severity)}>{event.severity}</StatusPill>
+                              </div>
+                              <div className="font-medium">{event.title}</div>
+                              <div className="max-w-xl text-sm text-muted-foreground">{event.note}</div>
+                            </div>
+                          </TD>
+                          <TD>
+                            <div className="space-y-1 text-sm">
+                              <p><span className="text-muted-foreground">Actor:</span> {event.actor}</p>
+                              <p><span className="text-muted-foreground">Owner:</span> {event.owner}</p>
+                            </div>
+                          </TD>
+                          <TD className="max-w-xs text-sm text-muted-foreground">{event.target}</TD>
+                          <TD className="whitespace-nowrap text-sm text-muted-foreground">{formatDateTime(event.createdAt)}</TD>
+                        </TR>
+                      ))}
+                    </TBody>
+                  </Table>
+                </div>
+              ) : (
+                <EmptyState title="No audit events found" description="Try clearing filters or generating activity through care access, alerts, reminders, mobile sessions, or jobs." />
+              )}
+            </CardContent>
+          </Card>
+
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Security posture</CardTitle>
+                <CardDescription>What this audit center is tracking.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm">
+                <div className="rounded-3xl border border-border/60 bg-background/40 p-4">
+                  <div className="flex items-center gap-2 font-medium"><ShieldCheck className="h-4 w-4 text-primary" /> Care access changes</div>
+                  <p className="mt-1 text-muted-foreground">Invite, grant, revoke, and shared-access audit entries.</p>
+                </div>
+                <div className="rounded-3xl border border-border/60 bg-background/40 p-4">
+                  <div className="flex items-center gap-2 font-medium"><AlertTriangle className="h-4 w-4 text-amber-500" /> Alert and reminder actions</div>
+                  <p className="mt-1 text-muted-foreground">Acknowledgements, resolutions, reminder state changes, and related notes.</p>
+                </div>
+                <div className="rounded-3xl border border-border/60 bg-background/40 p-4">
+                  <div className="flex items-center gap-2 font-medium"><Activity className="h-4 w-4 text-sky-500" /> Jobs and sessions</div>
+                  <p className="mt-1 text-muted-foreground">Worker runs, failed attempts, active mobile sessions, expired tokens, and revocations.</p>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Active mobile sessions</CardTitle>
+                <CardDescription>Current valid mobile/API tokens.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-5xl font-semibold">{data.summary.activeMobileSessions}</p>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Manage personal tokens from the Security Center. Admins can review aggregate visibility from this page.
+                </p>
+                <Link href="/security" className="mt-4 inline-flex rounded-2xl border border-border/70 bg-background/60 px-4 py-2 text-sm font-medium hover:bg-muted/50">
+                  Open Security Center
+                </Link>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </div>
+    </AppShell>
+  );
+}

--- a/app/security/page.tsx
+++ b/app/security/page.tsx
@@ -81,6 +81,12 @@ export default async function SecurityPage() {
           action={
             <div className="flex flex-wrap gap-3">
               <Link
+                href="/audit-log"
+                className="inline-flex items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 py-2.5 text-sm font-medium hover:bg-muted/50"
+              >
+                Audit log
+              </Link>
+              <Link
                 href="/device-connection"
                 className="inline-flex items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 py-2.5 text-sm font-medium hover:bg-muted/50"
               >

--- a/docs/PATCH_07_AUDIT_SECURITY_CENTER.md
+++ b/docs/PATCH_07_AUDIT_SECURITY_CENTER.md
@@ -1,0 +1,45 @@
+# Patch 07 — Audit Log Viewer and Security Activity Center
+
+This patch adds a unified audit/security review surface to VitaVault.
+
+## Files changed
+
+```txt
+app/audit-log/page.tsx
+app/security/page.tsx
+lib/audit-log.ts
+docs/PATCH_07_AUDIT_SECURITY_CENTER.md
+```
+
+## What was added
+
+- New protected `/audit-log` page.
+- Unified activity feed across care access audit logs, alert audit logs, reminder audit logs, worker job runs, and mobile/API session events.
+- Source filter for access, alert, reminder, job, and session events.
+- Severity filter for info, warning, danger, and success events.
+- Free-text search across action, actor, owner, target, note, and metadata.
+- Summary cards for visible events, high-risk events, warnings, open alerts, failed jobs, and active sessions.
+- CSV-style visible event export action.
+- Security Center link to the new Audit Log page.
+- Admin-aware visibility: admins can review system-wide activity, while normal users are scoped to their own workspace.
+
+## Notes
+
+- No Prisma migration is required.
+- This patch uses existing audit/session/job models already present in the schema.
+- This is intentionally a review surface first; destructive moderation actions remain in the existing Security/Admin pages.
+
+## Suggested verification
+
+```bash
+npm run typecheck
+npm run lint
+npm run test:run
+```
+
+Manual routes:
+
+```txt
+/audit-log
+/security
+```

--- a/lib/audit-log.ts
+++ b/lib/audit-log.ts
@@ -1,0 +1,310 @@
+import {
+  AlertSeverity,
+  AlertStatus,
+  AppRole,
+  JobRunStatus,
+  ReminderState,
+} from "@prisma/client";
+import { db } from "@/lib/db";
+
+type AuditSource = "all" | "access" | "alert" | "reminder" | "job" | "session";
+type AuditSeverity = "all" | "info" | "warning" | "danger" | "success";
+
+export type AuditLogFilters = {
+  source: AuditSource;
+  severity: AuditSeverity;
+  q: string;
+};
+
+export type SecurityAuditSummary = {
+  totalEvents: number;
+  dangerEvents: number;
+  warningEvents: number;
+  activeMobileSessions: number;
+  failedJobs: number;
+  openAlerts: number;
+};
+
+export type SecurityAuditEvent = {
+  id: string;
+  source: Exclude<AuditSource, "all">;
+  title: string;
+  actor: string;
+  owner: string;
+  target: string;
+  note: string;
+  severity: Exclude<AuditSeverity, "all">;
+  createdAt: Date;
+  metadata: string;
+};
+
+function labelUser(user: { name: string | null; email: string | null; id: string } | null | undefined) {
+  if (!user) return "System";
+  return user.name || user.email || user.id;
+}
+
+function normalizeText(value: unknown) {
+  if (value === null || value === undefined) return "";
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function includesQuery(event: SecurityAuditEvent, q: string) {
+  if (!q) return true;
+  const haystack = [
+    event.source,
+    event.title,
+    event.actor,
+    event.owner,
+    event.target,
+    event.note,
+    event.metadata,
+  ]
+    .join(" ")
+    .toLowerCase();
+
+  return haystack.includes(q.toLowerCase());
+}
+
+function severityFromAlert(severity: AlertSeverity, status: AlertStatus): SecurityAuditEvent["severity"] {
+  if (status === AlertStatus.RESOLVED || status === AlertStatus.DISMISSED) return "success";
+  if (severity === AlertSeverity.CRITICAL || severity === AlertSeverity.HIGH) return "danger";
+  if (severity === AlertSeverity.MEDIUM) return "warning";
+  return "info";
+}
+
+function severityFromJob(status: JobRunStatus): SecurityAuditEvent["severity"] {
+  if (status === JobRunStatus.FAILED) return "danger";
+  if (status === JobRunStatus.RETRYING || status === JobRunStatus.CANCELLED) return "warning";
+  if (status === JobRunStatus.COMPLETED) return "success";
+  return "info";
+}
+
+function severityFromReminder(state: ReminderState): SecurityAuditEvent["severity"] {
+  if (state === ReminderState.MISSED || state === ReminderState.OVERDUE) return "warning";
+  if (state === ReminderState.COMPLETED) return "success";
+  return "info";
+}
+
+export function parseAuditFilters(params: Record<string, string | string[] | undefined>): AuditLogFilters {
+  const source = String(params.source ?? "all");
+  const severity = String(params.severity ?? "all");
+  const q = String(params.q ?? "").trim();
+
+  return {
+    source: ["all", "access", "alert", "reminder", "job", "session"].includes(source)
+      ? (source as AuditSource)
+      : "all",
+    severity: ["all", "info", "warning", "danger", "success"].includes(severity)
+      ? (severity as AuditSeverity)
+      : "all",
+    q,
+  };
+}
+
+export async function getSecurityAuditCenterData(user: {
+  id: string;
+  role: AppRole;
+}, filters: AuditLogFilters) {
+  const now = new Date();
+  const isAdmin = user.role === AppRole.ADMIN;
+  const ownerWhere = isAdmin ? {} : { userId: user.id };
+  const accessWhere = isAdmin ? {} : { ownerUserId: user.id };
+
+  const [
+    accessLogs,
+    alertAuditLogs,
+    reminderAuditLogs,
+    jobRuns,
+    mobileSessions,
+    activeMobileSessions,
+    failedJobs,
+    openAlerts,
+  ] = await Promise.all([
+    db.accessAuditLog.findMany({
+      where: accessWhere,
+      orderBy: { createdAt: "desc" },
+      take: 80,
+      select: {
+        id: true,
+        action: true,
+        targetType: true,
+        targetId: true,
+        metadataJson: true,
+        createdAt: true,
+        owner: { select: { id: true, name: true, email: true } },
+        actor: { select: { id: true, name: true, email: true } },
+      },
+    }),
+    db.alertAuditLog.findMany({
+      where: ownerWhere,
+      orderBy: { createdAt: "desc" },
+      take: 80,
+      select: {
+        id: true,
+        action: true,
+        note: true,
+        metadataJson: true,
+        createdAt: true,
+        user: { select: { id: true, name: true, email: true } },
+        actor: { select: { id: true, name: true, email: true } },
+        alert: { select: { id: true, title: true, severity: true, status: true } },
+        rule: { select: { id: true, name: true, severity: true } },
+      },
+    }),
+    db.reminderAuditLog.findMany({
+      where: ownerWhere,
+      orderBy: { createdAt: "desc" },
+      take: 80,
+      select: {
+        id: true,
+        action: true,
+        note: true,
+        metadataJson: true,
+        createdAt: true,
+        user: { select: { id: true, name: true, email: true } },
+        actor: { select: { id: true, name: true, email: true } },
+        reminder: { select: { id: true, title: true, state: true, dueAt: true } },
+      },
+    }),
+    db.jobRun.findMany({
+      where: isAdmin ? {} : { userId: user.id },
+      orderBy: { createdAt: "desc" },
+      take: 80,
+      select: {
+        id: true,
+        queueName: true,
+        jobName: true,
+        jobKind: true,
+        status: true,
+        errorMessage: true,
+        attemptsMade: true,
+        maxAttempts: true,
+        createdAt: true,
+        user: { select: { id: true, name: true, email: true } },
+      },
+    }),
+    db.mobileSessionToken.findMany({
+      where: isAdmin ? {} : { userId: user.id },
+      orderBy: [{ revokedAt: "asc" }, { lastUsedAt: "desc" }, { createdAt: "desc" }],
+      take: 80,
+      select: {
+        id: true,
+        name: true,
+        expiresAt: true,
+        lastUsedAt: true,
+        revokedAt: true,
+        createdAt: true,
+        user: { select: { id: true, name: true, email: true } },
+      },
+    }),
+    db.mobileSessionToken.count({
+      where: isAdmin ? { revokedAt: null, expiresAt: { gt: now } } : { userId: user.id, revokedAt: null, expiresAt: { gt: now } },
+    }),
+    db.jobRun.count({
+      where: isAdmin
+        ? { status: { in: [JobRunStatus.FAILED, JobRunStatus.RETRYING] } }
+        : { userId: user.id, status: { in: [JobRunStatus.FAILED, JobRunStatus.RETRYING] } },
+    }),
+    db.alertEvent.count({
+      where: isAdmin ? { status: AlertStatus.OPEN } : { userId: user.id, status: AlertStatus.OPEN },
+    }),
+  ]);
+
+  const events: SecurityAuditEvent[] = [
+    ...accessLogs.map((log) => ({
+      id: `access-${log.id}`,
+      source: "access" as const,
+      title: log.action,
+      actor: labelUser(log.actor),
+      owner: labelUser(log.owner),
+      target: [log.targetType, log.targetId].filter(Boolean).join(" • ") || "Care access",
+      note: log.metadataJson || "Care-team access audit entry.",
+      severity: log.action.toLowerCase().includes("revok") || log.action.toLowerCase().includes("remove") ? "warning" as const : "info" as const,
+      createdAt: log.createdAt,
+      metadata: log.metadataJson || "",
+    })),
+    ...alertAuditLogs.map((log) => ({
+      id: `alert-${log.id}`,
+      source: "alert" as const,
+      title: log.action,
+      actor: labelUser(log.actor),
+      owner: labelUser(log.user),
+      target: log.alert?.title || log.rule?.name || "Alert workflow",
+      note: log.note || log.metadataJson || "Alert rule or event audit entry.",
+      severity: log.alert
+        ? severityFromAlert(log.alert.severity, log.alert.status)
+        : log.rule?.severity === AlertSeverity.CRITICAL || log.rule?.severity === AlertSeverity.HIGH
+          ? "danger" as const
+          : "info" as const,
+      createdAt: log.createdAt,
+      metadata: log.metadataJson || "",
+    })),
+    ...reminderAuditLogs.map((log) => ({
+      id: `reminder-${log.id}`,
+      source: "reminder" as const,
+      title: log.action,
+      actor: labelUser(log.actor),
+      owner: labelUser(log.user),
+      target: log.reminder?.title || "Reminder workflow",
+      note: log.note || (log.reminder?.dueAt ? `Due ${log.reminder.dueAt.toLocaleString()}` : "Reminder audit entry."),
+      severity: severityFromReminder(log.reminder?.state || ReminderState.DUE),
+      createdAt: log.createdAt,
+      metadata: log.metadataJson || "",
+    })),
+    ...jobRuns.map((job) => ({
+      id: `job-${job.id}`,
+      source: "job" as const,
+      title: `${job.jobKind} · ${job.status}`,
+      actor: "Worker",
+      owner: labelUser(job.user),
+      target: `${job.queueName} / ${job.jobName}`,
+      note: job.errorMessage || `Attempts ${job.attemptsMade}/${job.maxAttempts}`,
+      severity: severityFromJob(job.status),
+      createdAt: job.createdAt,
+      metadata: normalizeText({ queueName: job.queueName, jobName: job.jobName, jobKind: job.jobKind }),
+    })),
+    ...mobileSessions.map((session) => {
+      const isRevoked = Boolean(session.revokedAt);
+      const isExpired = session.expiresAt < now;
+      return {
+        id: `session-${session.id}`,
+        source: "session" as const,
+        title: isRevoked ? "Mobile session revoked" : isExpired ? "Mobile session expired" : "Mobile session active",
+        actor: labelUser(session.user),
+        owner: labelUser(session.user),
+        target: session.name || `Session ${session.id.slice(0, 10)}`,
+        note: `Created ${session.createdAt.toLocaleString()} · Last used ${session.lastUsedAt?.toLocaleString() || "never"}`,
+        severity: isRevoked ? "warning" as const : isExpired ? "info" as const : "success" as const,
+        createdAt: session.revokedAt || session.lastUsedAt || session.createdAt,
+        metadata: normalizeText({ expiresAt: session.expiresAt, revokedAt: session.revokedAt }),
+      };
+    }),
+  ]
+    .filter((event) => filters.source === "all" || event.source === filters.source)
+    .filter((event) => filters.severity === "all" || event.severity === filters.severity)
+    .filter((event) => includesQuery(event, filters.q))
+    .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+    .slice(0, 120);
+
+  const summary: SecurityAuditSummary = {
+    totalEvents: events.length,
+    dangerEvents: events.filter((event) => event.severity === "danger").length,
+    warningEvents: events.filter((event) => event.severity === "warning").length,
+    activeMobileSessions,
+    failedJobs,
+    openAlerts,
+  };
+
+  return {
+    filters,
+    isAdmin,
+    summary,
+    events,
+  };
+}


### PR DESCRIPTION
This PR adds a unified audit and security activity center to VitaVault.

Changes:
- Adds a protected /audit-log page
- Adds a unified audit feed for care access, alerts, reminders, jobs, and mobile/API sessions
- Adds source, severity, and text filters
- Adds security summary cards for high-risk events, warnings, open alerts, failed jobs, and active sessions
- Adds CSV-style export for visible audit events
- Links the Security Center to the new Audit Log page
- Adds admin-aware visibility for system-wide audit review
- Reuses existing schema models, so no Prisma migration is required