### PR TITLE
Add printable emergency health card

### DIFF
--- a/app/emergency-card/page.tsx
+++ b/app/emergency-card/page.tsx
@@ -1,0 +1,225 @@
+import { AlertTriangle, HeartPulse, Phone, Pill, Printer, ShieldAlert, Stethoscope, UserRound } from "lucide-react";
+import Link from "next/link";
+import { AppShell } from "@/components/app-shell";
+import { PageHeader, StatusPill } from "@/components/common";
+import { DataCard, ModuleHero, ModuleListCard } from "@/components/module-sections";
+import { PageTransition, StaggerGroup, StaggerItem } from "@/components/page-transition";
+import { Badge, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
+import { EmergencyCardActions } from "@/components/emergency-card-actions";
+import { getEmergencyCardData } from "@/lib/emergency-card";
+import { requireUser } from "@/lib/session";
+import { bpLabel, formatDate, formatDateTime } from "@/lib/utils";
+
+function Field({ label, value, urgent = false }: { label: string; value?: string | number | null; urgent?: boolean }) {
+  return (
+    <div className="rounded-2xl border border-border/60 bg-background/45 p-4">
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className={`mt-1 text-sm font-semibold ${urgent ? "text-destructive" : "text-foreground"}`}>{value || "—"}</p>
+    </div>
+  );
+}
+
+export default async function EmergencyCardPage() {
+  const currentUser = await requireUser();
+  const data = await getEmergencyCardData(currentUser.id!);
+  const { profile, patientName, medications, doctors, latestVitals, severeSymptoms, criticalProfileItems, generatedAt } = data;
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-7xl space-y-6 p-6">
+        <PageTransition>
+          <PageHeader
+            title="Emergency Health Card"
+            description="A quick-access printable card with the most important emergency details from the patient profile."
+            action={<EmergencyCardActions />}
+          />
+        </PageTransition>
+
+        <PageTransition delay={0.04}>
+          <ModuleHero
+            eyebrow="Emergency packet"
+            title={patientName}
+            description="Keep this card updated before appointments, travel, school, work, or caregiver handoffs. It is designed for browser printing and Save as PDF workflows."
+            stats={[
+              { label: "Active meds", value: medications.length },
+              { label: "Doctors", value: doctors.length },
+              { label: "Open severe symptoms", value: severeSymptoms.length },
+              { label: "Profile gaps", value: criticalProfileItems.length },
+            ]}
+          />
+        </PageTransition>
+
+        <StaggerGroup delay={0.08}>
+          <div className="grid gap-6 xl:grid-cols-[1.15fr_0.85fr]">
+            <StaggerItem>
+              <Card className="overflow-hidden border-destructive/25">
+                <CardHeader className="bg-destructive/5">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <CardTitle className="flex items-center gap-2 text-2xl">
+                        <ShieldAlert className="h-6 w-6 text-destructive" />
+                        Emergency profile
+                      </CardTitle>
+                      <CardDescription className="mt-1">Critical identity, allergy, condition, and contact details.</CardDescription>
+                    </div>
+                    <Badge className="bg-background/80">Generated {formatDateTime(generatedAt)}</Badge>
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-5">
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <Field label="Patient name" value={patientName} />
+                    <Field label="Date of birth" value={formatDate(profile?.dateOfBirth)} />
+                    <Field label="Sex" value={profile?.sex} />
+                    <Field label="Blood type" value={profile?.bloodType} urgent={!profile?.bloodType} />
+                    <Field label="Height" value={profile?.heightCm ? `${profile.heightCm} cm` : "—"} />
+                    <Field label="Weight" value={profile?.weightKg ? `${profile.weightKg} kg` : "—"} />
+                  </div>
+
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <DataCard className="border-destructive/25 bg-destructive/5">
+                      <div className="flex items-center gap-2">
+                        <AlertTriangle className="h-4 w-4 text-destructive" />
+                        <p className="text-sm font-semibold">Allergies</p>
+                      </div>
+                      <p className="mt-3 whitespace-pre-line text-sm text-muted-foreground">{profile?.allergiesSummary || "No allergies documented yet."}</p>
+                    </DataCard>
+                    <DataCard>
+                      <div className="flex items-center gap-2">
+                        <HeartPulse className="h-4 w-4" />
+                        <p className="text-sm font-semibold">Chronic conditions</p>
+                      </div>
+                      <p className="mt-3 whitespace-pre-line text-sm text-muted-foreground">{profile?.chronicConditions || "No chronic conditions documented yet."}</p>
+                    </DataCard>
+                  </div>
+
+                  <DataCard>
+                    <div className="flex items-center gap-2">
+                      <Phone className="h-4 w-4" />
+                      <p className="text-sm font-semibold">Emergency contact</p>
+                    </div>
+                    <div className="mt-3 grid gap-3 md:grid-cols-2">
+                      <Field label="Contact name" value={profile?.emergencyContactName} urgent={!profile?.emergencyContactName} />
+                      <Field label="Contact phone" value={profile?.emergencyContactPhone} urgent={!profile?.emergencyContactPhone} />
+                    </div>
+                  </DataCard>
+                </CardContent>
+              </Card>
+            </StaggerItem>
+
+            <StaggerItem>
+              <div className="space-y-6">
+                <ModuleListCard title="Card readiness" description="Profile gaps that should be fixed before sharing this card.">
+                  {criticalProfileItems.length ? (
+                    <div className="space-y-3">
+                      {criticalProfileItems.map((item) => (
+                        <div key={item} className="flex items-start gap-3 rounded-2xl border border-amber-200/60 bg-amber-50/70 p-3 text-sm text-amber-800 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-200">
+                          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                          <span>{item}</span>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="rounded-2xl border border-emerald-200/70 bg-emerald-50/70 p-4 text-sm text-emerald-800 dark:border-emerald-900/50 dark:bg-emerald-950/30 dark:text-emerald-200">
+                      Emergency essentials are filled in.
+                    </div>
+                  )}
+                </ModuleListCard>
+
+                <ModuleListCard title="Latest vitals snapshot" description="Most recent recorded vitals, if available.">
+                  {latestVitals ? (
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      <Field label="Recorded" value={formatDateTime(latestVitals.recordedAt)} />
+                      <Field label="Blood pressure" value={bpLabel(latestVitals.systolic, latestVitals.diastolic)} />
+                      <Field label="Heart rate" value={latestVitals.heartRate ? `${latestVitals.heartRate} bpm` : "—"} />
+                      <Field label="Oxygen" value={latestVitals.oxygenSaturation ? `${latestVitals.oxygenSaturation}%` : "—"} />
+                      <Field label="Blood sugar" value={latestVitals.bloodSugar ? `${latestVitals.bloodSugar}` : "—"} />
+                      <Field label="Temperature" value={latestVitals.temperatureC ? `${latestVitals.temperatureC} °C` : "—"} />
+                    </div>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">No vitals recorded yet.</p>
+                  )}
+                </ModuleListCard>
+
+                <Link
+                  href="/emergency-card/print?autoprint=1"
+                  className="flex items-center justify-center gap-2 rounded-[28px] border border-border/70 bg-primary px-5 py-4 text-sm font-semibold text-primary-foreground shadow-sm transition hover:opacity-95"
+                >
+                  <Printer className="h-4 w-4" />
+                  Open print-ready emergency card
+                </Link>
+              </div>
+            </StaggerItem>
+          </div>
+        </StaggerGroup>
+
+        <div className="grid gap-6 xl:grid-cols-3">
+          <ModuleListCard title="Active medications" description="Critical medication list for emergency responders and clinicians." className="xl:col-span-1">
+            {medications.length ? (
+              <div className="space-y-3">
+                {medications.map((medication) => (
+                  <DataCard key={medication.id}>
+                    <div className="flex items-start gap-3">
+                      <Pill className="mt-1 h-4 w-4 shrink-0 text-muted-foreground" />
+                      <div>
+                        <p className="font-semibold">{medication.name}</p>
+                        <p className="mt-1 text-sm text-muted-foreground">{medication.dosage} • {medication.frequency}</p>
+                        {medication.instructions ? <p className="mt-1 text-xs text-muted-foreground">{medication.instructions}</p> : null}
+                        {medication.doctor ? <p className="mt-1 text-xs text-muted-foreground">Prescriber: {medication.doctor.name}</p> : null}
+                      </div>
+                    </div>
+                  </DataCard>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">No active medications documented.</p>
+            )}
+          </ModuleListCard>
+
+          <ModuleListCard title="Care contacts" description="Doctors and providers to contact during handoffs." className="xl:col-span-1">
+            {doctors.length ? (
+              <div className="space-y-3">
+                {doctors.map((doctor) => (
+                  <DataCard key={doctor.id}>
+                    <div className="flex items-start gap-3">
+                      <Stethoscope className="mt-1 h-4 w-4 shrink-0 text-muted-foreground" />
+                      <div>
+                        <p className="font-semibold">{doctor.name}</p>
+                        <p className="mt-1 text-sm text-muted-foreground">{doctor.specialty ?? "General care"}{doctor.clinic ? ` • ${doctor.clinic}` : ""}</p>
+                        <p className="mt-1 text-xs text-muted-foreground">{doctor.phone ?? doctor.email ?? "No contact listed"}</p>
+                      </div>
+                    </div>
+                  </DataCard>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">No doctors documented.</p>
+            )}
+          </ModuleListCard>
+
+          <ModuleListCard title="Urgent symptom context" description="Open severe symptoms that may affect triage." className="xl:col-span-1">
+            {severeSymptoms.length ? (
+              <div className="space-y-3">
+                {severeSymptoms.map((symptom) => (
+                  <DataCard key={symptom.id} className="border-destructive/25 bg-destructive/5">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="font-semibold">{symptom.title}</p>
+                        <p className="mt-1 text-sm text-muted-foreground">Started {formatDate(symptom.startedAt)}{symptom.bodyArea ? ` • ${symptom.bodyArea}` : ""}</p>
+                      </div>
+                      <StatusPill tone="danger">{symptom.severity}</StatusPill>
+                    </div>
+                  </DataCard>
+                ))}
+              </div>
+            ) : (
+              <div className="flex items-center gap-3 rounded-2xl border border-border/60 bg-background/40 p-4 text-sm text-muted-foreground">
+                <UserRound className="h-4 w-4" />
+                No unresolved severe symptoms found.
+              </div>
+            )}
+          </ModuleListCard>
+        </div>
+      </div>
+    </AppShell>
+  );
+}

--- a/app/emergency-card/print/page.tsx
+++ b/app/emergency-card/print/page.tsx
@@ -1,0 +1,150 @@
+import type { ReactNode } from "react";
+import { AutoPrintOnLoad } from "@/components/auto-print-on-load";
+import { getEmergencyCardData } from "@/lib/emergency-card";
+import { requireUser } from "@/lib/session";
+import { bpLabel, formatDate, formatDateTime } from "@/lib/utils";
+
+type SearchParams = Promise<{ autoprint?: string }>;
+
+function PrintField({ label, value, urgent = false }: { label: string; value?: ReactNode; urgent?: boolean }) {
+  return (
+    <div className={`rounded-xl border p-3 ${urgent ? "border-red-300 bg-red-50" : "border-slate-200 bg-white"}`}>
+      <p className="text-[10px] font-bold uppercase tracking-[0.14em] text-slate-500">{label}</p>
+      <div className={`mt-1 text-sm font-semibold ${urgent ? "text-red-700" : "text-slate-950"}`}>{value || "—"}</div>
+    </div>
+  );
+}
+
+function PrintSection({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-4 break-inside-avoid">
+      <h2 className="text-sm font-bold uppercase tracking-[0.16em] text-slate-600">{title}</h2>
+      <div className="mt-3">{children}</div>
+    </section>
+  );
+}
+
+export default async function EmergencyCardPrintPage({ searchParams }: { searchParams?: SearchParams }) {
+  const resolvedSearchParams = (await searchParams) ?? {};
+  const autoprint = resolvedSearchParams.autoprint === "1";
+  const currentUser = await requireUser();
+  const { profile, patientName, medications, doctors, latestVitals, severeSymptoms, criticalProfileItems, generatedAt } = await getEmergencyCardData(currentUser.id!);
+
+  return (
+    <main className="min-h-screen bg-slate-100 p-6 print:bg-white print:p-0">
+      {autoprint ? <AutoPrintOnLoad /> : null}
+      <div className="mx-auto max-w-4xl space-y-4 rounded-[32px] bg-white p-6 shadow-sm print:max-w-none print:rounded-none print:p-0 print:shadow-none">
+        <header className="rounded-3xl border-2 border-red-200 bg-red-50 p-5 print:rounded-none">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <p className="text-xs font-bold uppercase tracking-[0.2em] text-red-700">VitaVault Emergency Health Card</p>
+              <h1 className="mt-2 text-3xl font-black tracking-tight text-slate-950">{patientName}</h1>
+              <p className="mt-1 text-sm text-slate-700">Generated {formatDateTime(generatedAt)} • Carry with ID or share with a caregiver.</p>
+            </div>
+            <div className="rounded-2xl border border-red-200 bg-white px-4 py-3 text-right">
+              <p className="text-[10px] font-bold uppercase tracking-[0.14em] text-slate-500">Emergency contact</p>
+              <p className="mt-1 text-base font-bold text-slate-950">{profile?.emergencyContactName ?? "Not documented"}</p>
+              <p className="text-sm font-semibold text-red-700">{profile?.emergencyContactPhone ?? "No phone documented"}</p>
+            </div>
+          </div>
+        </header>
+
+        <div className="grid gap-4 md:grid-cols-2 print:grid-cols-2">
+          <PrintSection title="Critical identity">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <PrintField label="Date of birth" value={formatDate(profile?.dateOfBirth)} />
+              <PrintField label="Sex" value={profile?.sex} />
+              <PrintField label="Blood type" value={profile?.bloodType} urgent={!profile?.bloodType} />
+              <PrintField label="Height / Weight" value={`${profile?.heightCm ?? "—"} cm / ${profile?.weightKg ?? "—"} kg`} />
+            </div>
+          </PrintSection>
+
+          <PrintSection title="Latest vitals">
+            {latestVitals ? (
+              <div className="grid gap-3 sm:grid-cols-2">
+                <PrintField label="Recorded" value={formatDateTime(latestVitals.recordedAt)} />
+                <PrintField label="Blood pressure" value={bpLabel(latestVitals.systolic, latestVitals.diastolic)} />
+                <PrintField label="Heart rate" value={latestVitals.heartRate ? `${latestVitals.heartRate} bpm` : "—"} />
+                <PrintField label="Oxygen" value={latestVitals.oxygenSaturation ? `${latestVitals.oxygenSaturation}%` : "—"} />
+              </div>
+            ) : (
+              <p className="text-sm text-slate-600">No vitals recorded yet.</p>
+            )}
+          </PrintSection>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2 print:grid-cols-2">
+          <PrintSection title="Allergies">
+            <div className="rounded-xl border border-red-200 bg-red-50 p-3 text-sm font-semibold text-red-800">
+              {profile?.allergiesSummary || "No allergies documented yet."}
+            </div>
+          </PrintSection>
+
+          <PrintSection title="Chronic conditions">
+            <div className="rounded-xl border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700">
+              {profile?.chronicConditions || "No chronic conditions documented yet."}
+            </div>
+          </PrintSection>
+        </div>
+
+        <PrintSection title="Active medications">
+          {medications.length ? (
+            <div className="grid gap-3 md:grid-cols-2 print:grid-cols-2">
+              {medications.slice(0, 6).map((medication) => (
+                <div key={medication.id} className="rounded-xl border border-slate-200 p-3 text-sm">
+                  <p className="font-bold text-slate-950">{medication.name}</p>
+                  <p className="text-slate-700">{medication.dosage} • {medication.frequency}</p>
+                  {medication.instructions ? <p className="mt-1 text-xs text-slate-500">{medication.instructions}</p> : null}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-slate-600">No active medications documented.</p>
+          )}
+        </PrintSection>
+
+        <div className="grid gap-4 md:grid-cols-2 print:grid-cols-2">
+          <PrintSection title="Care contacts">
+            {doctors.length ? (
+              <div className="space-y-2">
+                {doctors.slice(0, 3).map((doctor) => (
+                  <div key={doctor.id} className="rounded-xl border border-slate-200 p-3 text-sm">
+                    <p className="font-bold text-slate-950">{doctor.name}</p>
+                    <p className="text-slate-700">{doctor.specialty ?? "General care"}{doctor.clinic ? ` • ${doctor.clinic}` : ""}</p>
+                    <p className="text-slate-600">{doctor.phone ?? doctor.email ?? "No contact listed"}</p>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-slate-600">No doctors documented.</p>
+            )}
+          </PrintSection>
+
+          <PrintSection title="Triage warnings">
+            <div className="space-y-2">
+              {criticalProfileItems.map((item) => (
+                <div key={item} className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm font-semibold text-amber-800">{item}</div>
+              ))}
+              {severeSymptoms.map((symptom) => (
+                <div key={symptom.id} className="rounded-xl border border-red-200 bg-red-50 p-3 text-sm font-semibold text-red-800">
+                  Severe symptom: {symptom.title} • started {formatDate(symptom.startedAt)}
+                </div>
+              ))}
+              {!criticalProfileItems.length && !severeSymptoms.length ? <p className="text-sm text-slate-600">No triage warnings detected from current records.</p> : null}
+            </div>
+          </PrintSection>
+        </div>
+
+        {profile?.notes ? (
+          <PrintSection title="Care notes">
+            <p className="whitespace-pre-line text-sm text-slate-700">{profile.notes}</p>
+          </PrintSection>
+        ) : null}
+
+        <footer className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-xs text-slate-500 print:rounded-none">
+          This emergency card is generated from VitaVault records. It is a patient-provided snapshot and should be verified with a licensed clinician during medical care.
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/components/emergency-card-actions.tsx
+++ b/components/emergency-card-actions.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import Link from "next/link";
+import { Download, Printer } from "lucide-react";
+import { Button } from "@/components/ui";
+
+export function EmergencyCardActions() {
+  return (
+    <div className="flex flex-wrap gap-3">
+      <Button type="button" onClick={() => window.print()}>
+        <Printer className="h-4 w-4" />
+        Print current page
+      </Button>
+      <Link
+        href="/emergency-card/print?autoprint=1"
+        className="inline-flex h-10 items-center justify-center gap-2 rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium transition-all hover:bg-muted/60"
+      >
+        <Download className="h-4 w-4" />
+        Open print card
+      </Link>
+    </div>
+  );
+}

--- a/docs/PATCH_08_EMERGENCY_HEALTH_CARD.md
+++ b/docs/PATCH_08_EMERGENCY_HEALTH_CARD.md
@@ -1,0 +1,26 @@
+# Patch 08 — Printable Emergency Health Card
+
+## Summary
+
+This patch adds a dedicated emergency health card workflow for VitaVault. The card pulls from existing records and presents the most important triage details in a print-friendly format.
+
+## Added
+
+- `/emergency-card` protected workspace page
+- `/emergency-card/print` print-ready emergency card route
+- Patient identity, blood type, allergies, chronic conditions, emergency contact, active medications, doctors, latest vitals, severe symptoms, and triage warnings
+- Browser print and auto-print support
+- Sidebar navigation entry for Emergency Card
+- Shared emergency card data layer
+
+## Technical notes
+
+- No Prisma migration is required.
+- Data comes from existing `HealthProfile`, `Medication`, `Doctor`, `VitalRecord`, and `SymptomEntry` records.
+- The print route supports `/emergency-card/print?autoprint=1`.
+
+## Manual test routes
+
+- `/emergency-card`
+- `/emergency-card/print`
+- `/emergency-card/print?autoprint=1`

--- a/lib/app-routes.ts
+++ b/lib/app-routes.ts
@@ -10,6 +10,7 @@ import {
   LayoutDashboard,
   ClipboardCheck,
   Pill,
+  ShieldAlert,
   ShieldPlus,
   ShieldCheck,
   Smartphone,
@@ -39,6 +40,12 @@ export const primaryRoutes: AppRouteItem[] = [
     href: "/onboarding",
     description: "Guided first-run health setup",
     icon: ClipboardCheck,
+  },
+  {
+    title: "Emergency Card",
+    href: "/emergency-card",
+    description: "Printable critical care card",
+    icon: ShieldAlert,
   },
   {
     title: "AI Insights",
@@ -125,11 +132,11 @@ export const primaryRoutes: AppRouteItem[] = [
     icon: FileBarChart2,
   },
   {
-  title: "Reminders",
-  href: "/reminders",
-  description: "In-app reminder center for due and overdue tasks",
-  icon: BellRing,
-},
+    title: "Reminders",
+    href: "/reminders",
+    description: "In-app reminder center for due and overdue tasks",
+    icon: BellRing,
+  },
 ];
 
 export const utilityRoutes: AppRouteItem[] = [

--- a/lib/emergency-card.ts
+++ b/lib/emergency-card.ts
@@ -1,0 +1,78 @@
+import { db } from "@/lib/db";
+
+export async function getEmergencyCardData(userId: string) {
+  const [user, profile, medications, doctors, latestVitals, severeSymptoms] = await Promise.all([
+    db.user.findUnique({
+      where: { id: userId },
+      select: { id: true, name: true, email: true },
+    }),
+    db.healthProfile.findUnique({
+      where: { userId },
+    }),
+    db.medication.findMany({
+      where: { userId, status: "ACTIVE", active: true },
+      orderBy: [{ updatedAt: "desc" }, { name: "asc" }],
+      take: 8,
+      include: {
+        doctor: {
+          select: {
+            name: true,
+            specialty: true,
+            phone: true,
+          },
+        },
+      },
+    }),
+    db.doctor.findMany({
+      where: { userId },
+      orderBy: [{ updatedAt: "desc" }, { name: "asc" }],
+      take: 4,
+      select: {
+        id: true,
+        name: true,
+        specialty: true,
+        clinic: true,
+        phone: true,
+        email: true,
+      },
+    }),
+    db.vitalRecord.findFirst({
+      where: { userId },
+      orderBy: { recordedAt: "desc" },
+    }),
+    db.symptomEntry.findMany({
+      where: { userId, resolved: false, severity: "SEVERE" },
+      orderBy: { startedAt: "desc" },
+      take: 5,
+      select: {
+        id: true,
+        title: true,
+        severity: true,
+        startedAt: true,
+        bodyArea: true,
+      },
+    }),
+  ]);
+
+  const patientName = profile?.fullName ?? user?.name ?? user?.email ?? "VitaVault patient";
+  const criticalProfileItems = [
+    profile?.allergiesSummary ? null : "Allergies not documented",
+    profile?.emergencyContactName && profile.emergencyContactPhone ? null : "Emergency contact incomplete",
+    profile?.bloodType ? null : "Blood type not documented",
+    medications.length ? null : "No active medications listed",
+  ].filter(Boolean) as string[];
+
+  return {
+    generatedAt: new Date(),
+    user,
+    profile,
+    patientName,
+    medications,
+    doctors,
+    latestVitals,
+    severeSymptoms,
+    criticalProfileItems,
+  };
+}
+
+export type EmergencyCardData = Awaited<ReturnType<typeof getEmergencyCardData>>;


### PR DESCRIPTION
This PR adds a printable emergency health card workflow to VitaVault.

Changes:
- Adds a protected /emergency-card page
- Adds a print-ready /emergency-card/print route
- Adds auto-print support through /emergency-card/print?autoprint=1
- Shows patient identity, blood type, allergies, chronic conditions, emergency contact, active medications, care contacts, latest vitals, and severe symptom warnings
- Adds card readiness warnings for missing emergency details
- Adds Emergency Card to the sidebar navigation
- Adds a shared emergency-card data layer
- Reuses existing schema models, so no Prisma migration is required