### PR TITLE
Upgrade document intelligence hub

### DIFF
--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -1,22 +1,45 @@
-import { FileText, Link2, PencilLine, Trash2, UploadCloud } from "lucide-react";
+import {
+  AlertTriangle,
+  Archive,
+  CheckCircle2,
+  FileSearch,
+  FileText,
+  Filter,
+  Link2,
+  PencilLine,
+  Search,
+  ShieldCheck,
+  Sparkles,
+  Trash2,
+  UploadCloud,
+} from "lucide-react";
 import { AppShell } from "@/components/app-shell";
-import { PageHeader, EmptyState } from "@/components/common";
+import { EmptyState, PageHeader, StatusPill } from "@/components/common";
 import { deleteDocument, updateDocumentMetadata, uploadDocument } from "@/app/actions";
 import { requireUser } from "@/lib/session";
 import { db } from "@/lib/db";
-import {
-  Badge,
-  Button,
-  Input,
-  Label,
-  Select,
-  Textarea,
-} from "@/components/ui";
+import { Badge, Button, Card, CardContent, CardHeader, CardTitle, Input, Label, Select, Textarea } from "@/components/ui";
 import { formatDateTime } from "@/lib/utils";
-import { ModuleFormCard, ModuleHero, ModuleListCard, DataCard } from "@/components/module-sections";
+import { DataCard, ModuleFormCard, ModuleHero, ModuleListCard } from "@/components/module-sections";
 import { PageTransition, StaggerGroup, StaggerItem } from "@/components/page-transition";
 import { getFocusedCardClass } from "@/lib/record-focus";
 import { getDocumentLinkSummary, serializeDocumentLinkKey } from "@/lib/document-links";
