### PR TITLE
Fix admin CI lint and typecheck issues

### DIFF
--- a/docs/PATCH_11D_ADMIN_CI_LINT_FIX.md
+++ b/docs/PATCH_11D_ADMIN_CI_LINT_FIX.md
@@ -1,0 +1,26 @@
+# Patch 11D — Admin CI Lint + Typecheck Fix
+
+This hotfix stabilizes the Patch 11 admin command center for CI.
+
+## Fixes
+
+- Restores the `ClipboardList` icon import used by the admin polish card.
+- Restores the `AuditCard` helper used by the admin audit feed.
+- Restores the admin dashboard data helper where `sevenDaysAgo` and `verificationRate` are actively used.
+- Includes the admin server actions file required by `app/admin/page.tsx`.
+
+## Files changed
+
+- `app/admin/page.tsx`
+- `app/admin/actions.ts`
+- `lib/admin-dashboard.ts`
+
+## Validation
+
+Run:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:run
+```


### PR DESCRIPTION
This PR stabilizes the Patch 11 admin command center after CI detected a mixed admin file state.

Changes:
- Restores the ClipboardList import used by the admin polish card
- Restores the AuditCard helper used by the admin audit feed
- Restores the admin dashboard helper where sevenDaysAgo and verificationRate are actively used
- Includes the admin server actions module required by app/admin/page.tsx
- Requires no Prisma migration