### PR TITLE
Add notification center

### DIFF
--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -1,0 +1,225 @@
+import Link from "next/link";
+import {
+  AlertTriangle,
+  BellRing,
+  CalendarClock,
+  ClipboardList,
+  FileText,
+  HeartPulse,
+  Inbox,
+  RadioTower,
+  Users,
+} from "lucide-react";
+import { AppShell } from "@/components/app-shell";
+import { EmptyState, PageHeader, StatusPill } from "@/components/common";
+import { Badge, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
+import { requireUser } from "@/lib/session";
+import {
+  getNotificationCenterData,
+  type NotificationItem,
+  type NotificationPriority,
+  type NotificationSource,
+  type NotificationTone,
+} from "@/lib/notification-center";
+
+const sourceLabels: Record<NotificationSource, string> = {
+  ALERT: "Alerts",
+  REMINDER: "Reminders",
+  APPOINTMENT: "Appointments",
+  LAB: "Labs",
+  DOCUMENT: "Documents",
+  CARE: "Care team",
+  DEVICE: "Devices",
+};
+
+const sourceIcons: Record<NotificationSource, typeof BellRing> = {
+  ALERT: AlertTriangle,
+  REMINDER: BellRing,
+  APPOINTMENT: CalendarClock,
+  LAB: ClipboardList,
+  DOCUMENT: FileText,
+  CARE: Users,
+  DEVICE: RadioTower,
+};
+
+function formatDateTime(value: Date | null | undefined) {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat("en-PH", { dateStyle: "medium", timeStyle: "short" }).format(value);
+}
+
+function priorityTone(priority: NotificationPriority): NotificationTone {
+  if (priority === "critical" || priority === "high") return "danger";
+  if (priority === "medium") return "warning";
+  return "neutral";
+}
+
+function sourceTone(source: NotificationSource): NotificationTone {
+  if (source === "ALERT") return "danger";
+  if (source === "REMINDER") return "warning";
+  if (source === "LAB" || source === "DEVICE") return "info";
+  if (source === "CARE") return "success";
+  return "neutral";
+}
+
+function filterHref(params: Record<string, string | undefined>) {
+  const query = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value && value !== "ALL") query.set(key, value);
+  });
+  const qs = query.toString();
+  return qs ? `/notifications?${qs}` : "/notifications";
+}
+
+function NotificationCard({ item }: { item: NotificationItem }) {
+  const Icon = sourceIcons[item.source];
+
+  return (
+    <Link
+      href={item.href}
+      className="block rounded-3xl border border-border/60 bg-background/50 p-5 transition hover:border-border hover:bg-muted/30"
+    >
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="flex gap-4">
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-border/60 bg-background/70">
+            <Icon className="h-5 w-5 text-primary" />
+          </div>
+          <div className="min-w-0 space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <StatusPill tone={sourceTone(item.source)}>{sourceLabels[item.source]}</StatusPill>
+              <StatusPill tone={priorityTone(item.priority)}>{item.priority}</StatusPill>
+              <Badge>{item.status}</Badge>
+            </div>
+            <div>
+              <h3 className="font-semibold tracking-tight">{item.title}</h3>
+              <p className="mt-1 text-sm leading-6 text-muted-foreground">{item.description}</p>
+            </div>
+          </div>
+        </div>
+        <div className="shrink-0 text-left text-xs text-muted-foreground md:text-right">
+          <p>{item.meta}</p>
+          <p className="mt-1">{formatDateTime(item.dueAt || item.createdAt)}</p>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+function MetricCard({ title, value, description, icon }: { title: string; value: number | string; description: string; icon: React.ReactNode }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardDescription>{title}</CardDescription>
+            <CardTitle className="mt-2 text-3xl">{value}</CardTitle>
+          </div>
+          <div className="rounded-2xl border border-border/60 bg-background/70 p-2">{icon}</div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default async function NotificationsPage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const user = await requireUser();
+  const params = (await searchParams) ?? {};
+  const source = typeof params.source === "string" ? params.source : "ALL";
+  const priority = typeof params.priority === "string" ? params.priority : "ALL";
+  const data = await getNotificationCenterData(user.id!, { source, priority });
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-7xl space-y-6 p-6">
+        <PageHeader
+          title="Notification Center"
+          description="A unified inbox for alerts, reminders, upcoming care tasks, abnormal results, document hygiene, care invites, and device sync issues."
+          action={
+            <div className="flex flex-wrap gap-2">
+              <Link href="/alerts" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium hover:bg-muted/50">Alerts</Link>
+              <Link href="/reminders" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium hover:bg-muted/50">Reminders</Link>
+              <Link href="/dashboard" className="inline-flex h-10 items-center justify-center rounded-2xl bg-primary px-4 text-sm font-medium text-primary-foreground shadow-sm hover:opacity-95">Dashboard</Link>
+            </div>
+          }
+        />
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <MetricCard title="Visible items" value={data.counts.visible} description={`${data.counts.total} total inbox signals before filters.`} icon={<Inbox className="h-5 w-5 text-primary" />} />
+          <MetricCard title="Critical" value={data.counts.critical} description="Critical alert or high-urgency workflow items." icon={<AlertTriangle className="h-5 w-5 text-rose-500" />} />
+          <MetricCard title="High priority" value={data.counts.high} description="Items that should be reviewed before routine updates." icon={<BellRing className="h-5 w-5 text-amber-500" />} />
+          <MetricCard title="Care workload" value={data.counts.medium + data.counts.low} description="Medium and low priority items for normal follow-up." icon={<HeartPulse className="h-5 w-5 text-emerald-500" />} />
+        </div>
+
+        <div className="grid gap-6 xl:grid-cols-[0.85fr_1.15fr]">
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Filters</CardTitle>
+                <CardDescription>Switch between source and priority views without losing the inbox context.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-5">
+                <div>
+                  <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Source</p>
+                  <div className="flex flex-wrap gap-2">
+                    <Link href={filterHref({ source: "ALL", priority })} className="rounded-full border border-border/60 px-3 py-1.5 text-xs font-medium hover:bg-muted/50">All</Link>
+                    {data.counts.bySource.map((row) => (
+                      <Link key={row.source} href={filterHref({ source: row.source, priority })} className="rounded-full border border-border/60 px-3 py-1.5 text-xs font-medium hover:bg-muted/50">
+                        {sourceLabels[row.source]} ({row.count})
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Priority</p>
+                  <div className="flex flex-wrap gap-2">
+                    {(["ALL", "critical", "high", "medium", "low"] as const).map((option) => (
+                      <Link key={option} href={filterHref({ source, priority: option })} className="rounded-full border border-border/60 px-3 py-1.5 text-xs font-medium hover:bg-muted/50">
+                        {option}
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Recommended next actions</CardTitle>
+                <CardDescription>Generated from the current notification workload.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {data.nextActions.map((action) => (
+                  <div key={action} className="rounded-2xl border border-border/60 bg-background/50 p-4 text-sm text-muted-foreground">
+                    {action}
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          </div>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Unified inbox</CardTitle>
+              <CardDescription>
+                {source !== "ALL" || priority !== "ALL"
+                  ? `Filtered by source ${source} and priority ${priority}.`
+                  : "Sorted by priority first, then by the most relevant date."}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {data.items.map((item) => <NotificationCard key={item.id} item={item} />)}
+              {data.items.length === 0 ? <EmptyState title="Inbox is clear" description="No alerts, reminders, follow-ups, document gaps, care invites, or device issues match the current filter." /> : null}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </AppShell>
+  );
+}

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -146,7 +146,7 @@ export function AppShell({ children }: AppShellProps) {
     const pick = (hrefs: string[]) =>
       hrefs.map((h) => routeMap.get(h)).filter(Boolean) as AppRouteItem[];
 
-    const overview = pick(["/dashboard", "/onboarding"]);
+    const overview = pick(["/dashboard", "/onboarding", "/notifications"]);
     const collaboration = pick([
       "/ai-insights",
       "/care-team",
@@ -158,6 +158,8 @@ export function AppShell({ children }: AppShellProps) {
       (r) =>
         ![
           "/dashboard",
+          "/onboarding",
+          "/notifications",
           "/ai-insights",
           "/care-team",
           "/alerts",

--- a/docs/PATCH_12_NOTIFICATION_CENTER.md
+++ b/docs/PATCH_12_NOTIFICATION_CENTER.md
@@ -1,0 +1,59 @@
+# Patch 12 — Notification Center
+
+## Summary
+
+This patch adds a protected Notification Center that works as a unified inbox for VitaVault care signals.
+
+## Files changed
+
+- `app/notifications/page.tsx`
+- `lib/notification-center.ts`
+- `lib/app-routes.ts`
+- `components/app-shell.tsx`
+
+## What was added
+
+- New `/notifications` route
+- Unified inbox for:
+  - open and acknowledged alerts
+  - due, sent, overdue, and missed reminders
+  - upcoming appointments in the next 14 days
+  - abnormal and borderline labs
+  - unlinked or under-documented medical documents
+  - pending care-team invites
+  - stale, disconnected, or errored device connections
+- Priority scoring:
+  - critical
+  - high
+  - medium
+  - low
+- Source filtering
+- Priority filtering
+- Summary cards for visible items, critical items, high-priority items, and care workload
+- Recommended next-action panel
+- Sidebar navigation entry
+
+## Implementation notes
+
+- No Prisma migration is required.
+- The patch only reads existing models.
+- It intentionally avoids schema changes, background workers, or destructive notification acknowledgement actions.
+- The route links back to the existing source workflows instead of creating duplicate state.
+
+## Manual checks
+
+Visit:
+
+- `/notifications`
+- `/notifications?source=ALERT`
+- `/notifications?source=REMINDER`
+- `/notifications?priority=high`
+- `/notifications?priority=medium`
+
+Run:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:run
+```

--- a/lib/app-routes.ts
+++ b/lib/app-routes.ts
@@ -3,6 +3,7 @@ import {
   Activity,
   BellRing,
   CalendarClock,
+  Inbox,
   ClipboardList,
   FileBarChart2,
   FileHeart,
@@ -40,6 +41,12 @@ export const primaryRoutes: AppRouteItem[] = [
     href: "/onboarding",
     description: "Guided first-run health setup",
     icon: ClipboardCheck,
+  },
+  {
+    title: "Notification Center",
+    href: "/notifications",
+    description: "Unified inbox for alerts, reminders, records, and care updates",
+    icon: Inbox,
   },
   {
     title: "Emergency Card",

--- a/lib/notification-center.ts
+++ b/lib/notification-center.ts
@@ -1,0 +1,360 @@
+import {
+  AlertSeverity,
+  AlertStatus,
+  AppointmentStatus,
+  CareAccessStatus,
+  DeviceConnectionStatus,
+  LabFlag,
+  ReminderState,
+} from "@prisma/client";
+import { db } from "@/lib/db";
+
+export type NotificationPriority = "critical" | "high" | "medium" | "low";
+export type NotificationTone = "danger" | "warning" | "info" | "success" | "neutral";
+export type NotificationSource =
+  | "ALERT"
+  | "REMINDER"
+  | "APPOINTMENT"
+  | "LAB"
+  | "DOCUMENT"
+  | "CARE"
+  | "DEVICE";
+
+export type NotificationItem = {
+  id: string;
+  source: NotificationSource;
+  title: string;
+  description: string;
+  priority: NotificationPriority;
+  tone: NotificationTone;
+  href: string;
+  createdAt: Date;
+  dueAt?: Date | null;
+  status: string;
+  meta: string;
+};
+
+export type NotificationCenterFilters = {
+  source?: string;
+  priority?: string;
+};
+
+function addDays(date: Date, days: number) {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+function startOfToday() {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return today;
+}
+
+function priorityScore(priority: NotificationPriority) {
+  if (priority === "critical") return 4;
+  if (priority === "high") return 3;
+  if (priority === "medium") return 2;
+  return 1;
+}
+
+function alertPriority(severity: AlertSeverity): NotificationPriority {
+  if (severity === AlertSeverity.CRITICAL) return "critical";
+  if (severity === AlertSeverity.HIGH) return "high";
+  if (severity === AlertSeverity.MEDIUM) return "medium";
+  return "low";
+}
+
+function alertTone(severity: AlertSeverity): NotificationTone {
+  if (severity === AlertSeverity.CRITICAL || severity === AlertSeverity.HIGH) return "danger";
+  if (severity === AlertSeverity.MEDIUM) return "warning";
+  return "info";
+}
+
+function reminderPriority(state: ReminderState, dueAt: Date): NotificationPriority {
+  if (state === ReminderState.OVERDUE || dueAt.getTime() < Date.now()) return "high";
+  if (dueAt.getTime() - Date.now() <= 4 * 60 * 60 * 1000) return "medium";
+  return "low";
+}
+
+function labPriority(flag: LabFlag): NotificationPriority {
+  if (flag === LabFlag.HIGH || flag === LabFlag.LOW) return "high";
+  if (flag === LabFlag.BORDERLINE) return "medium";
+  return "low";
+}
+
+function labTone(flag: LabFlag): NotificationTone {
+  if (flag === LabFlag.HIGH || flag === LabFlag.LOW) return "danger";
+  if (flag === LabFlag.BORDERLINE) return "warning";
+  return "success";
+}
+
+function matchesFilter(item: NotificationItem, filters: NotificationCenterFilters) {
+  const source = filters.source && filters.source !== "ALL" ? filters.source : undefined;
+  const priority = filters.priority && filters.priority !== "ALL" ? filters.priority : undefined;
+
+  if (source && item.source !== source) return false;
+  if (priority && item.priority !== priority) return false;
+  return true;
+}
+
+export async function getNotificationCenterData(userId: string, filters: NotificationCenterFilters = {}) {
+  const now = new Date();
+  const today = startOfToday();
+  const soon = addDays(now, 14);
+  const staleDeviceCutoff = addDays(now, -7);
+
+  const [alerts, reminders, appointments, labs, documents, careInvites, deviceConnections] = await Promise.all([
+    db.alertEvent.findMany({
+      where: { userId, status: { in: [AlertStatus.OPEN, AlertStatus.ACKNOWLEDGED] } },
+      orderBy: { createdAt: "desc" },
+      take: 20,
+      select: {
+        id: true,
+        title: true,
+        message: true,
+        severity: true,
+        status: true,
+        category: true,
+        createdAt: true,
+      },
+    }),
+    db.reminder.findMany({
+      where: {
+        userId,
+        state: { in: [ReminderState.DUE, ReminderState.SENT, ReminderState.OVERDUE, ReminderState.MISSED] },
+        dueAt: { lte: soon },
+      },
+      orderBy: { dueAt: "asc" },
+      take: 20,
+      select: {
+        id: true,
+        title: true,
+        description: true,
+        state: true,
+        type: true,
+        dueAt: true,
+        createdAt: true,
+      },
+    }),
+    db.appointment.findMany({
+      where: {
+        userId,
+        status: AppointmentStatus.UPCOMING,
+        scheduledAt: { gte: today, lte: soon },
+      },
+      orderBy: { scheduledAt: "asc" },
+      take: 12,
+      select: {
+        id: true,
+        purpose: true,
+        doctorName: true,
+        clinic: true,
+        scheduledAt: true,
+        createdAt: true,
+      },
+    }),
+    db.labResult.findMany({
+      where: { userId, flag: { in: [LabFlag.BORDERLINE, LabFlag.HIGH, LabFlag.LOW] } },
+      orderBy: { dateTaken: "desc" },
+      take: 12,
+      select: {
+        id: true,
+        testName: true,
+        resultSummary: true,
+        flag: true,
+        dateTaken: true,
+        createdAt: true,
+      },
+    }),
+    db.medicalDocument.findMany({
+      where: {
+        userId,
+        OR: [{ linkedRecordType: null }, { notes: null }, { notes: "" }],
+      },
+      orderBy: { createdAt: "desc" },
+      take: 12,
+      select: {
+        id: true,
+        title: true,
+        type: true,
+        fileName: true,
+        linkedRecordType: true,
+        notes: true,
+        createdAt: true,
+      },
+    }),
+    db.careInvite.findMany({
+      where: { ownerUserId: userId, status: CareAccessStatus.PENDING },
+      orderBy: { createdAt: "desc" },
+      take: 12,
+      select: {
+        id: true,
+        email: true,
+        accessRole: true,
+        status: true,
+        expiresAt: true,
+        createdAt: true,
+      },
+    }),
+    db.deviceConnection.findMany({
+      where: {
+        userId,
+        OR: [
+          { status: DeviceConnectionStatus.ERROR },
+          { status: DeviceConnectionStatus.DISCONNECTED },
+          { lastError: { not: null } },
+          { lastSyncedAt: { lt: staleDeviceCutoff } },
+        ],
+      },
+      orderBy: { updatedAt: "desc" },
+      take: 12,
+      select: {
+        id: true,
+        source: true,
+        platform: true,
+        deviceLabel: true,
+        status: true,
+        lastSyncedAt: true,
+        lastError: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    }),
+  ]);
+
+  const items: NotificationItem[] = [
+    ...alerts.map((alert) => ({
+      id: `alert-${alert.id}`,
+      source: "ALERT" as const,
+      title: alert.title,
+      description: alert.message,
+      priority: alertPriority(alert.severity),
+      tone: alertTone(alert.severity),
+      href: `/alerts?status=${alert.status}&severity=${alert.severity}`,
+      createdAt: alert.createdAt,
+      status: alert.status,
+      meta: `${alert.category} • ${alert.severity}`,
+    })),
+    ...reminders.map((reminder) => ({
+      id: `reminder-${reminder.id}`,
+      source: "REMINDER" as const,
+      title: reminder.title,
+      description: reminder.description || `${reminder.type} reminder due ${reminder.dueAt.toLocaleString()}`,
+      priority: reminderPriority(reminder.state, reminder.dueAt),
+      tone: reminder.state === ReminderState.OVERDUE || reminder.dueAt.getTime() < Date.now() ? "warning" as const : "info" as const,
+      href: `/reminders?state=${reminder.state}`,
+      createdAt: reminder.createdAt,
+      dueAt: reminder.dueAt,
+      status: reminder.state,
+      meta: reminder.type,
+    })),
+    ...appointments.map((appointment) => ({
+      id: `appointment-${appointment.id}`,
+      source: "APPOINTMENT" as const,
+      title: appointment.purpose,
+      description: `${appointment.doctorName} • ${appointment.clinic}`,
+      priority: appointment.scheduledAt.getTime() - now.getTime() <= 3 * 24 * 60 * 60 * 1000 ? "medium" as const : "low" as const,
+      tone: "info" as const,
+      href: "/appointments",
+      createdAt: appointment.createdAt,
+      dueAt: appointment.scheduledAt,
+      status: "UPCOMING",
+      meta: "Upcoming visit",
+    })),
+    ...labs.map((lab) => ({
+      id: `lab-${lab.id}`,
+      source: "LAB" as const,
+      title: lab.testName,
+      description: lab.resultSummary,
+      priority: labPriority(lab.flag),
+      tone: labTone(lab.flag),
+      href: "/labs",
+      createdAt: lab.createdAt,
+      dueAt: lab.dateTaken,
+      status: lab.flag,
+      meta: "Lab follow-up",
+    })),
+    ...documents.map((document) => {
+      const needsLink = !document.linkedRecordType;
+      const needsNotes = !document.notes;
+      return {
+        id: `document-${document.id}`,
+        source: "DOCUMENT" as const,
+        title: document.title,
+        description: needsLink
+          ? `${document.fileName} is not linked to a record yet.`
+          : `${document.fileName} needs stronger review notes.`,
+        priority: needsLink ? "medium" as const : "low" as const,
+        tone: needsLink ? "warning" as const : "neutral" as const,
+        href: needsLink ? "/documents?link=UNLINKED" : "/documents?quality=NEEDS_NOTES",
+        createdAt: document.createdAt,
+        status: needsLink ? "UNLINKED" : needsNotes ? "NEEDS_NOTES" : "READY",
+        meta: document.type,
+      };
+    }),
+    ...careInvites.map((invite) => ({
+      id: `care-${invite.id}`,
+      source: "CARE" as const,
+      title: `Pending invite for ${invite.email}`,
+      description: `${invite.accessRole} access expires ${invite.expiresAt.toLocaleDateString()}`,
+      priority: invite.expiresAt.getTime() - now.getTime() <= 3 * 24 * 60 * 60 * 1000 ? "medium" as const : "low" as const,
+      tone: "info" as const,
+      href: "/care-team",
+      createdAt: invite.createdAt,
+      dueAt: invite.expiresAt,
+      status: invite.status,
+      meta: invite.accessRole,
+    })),
+    ...deviceConnections.map((device) => ({
+      id: `device-${device.id}`,
+      source: "DEVICE" as const,
+      title: device.deviceLabel || `${device.platform} ${device.source}`,
+      description: device.lastError || `Last synced ${device.lastSyncedAt ? device.lastSyncedAt.toLocaleDateString() : "never"}`,
+      priority: device.status === DeviceConnectionStatus.ERROR ? "high" as const : "medium" as const,
+      tone: device.status === DeviceConnectionStatus.ERROR ? "danger" as const : "warning" as const,
+      href: "/device-connection",
+      createdAt: device.updatedAt || device.createdAt,
+      dueAt: device.lastSyncedAt,
+      status: device.status,
+      meta: `${device.source} • ${device.platform}`,
+    })),
+  ];
+
+  const sortedItems = items
+    .sort((a, b) => {
+      const score = priorityScore(b.priority) - priorityScore(a.priority);
+      if (score !== 0) return score;
+      const aTime = (a.dueAt || a.createdAt).getTime();
+      const bTime = (b.dueAt || b.createdAt).getTime();
+      return bTime - aTime;
+    });
+
+  const filteredItems = sortedItems.filter((item) => matchesFilter(item, filters));
+
+  const counts = {
+    total: sortedItems.length,
+    visible: filteredItems.length,
+    critical: sortedItems.filter((item) => item.priority === "critical").length,
+    high: sortedItems.filter((item) => item.priority === "high").length,
+    medium: sortedItems.filter((item) => item.priority === "medium").length,
+    low: sortedItems.filter((item) => item.priority === "low").length,
+    bySource: (['ALERT', 'REMINDER', 'APPOINTMENT', 'LAB', 'DOCUMENT', 'CARE', 'DEVICE'] as NotificationSource[]).map((source) => ({
+      source,
+      count: sortedItems.filter((item) => item.source === source).length,
+    })),
+  };
+
+  const nextActions = [
+    counts.critical || counts.high ? "Review high-priority alerts, abnormal labs, or device errors first." : "No high-risk items are waiting right now.",
+    counts.bySource.find((item) => item.source === "REMINDER")?.count ? "Clear due and overdue reminders to keep the care plan current." : "Reminder queue is clear for the current filter window.",
+    counts.bySource.find((item) => item.source === "DOCUMENT")?.count ? "Link uploaded documents to records so future summaries are more complete." : "Document hygiene looks good for now.",
+  ];
+
+  return {
+    items: filteredItems,
+    allItems: sortedItems,
+    counts,
+    nextActions,
+  };
+}


### PR DESCRIPTION
This PR adds Patch 12: a unified Notification Center for VitaVault.

Changes:
- Adds a protected /notifications page
- Adds a unified inbox for alerts, reminders, appointments, labs, documents, care invites, and device sync issues
- Adds priority scoring for critical, high, medium, and low-priority items
- Adds source and priority filters
- Adds summary cards for visible items, critical items, high-priority items, and care workload
- Adds a recommended next-action panel
- Adds Notification Center to the sidebar navigation
- Reuses existing schema models, so no Prisma migration is required