+import {
+  DOCUMENT_FILTERS,
+  DOCUMENT_TYPE_LABELS,
+  buildDocumentHub,
+  filterDocumentsForHub,
+  parseDocumentHubFilters,
+} from "@/lib/document-hub";
+
+const documentTypeOptions = [
+  { value: "LAB_RESULT", label: "Lab Result" },
+  { value: "PRESCRIPTION", label: "Prescription" },
+  { value: "SCAN", label: "Imaging / Scan" },
+  { value: "DISCHARGE_SUMMARY", label: "Discharge Summary" },
+  { value: "CERTIFICATE", label: "Consult Note / Certificate" },
+  { value: "OTHER", label: "Other" },
+] as const;
 
 export default async function DocumentsPage({
   searchParams,
@@ -26,6 +49,7 @@ export default async function DocumentsPage({
   const user = await requireUser();
   const params = (await searchParams) ?? {};
   const focus = typeof params.focus === "string" ? params.focus : undefined;
+  const filters = parseDocumentHubFilters(params);
 
   const [documents, appointments, labs, doctors] = await Promise.all([
     db.medicalDocument.findMany({
@@ -52,10 +76,11 @@ export default async function DocumentsPage({
     }),
   ]);
 
+  const hub = buildDocumentHub(documents);
+  const visibleDocuments = filterDocumentsForHub(documents, filters);
   const latest = documents[0] ?? null;
-  const linkedCount = documents.filter((document) => document.linkedRecordType && document.linkedRecordId).length;
   const linkSummaries = await Promise.all(
-    documents.map(async (document) => [
+    visibleDocuments.map(async (document) => [
       document.id,
       await getDocumentLinkSummary(user.id, document.linkedRecordType, document.linkedRecordId),
     ] as const)
@@ -68,11 +93,12 @@ export default async function DocumentsPage({
         <PageTransition>
           <PageHeader
             title="Documents"
-            description="Upload reports, scans, and supporting clinical files so your workspace remains complete."
+            description="A protected medical file hub for uploads, linked clinical context, review readiness, and secure handoff preparation."
             action={
               <div className="flex flex-wrap gap-2">
                 <Badge className="bg-background/70">{documents.length} files</Badge>
-                <Badge className="bg-background/70">{linkedCount} linked</Badge>
+                <Badge className="bg-background/70">{hub.linkedCount} linked</Badge>
+                <Badge className="bg-background/70">{hub.readinessScore}% ready</Badge>
                 <Badge className="bg-background/70">
                   {latest ? `Latest: ${formatDateTime(latest.createdAt)}` : "No uploads yet"}
                 </Badge>
@@ -83,19 +109,177 @@ export default async function DocumentsPage({
 
         <PageTransition delay={0.04}>
           <ModuleHero
-            eyebrow="Medical files"
-            title="Structured clinical document storage"
-            description="Keep source files organized so appointments, labs, doctors, and care-team review become easier."
+            eyebrow="Document intelligence"
+            title="Turn uploaded files into review-ready clinical context"
+            description="VitaVault now surfaces document quality, linking coverage, review gaps, and quick filters so the file library feels like a real health-record workspace instead of a static upload folder."
             stats={[
               { label: "Stored files", value: documents.length },
-              { label: "Linked records", value: linkedCount },
-              { label: "Access mode", value: "Protected delivery" },
-              { label: "Latest upload", value: latest ? latest.title : "—" },
+              { label: "Linked records", value: hub.linkedCount, hint: `${hub.unlinkedCount} still unlinked` },
+              { label: "Readiness", value: `${hub.readinessScore}%`, hint: hub.readinessLabel },
+              { label: "Review items", value: hub.reviewItems.length },
             ]}
           />
         </PageTransition>
 
-        <StaggerGroup delay={0.08}>
+        <PageTransition delay={0.06}>
+          <div className="grid gap-4 lg:grid-cols-4">
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center gap-2 text-sm">
+                  <ShieldCheck className="h-4 w-4 text-primary" /> Protected delivery
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-2xl font-semibold">Secure</p>
+                <p className="mt-1 text-xs text-muted-foreground">Files are served through protected download routes.</p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center gap-2 text-sm">
+                  <Link2 className="h-4 w-4 text-primary" /> Link coverage
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-2xl font-semibold">{hub.linkCoverage}%</p>
+                <p className="mt-1 text-xs text-muted-foreground">Documents connected to appointments, labs, or doctors.</p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center gap-2 text-sm">
+                  <FileSearch className="h-4 w-4 text-primary" /> Notes coverage
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-2xl font-semibold">{hub.notesCoverage}%</p>
+                <p className="mt-1 text-xs text-muted-foreground">Files with usable context notes.</p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center gap-2 text-sm">
+                  <Archive className="h-4 w-4 text-primary" /> Storage footprint
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-2xl font-semibold">{hub.totalSizeLabel}</p>
+                <p className="mt-1 text-xs text-muted-foreground">Across all stored medical files.</p>
+              </CardContent>
+            </Card>
+          </div>
+        </PageTransition>
+
+        <PageTransition delay={0.08}>
+          <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Sparkles className="h-5 w-5 text-primary" /> Review readiness
+                </CardTitle>
+                <p className="text-sm text-muted-foreground">
+                  These checks help make uploaded documents easier to understand during doctor visits, caregiver review, and export preparation.
+                </p>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {hub.reviewItems.length ? (
+                  hub.reviewItems.map((item) => (
+                    <div key={item.title} className="rounded-2xl border border-border/60 bg-background/40 p-4">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <div className="flex items-center gap-2">
+                          {item.tone === "success" ? (
+                            <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+                          ) : (
+                            <AlertTriangle className="h-4 w-4 text-amber-500" />
+                          )}
+                          <p className="font-medium">{item.title}</p>
+                        </div>
+                        <StatusPill tone={item.tone}>{item.status}</StatusPill>
+                      </div>
+                      <p className="mt-2 text-sm text-muted-foreground">{item.description}</p>
+                    </div>
+                  ))
+                ) : (
+                  <EmptyState title="No review gaps" description="Your document library has strong linking and note coverage." />
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Filter className="h-5 w-5 text-primary" /> Library filters
+                </CardTitle>
+                <p className="text-sm text-muted-foreground">Search by title, filename, notes, type, link status, and readiness quality.</p>
+              </CardHeader>
+              <CardContent>
+                <form className="grid gap-4" action="/documents">
+                  <div className="space-y-2">
+                    <Label>Search</Label>
+                    <div className="relative">
+                      <Search className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
+                      <Input name="q" defaultValue={filters.q} className="pl-9" placeholder="Find prescriptions, labs, scans, notes..." />
+                    </div>
+                  </div>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div className="space-y-2">
+                      <Label>Type</Label>
+                      <Select name="type" defaultValue={filters.type}>
+                        <option value="ALL">All types</option>
+                        {documentTypeOptions.map((type) => (
+                          <option key={type.value} value={type.value}>{type.label}</option>
+                        ))}
+                      </Select>
+                    </div>
+                    <div className="space-y-2">
+                      <Label>Link status</Label>
+                      <Select name="link" defaultValue={filters.link}>
+                        <option value="ALL">All documents</option>
+                        <option value="LINKED">Linked only</option>
+                        <option value="UNLINKED">Unlinked only</option>
+                      </Select>
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Readiness</Label>
+                    <Select name="quality" defaultValue={filters.quality}>
+                      {DOCUMENT_FILTERS.quality.map((item) => (
+                        <option key={item.value} value={item.value}>{item.label}</option>
+                      ))}
+                    </Select>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Button type="submit">Apply filters</Button>
+                    <a className="inline-flex h-10 items-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium" href="/documents">
+                      Reset
+                    </a>
+                  </div>
+                </form>
+              </CardContent>
+            </Card>
+          </div>
+        </PageTransition>
+
+        <PageTransition delay={0.1}>
+          <Card>
+            <CardHeader>
+              <CardTitle>Document mix</CardTitle>
+              <p className="text-sm text-muted-foreground">A quick breakdown of the records stored in the library.</p>
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+                {hub.typeBreakdown.map((type) => (
+                  <div key={type.type} className="rounded-2xl border border-border/60 bg-background/40 p-4">
+                    <p className="text-xs font-medium text-muted-foreground">{type.label}</p>
+                    <p className="mt-1 text-2xl font-semibold">{type.count}</p>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </PageTransition>
+
+        <StaggerGroup delay={0.12}>
           <div className="grid gap-6 xl:grid-cols-[1.02fr_1.48fr]">
             <StaggerItem>
               <ModuleFormCard
@@ -111,12 +295,9 @@ export default async function DocumentsPage({
                   <div className="space-y-2">
                     <Label>Type</Label>
                     <Select name="type" defaultValue="OTHER">
-                      <option value="LAB_RESULT">Lab Result</option>
-                      <option value="PRESCRIPTION">Prescription</option>
-                      <option value="SCAN">Imaging / Scan</option>
-                      <option value="DISCHARGE_SUMMARY">Discharge Summary</option>
-                      <option value="CERTIFICATE">Consult Note / Certificate</option>
-                      <option value="OTHER">Other</option>
+                      {documentTypeOptions.map((type) => (
+                        <option key={type.value} value={type.value}>{type.label}</option>
+                      ))}
                     </Select>
                   </div>
 
@@ -179,12 +360,14 @@ export default async function DocumentsPage({
             <StaggerItem>
               <ModuleListCard
                 title="Document library"
-                description="Review uploaded files, linked context, and open the source record when needed."
+                description={`${visibleDocuments.length} of ${documents.length} documents shown with linked context and review signals.`}
               >
                 <div className="space-y-4">
-                  {documents.length ? (
-                    documents.map((document) => {
+                  {visibleDocuments.length ? (
+                    visibleDocuments.map((document) => {
                       const linked = linkMap.get(document.id) ?? null;
+                      const hasNotes = Boolean(document.notes?.trim());
+                      const hasLink = Boolean(document.linkedRecordType && document.linkedRecordId);
 
                       return (
                         <DataCard
@@ -199,7 +382,11 @@ export default async function DocumentsPage({
                                 Uploaded: {formatDateTime(document.createdAt)}
                               </p>
                             </div>
-                            <Badge className="bg-background/70">{document.type}</Badge>
+                            <div className="flex flex-wrap gap-2">
+                              <Badge className="bg-background/70">{DOCUMENT_TYPE_LABELS[document.type]}</Badge>
+                              <StatusPill tone={hasLink ? "success" : "warning"}>{hasLink ? "Linked" : "Needs link"}</StatusPill>
+                              <StatusPill tone={hasNotes ? "success" : "neutral"}>{hasNotes ? "Notes added" : "No notes"}</StatusPill>
+                            </div>
                           </div>
 
                           {linked ? (
@@ -216,7 +403,14 @@ export default async function DocumentsPage({
                               </div>
                               <p className="mt-2 text-sm text-muted-foreground">{linked.meta}</p>
                             </div>
-                          ) : null}
+                          ) : (
+                            <div className="mt-4 rounded-2xl border border-amber-200/70 bg-amber-50/50 p-4 text-sm dark:border-amber-900/50 dark:bg-amber-950/20">
+                              <p className="font-medium text-amber-800 dark:text-amber-200">Suggested next step</p>
+                              <p className="mt-1 text-amber-700 dark:text-amber-300">
+                                Link this file to an appointment, lab result, or doctor so it appears with better clinical context.
+                              </p>
+                            </div>
+                          )}
 
                           <div className="mt-4 rounded-2xl border border-border/60 bg-background/40 p-4">
                             <div className="flex items-center gap-2">
@@ -224,7 +418,7 @@ export default async function DocumentsPage({
                               <p className="text-sm font-medium">Notes</p>
                             </div>
                             <p className="mt-2 text-sm text-muted-foreground">
-                              {document.notes ?? "No notes added."}
+                              {document.notes ?? "No notes added. Add context so this document is easier to review later."}
                             </p>
                           </div>
 
@@ -232,6 +426,7 @@ export default async function DocumentsPage({
                             {document.fileName ? (
                               <Badge className="bg-background/70">{document.fileName}</Badge>
                             ) : null}
+                            <Badge className="bg-background/70">{Math.max(1, Math.round(document.sizeBytes / 1024))} KB</Badge>
 
                             {document.filePath ? (
                               <a
@@ -263,12 +458,9 @@ export default async function DocumentsPage({
                                 <div className="space-y-2">
                                   <Label>Type</Label>
                                   <Select name="type" defaultValue={document.type}>
-                                    <option value="LAB_RESULT">Lab Result</option>
-                                    <option value="PRESCRIPTION">Prescription</option>
-                                    <option value="SCAN">Imaging / Scan</option>
-                                    <option value="DISCHARGE_SUMMARY">Discharge Summary</option>
-                                    <option value="CERTIFICATE">Consult Note / Certificate</option>
-                                    <option value="OTHER">Other</option>
+                                    {documentTypeOptions.map((type) => (
+                                      <option key={type.value} value={type.value}>{type.label}</option>
+                                    ))}
                                   </Select>
                                 </div>
 
@@ -331,11 +523,10 @@ export default async function DocumentsPage({
                         </DataCard>
                       );
                     })
+                  ) : documents.length ? (
+                    <EmptyState title="No documents match these filters" description="Reset filters or search for another title, type, file name, or note." />
                   ) : (
-                    <EmptyState
-                      title="No documents yet"
-                      description="Upload a medical file to begin building your document library."
-                    />
+                    <EmptyState title="No documents yet" description="Upload a medical file to begin building your document library." />
                   )}
                 </div>
               </ModuleListCard>

--- a/docs/PATCH_09_DOCUMENT_INTELLIGENCE_HUB.md
+++ b/docs/PATCH_09_DOCUMENT_INTELLIGENCE_HUB.md
@@ -1,0 +1,46 @@
+# Patch 09 — Document Intelligence Hub
+
+## Summary
+
+This patch upgrades the Documents module from a basic protected upload list into a stronger health-record document hub.
+
+The feature is intentionally schema-safe. It uses the existing `MedicalDocument` fields, existing document upload actions, existing linked-record metadata, and existing protected download route.
+
+## Added
+
+- Document intelligence command center
+- Readiness score for uploaded documents
+- Link coverage metric
+- Notes coverage metric
+- Storage footprint summary
+- Review readiness panel
+- Document type breakdown
+- Search and filtering by title, file name, notes, type, link status, and readiness
+- Linked/unlinked status pills on each document
+- Notes coverage status pills on each document
+- Suggested next-step panel for unlinked files
+- Shared `lib/document-hub.ts` helper layer
+
+## Changed
+
+- `app/documents/page.tsx` now includes a richer document hub UI while preserving existing upload, metadata edit, linked-record selection, secure file download, and delete functionality.
+
+## No migration required
+
+This patch does not add or change Prisma models. It reuses the existing `MedicalDocument` fields.
+
+## Manual test routes
+
+- `/documents`
+- `/documents?q=lab`
+- `/documents?link=UNLINKED`
+- `/documents?quality=NEEDS_NOTES`
+- `/documents?quality=READY`
+
+## Recommended checks
+
+```bash
+npm run typecheck
+npm run lint
+npm run test:run
+```

--- a/lib/document-hub.ts
+++ b/lib/document-hub.ts
@@ -1,0 +1,187 @@
+import { type DocumentType, type MedicalDocument } from "@prisma/client";
+
+export const DOCUMENT_TYPE_LABELS: Record<DocumentType, string> = {
+  PRESCRIPTION: "Prescription",
+  LAB_RESULT: "Lab Result",
+  DISCHARGE_SUMMARY: "Discharge Summary",
+  CERTIFICATE: "Consult Note / Certificate",
+  SCAN: "Imaging / Scan",
+  OTHER: "Other",
+};
+
+const DOCUMENT_TYPE_ORDER: DocumentType[] = [
+  "PRESCRIPTION",
+  "LAB_RESULT",
+  "SCAN",
+  "DISCHARGE_SUMMARY",
+  "CERTIFICATE",
+  "OTHER",
+];
+
+export type DocumentHubFilterState = {
+  q: string;
+  type: DocumentType | "ALL";
+  link: "ALL" | "LINKED" | "UNLINKED";
+  quality: "ALL" | "NEEDS_NOTES" | "NEEDS_LINK" | "READY";
+};
+
+export const DOCUMENT_FILTERS = {
+  quality: [
+    { value: "ALL", label: "All readiness states" },
+    { value: "READY", label: "Ready / linked with notes" },
+    { value: "NEEDS_LINK", label: "Needs linked record" },
+    { value: "NEEDS_NOTES", label: "Needs notes" },
+  ] satisfies Array<{ value: DocumentHubFilterState["quality"]; label: string }>,
+};
+
+type HubDocument = Pick<
+  MedicalDocument,
+  | "id"
+  | "title"
+  | "type"
+  | "fileName"
+  | "mimeType"
+  | "sizeBytes"
+  | "notes"
+  | "linkedRecordType"
+  | "linkedRecordId"
+  | "createdAt"
+>;
+
+export function parseDocumentHubFilters(
+  params: Record<string, string | string[] | undefined>
+): DocumentHubFilterState {
+  const q = valueOf(params.q);
+  const type = parseDocumentType(valueOf(params.type));
+  const link = parseOneOf(valueOf(params.link), ["ALL", "LINKED", "UNLINKED"] as const, "ALL");
+  const quality = parseOneOf(
+    valueOf(params.quality),
+    ["ALL", "NEEDS_NOTES", "NEEDS_LINK", "READY"] as const,
+    "ALL"
+  );
+
+  return { q, type, link, quality };
+}
+
+export function filterDocumentsForHub<T extends HubDocument>(
+  documents: T[],
+  filters: DocumentHubFilterState
+): T[] {
+  const q = filters.q.toLowerCase();
+
+  return documents.filter((document) => {
+    const hasLink = Boolean(document.linkedRecordType && document.linkedRecordId);
+    const hasNotes = Boolean(document.notes?.trim());
+
+    if (filters.type !== "ALL" && document.type !== filters.type) return false;
+    if (filters.link === "LINKED" && !hasLink) return false;
+    if (filters.link === "UNLINKED" && hasLink) return false;
+    if (filters.quality === "READY" && (!hasLink || !hasNotes)) return false;
+    if (filters.quality === "NEEDS_LINK" && hasLink) return false;
+    if (filters.quality === "NEEDS_NOTES" && hasNotes) return false;
+
+    if (!q) return true;
+
+    const haystack = [
+      document.title,
+      document.fileName,
+      document.mimeType,
+      document.notes ?? "",
+      DOCUMENT_TYPE_LABELS[document.type],
+      document.linkedRecordType ?? "",
+    ]
+      .join(" ")
+      .toLowerCase();
+
+    return haystack.includes(q);
+  });
+}
+
+export function buildDocumentHub(documents: HubDocument[]) {
+  const total = documents.length;
+  const linkedCount = documents.filter((document) => document.linkedRecordType && document.linkedRecordId).length;
+  const unlinkedCount = total - linkedCount;
+  const notesCount = documents.filter((document) => document.notes?.trim()).length;
+  const totalSizeBytes = documents.reduce((sum, document) => sum + document.sizeBytes, 0);
+  const readyCount = documents.filter(
+    (document) => document.notes?.trim() && document.linkedRecordType && document.linkedRecordId
+  ).length;
+
+  const linkCoverage = percentage(linkedCount, total);
+  const notesCoverage = percentage(notesCount, total);
+  const readinessScore = percentage(readyCount, total);
+
+  const typeBreakdown = DOCUMENT_TYPE_ORDER.map((type) => ({
+    type,
+    label: DOCUMENT_TYPE_LABELS[type],
+    count: documents.filter((document) => document.type === type).length,
+  }));
+
+  const reviewItems = [
+    {
+      title: "Linked clinical context",
+      description:
+        unlinkedCount === 0
+          ? "Every document is connected to a source record."
+          : `${unlinkedCount} document${unlinkedCount === 1 ? "" : "s"} should be linked to an appointment, lab, or doctor.`,
+      status: unlinkedCount === 0 ? "Ready" : "Needs review",
+      tone: unlinkedCount === 0 ? "success" : "warning",
+    },
+    {
+      title: "Reviewer notes",
+      description:
+        notesCount === total
+          ? "Every document has notes for future context."
+          : `${Math.max(total - notesCount, 0)} document${total - notesCount === 1 ? "" : "s"} still need notes.`,
+      status: notesCount === total ? "Ready" : "Needs notes",
+      tone: notesCount === total ? "success" : "warning",
+    },
+    {
+      title: "Protected source files",
+      description:
+        total === 0
+          ? "Upload a document to start the protected library."
+          : "Uploaded files remain available through protected document download routes.",
+      status: total === 0 ? "Waiting" : "Protected",
+      tone: total === 0 ? "neutral" : "success",
+    },
+  ] as const;
+
+  return {
+    total,
+    linkedCount,
+    unlinkedCount,
+    notesCount,
+    readyCount,
+    linkCoverage,
+    notesCoverage,
+    readinessScore,
+    readinessLabel: readinessScore >= 80 ? "Review-ready" : readinessScore >= 40 ? "Improving" : "Needs cleanup",
+    totalSizeLabel: formatBytes(totalSizeBytes),
+    typeBreakdown,
+    reviewItems,
+  };
+}
+
+function valueOf(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0]?.trim() ?? "" : value?.trim() ?? "";
+}
+
+function parseDocumentType(value: string): DocumentHubFilterState["type"] {
+  return DOCUMENT_TYPE_ORDER.includes(value as DocumentType) ? (value as DocumentType) : "ALL";
+}
+
+function parseOneOf<const T extends readonly string[]>(value: string, allowed: T, fallback: T[number]): T[number] {
+  return (allowed as readonly string[]).includes(value) ? (value as T[number]) : fallback;
+}
+
+function percentage(value: number, total: number) {
+  if (!total) return 0;
+  return Math.round((value / total) * 100);
+}
+
+function formatBytes(bytes: number) {
+  if (bytes <= 0) return "0 KB";
+  if (bytes < 1024 * 1024) return `${Math.max(1, Math.round(bytes / 1024))} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}


### PR DESCRIPTION
This PR upgrades VitaVault's Documents module into a stronger document intelligence hub.

Changes:
- Adds document readiness scoring
- Adds link coverage and notes coverage metrics
- Adds storage footprint summary
- Adds review readiness checks
- Adds document type breakdown
- Adds search and filters for title, file name, notes, type, link status, and readiness
- Adds linked/unlinked and notes coverage status pills
- Adds suggested next-step messaging for unlinked files
- Adds a shared document hub helper layer
- Preserves existing upload, metadata edit, linked-record selection, secure download, and delete workflows
- Requires no Prisma migration