### PR TITLE
Add care plan hub

### DIFF
--- a/app/care-plan/page.tsx
+++ b/app/care-plan/page.tsx
@@ -1,0 +1,265 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import {
+  AlertTriangle,
+  CalendarClock,
+  CheckCircle2,
+  ClipboardCheck,
+  FileHeart,
+  HeartPulse,
+  Pill,
+  ShieldCheck,
+  Stethoscope,
+  Users,
+} from "lucide-react";
+
+import { AppShell } from "@/components/app-shell";
+import { EmptyState, PageHeader, StatusPill } from "@/components/common";
+import { Badge, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
+import { getCarePlanHubData, type CarePlanPriority, type CarePlanTone } from "@/lib/care-plan";
+import { requireUser } from "@/lib/session";
+
+function formatDate(value: Date | null | undefined) {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat("en-PH", { dateStyle: "medium", timeStyle: "short" }).format(value);
+}
+
+function priorityLabel(priority: CarePlanPriority) {
+  if (priority === "critical") return "Critical";
+  if (priority === "high") return "High";
+  if (priority === "medium") return "Medium";
+  return "Low";
+}
+
+function toneToPill(tone: CarePlanTone) {
+  if (tone === "danger") return "danger" as const;
+  if (tone === "warning") return "warning" as const;
+  if (tone === "success") return "success" as const;
+  if (tone === "info") return "info" as const;
+  return "neutral" as const;
+}
+
+function ProgressBar({ value }: { value: number }) {
+  const safeValue = Math.max(0, Math.min(100, value));
+  return (
+    <div className="h-2 overflow-hidden rounded-full bg-muted">
+      <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${safeValue}%` }} />
+    </div>
+  );
+}
+
+function StatCard({ title, value, description, icon }: { title: string; value: string | number; description: string; icon: ReactNode }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardDescription>{title}</CardDescription>
+            <CardTitle className="mt-2 text-3xl">{value}</CardTitle>
+          </div>
+          <div className="rounded-2xl border border-border/60 bg-background/70 p-2">{icon}</div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default async function CarePlanPage() {
+  const user = await requireUser();
+  const data = await getCarePlanHubData(user.id);
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-7xl space-y-6 p-6">
+        <PageHeader
+          title="Care Plan Hub"
+          description="A practical action plan that turns your records, alerts, reminders, appointments, labs, documents, and care-team context into one prioritized next-step view."
+          action={
+            <div className="flex flex-wrap gap-2">
+              <Link href="/summary" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium transition-all hover:border-border hover:bg-muted/60">
+                Patient summary
+              </Link>
+              <Link href="/notifications" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium transition-all hover:border-border hover:bg-muted/60">
+                Notifications
+              </Link>
+            </div>
+          }
+        />
+
+        <Card className="overflow-hidden">
+          <CardContent className="p-0">
+            <div className="grid gap-0 lg:grid-cols-[1.1fr_0.9fr]">
+              <div className="space-y-5 p-6">
+                <div className="flex flex-wrap items-center gap-2">
+                  <StatusPill tone={toneToPill(data.readinessTone)}>
+                    {data.overallScore >= 85 ? "Visit ready" : data.overallScore >= 60 ? "Needs polish" : "Needs setup"}
+                  </StatusPill>
+                  <Badge>Care-plan score: {data.overallScore}%</Badge>
+                </div>
+                <div>
+                  <h2 className="text-2xl font-semibold tracking-tight">Your next best care actions</h2>
+                  <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+                    VitaVault prioritizes urgent health signals first, then highlights missing handoff details that make your doctor visits, emergency card, and caregiver sharing more useful.
+                  </p>
+                </div>
+                <ProgressBar value={data.overallScore} />
+              </div>
+              <div className="border-t border-border/60 bg-muted/20 p-6 lg:border-l lg:border-t-0">
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="rounded-2xl border border-border/60 bg-background/70 p-4">
+                    <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Critical</p>
+                    <p className="mt-2 text-2xl font-semibold">{data.stats.criticalCount}</p>
+                  </div>
+                  <div className="rounded-2xl border border-border/60 bg-background/70 p-4">
+                    <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">High priority</p>
+                    <p className="mt-2 text-2xl font-semibold">{data.stats.highCount}</p>
+                  </div>
+                  <div className="rounded-2xl border border-border/60 bg-background/70 p-4">
+                    <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Open alerts</p>
+                    <p className="mt-2 text-2xl font-semibold">{data.stats.openAlerts}</p>
+                  </div>
+                  <div className="rounded-2xl border border-border/60 bg-background/70 p-4">
+                    <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Upcoming visits</p>
+                    <p className="mt-2 text-2xl font-semibold">{data.stats.upcomingAppointments}</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <StatCard title="Active medications" value={data.stats.activeMedications} description="Medication context available for doctor handoff." icon={<Pill className="h-5 w-5 text-primary" />} />
+          <StatCard title="Abnormal labs" value={data.stats.abnormalLabs} description="Lab results that may need review or follow-up." icon={<ClipboardCheck className="h-5 w-5 text-amber-500" />} />
+          <StatCard title="Care members" value={data.stats.activeCareMembers} description="Active people with shared care access." icon={<Users className="h-5 w-5 text-sky-500" />} />
+          <StatCard title="Unlinked documents" value={data.stats.unlinkedDocuments} description="Files that need record linking for better context." icon={<FileHeart className="h-5 w-5 text-violet-500" />} />
+        </div>
+
+        <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
+          <Card>
+            <CardHeader>
+              <CardTitle>Prioritized action list</CardTitle>
+              <CardDescription>Highest-value follow-ups across records, reminders, alerts, and profile readiness.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {data.tasks.map((task) => (
+                <Link key={task.id} href={task.href} className="block rounded-2xl border border-border/60 bg-background/60 p-4 transition hover:border-border hover:bg-muted/40">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="space-y-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <StatusPill tone={toneToPill(task.tone)}>{priorityLabel(task.priority)}</StatusPill>
+                        <Badge>{task.source}</Badge>
+                      </div>
+                      <p className="font-medium">{task.title}</p>
+                      <p className="text-sm text-muted-foreground">{task.detail}</p>
+                    </div>
+                    <span className="text-xs text-muted-foreground">{task.dueLabel}</span>
+                  </div>
+                </Link>
+              ))}
+              {data.tasks.length === 0 ? <EmptyState title="No urgent care-plan tasks" description="Your current records do not show urgent follow-up items. Keep adding records to maintain a stronger plan." /> : null}
+            </CardContent>
+          </Card>
+
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Readiness breakdown</CardTitle>
+                <CardDescription>Where your care plan is strong and where it needs setup.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-5">
+                {data.sections.map((section) => (
+                  <div key={section.title} className="space-y-3 rounded-2xl border border-border/60 bg-background/60 p-4">
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <p className="font-medium">{section.title}</p>
+                        <p className="text-xs text-muted-foreground">{section.score}% complete</p>
+                      </div>
+                      <StatusPill tone={toneToPill(section.tone)}>{section.status}</StatusPill>
+                    </div>
+                    <ProgressBar value={section.score} />
+                    <div className="space-y-2">
+                      {section.checks.map((check) => (
+                        <div key={check.label} className="flex items-start gap-2 text-sm">
+                          {check.complete ? <CheckCircle2 className="mt-0.5 h-4 w-4 text-emerald-500" /> : <AlertTriangle className="mt-0.5 h-4 w-4 text-amber-500" />}
+                          <div>
+                            <p className="font-medium">{check.label}</p>
+                            <p className="text-xs text-muted-foreground">{check.detail}</p>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+
+        <div className="grid gap-6 xl:grid-cols-3">
+          <Card className="xl:col-span-2">
+            <CardHeader>
+              <CardTitle>Upcoming care timeline</CardTitle>
+              <CardDescription>Appointments, reminders, and vaccine follow-ups in one planning stream.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {data.timeline.map((item) => (
+                <Link key={item.id} href={item.href} className="flex items-start gap-4 rounded-2xl border border-border/60 bg-background/60 p-4 transition hover:border-border hover:bg-muted/40">
+                  <div className="rounded-2xl border border-border/60 bg-background/70 p-2">
+                    {item.type === "appointment" ? <CalendarClock className="h-4 w-4" /> : item.type === "reminder" ? <ShieldCheck className="h-4 w-4" /> : <HeartPulse className="h-4 w-4" />}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <p className="font-medium">{item.title}</p>
+                      <StatusPill tone={toneToPill(item.tone)}>{item.type}</StatusPill>
+                    </div>
+                    <p className="mt-1 text-sm text-muted-foreground">{item.detail}</p>
+                    <p className="mt-1 text-xs text-muted-foreground">{formatDate(item.when)}</p>
+                  </div>
+                </Link>
+              ))}
+              {data.timeline.length === 0 ? <EmptyState title="No upcoming care items" description="Upcoming appointments, reminders, and vaccination due dates will appear here." /> : null}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Care context snapshot</CardTitle>
+              <CardDescription>Quick context to prepare for appointments or caregiver review.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="rounded-2xl border border-border/60 bg-background/60 p-4">
+                <div className="flex items-center gap-2"><Stethoscope className="h-4 w-4" /><p className="font-medium">Care providers</p></div>
+                <div className="mt-3 space-y-2 text-sm text-muted-foreground">
+                  {data.doctors.map((doctor) => <p key={doctor.id}>{doctor.name}{doctor.specialty ? ` • ${doctor.specialty}` : ""}</p>)}
+                  {data.doctors.length === 0 ? <p>No providers saved yet.</p> : null}
+                </div>
+              </div>
+              <div className="rounded-2xl border border-border/60 bg-background/60 p-4">
+                <div className="flex items-center gap-2"><Pill className="h-4 w-4" /><p className="font-medium">Medication context</p></div>
+                <div className="mt-3 space-y-2 text-sm text-muted-foreground">
+                  {data.medications.map((med) => <p key={med.id}>{med.name} • {med.dosage} • {med.frequency}</p>)}
+                  {data.medications.length === 0 ? <p>No active medications saved yet.</p> : null}
+                </div>
+              </div>
+              <div className="rounded-2xl border border-border/60 bg-background/60 p-4">
+                <div className="flex items-center gap-2"><HeartPulse className="h-4 w-4" /><p className="font-medium">Latest vitals</p></div>
+                <div className="mt-3 space-y-2 text-sm text-muted-foreground">
+                  {data.latestVitals.map((vital) => (
+                    <p key={vital.id}>
+                      {formatDate(vital.recordedAt)} • BP {vital.systolic && vital.diastolic ? `${vital.systolic}/${vital.diastolic}` : "—"} • HR {vital.heartRate ?? "—"}
+                    </p>
+                  ))}
+                  {data.latestVitals.length === 0 ? <p>No recent vitals saved yet.</p> : null}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </AppShell>
+  );
+}

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -146,7 +146,7 @@ export function AppShell({ children }: AppShellProps) {
     const pick = (hrefs: string[]) =>
       hrefs.map((h) => routeMap.get(h)).filter(Boolean) as AppRouteItem[];
 
-    const overview = pick(["/dashboard", "/onboarding", "/notifications"]);
+    const overview = pick(["/dashboard", "/onboarding", "/notifications", "/care-plan"]);
     const collaboration = pick([
       "/ai-insights",
       "/care-team",
@@ -160,6 +160,7 @@ export function AppShell({ children }: AppShellProps) {
           "/dashboard",
           "/onboarding",
           "/notifications",
+          "/care-plan",
           "/ai-insights",
           "/care-team",
           "/alerts",

--- a/docs/PATCH_13_CARE_PLAN_HUB.md
+++ b/docs/PATCH_13_CARE_PLAN_HUB.md
@@ -1,0 +1,34 @@
+# Patch 13 — Care Plan Hub
+
+This patch adds a new protected `/care-plan` page that turns existing VitaVault records into a prioritized care-planning workspace.
+
+## Added
+
+- New `/care-plan` route
+- `lib/care-plan.ts` data aggregation layer
+- Care-plan readiness score
+- Profile, record, and workflow readiness sections
+- Prioritized action list from:
+  - open alerts
+  - due/overdue reminders
+  - abnormal lab results
+  - unresolved moderate/severe symptoms
+  - missing profile emergency/allergy details
+  - unlinked medical documents
+  - missing active medication context
+- Upcoming care timeline from:
+  - appointments
+  - reminders
+  - vaccination due dates
+- Care context snapshot for:
+  - providers
+  - active medications
+  - latest vitals
+- Sidebar navigation entry
+
+## Notes
+
+- No Prisma migration required.
+- Uses existing models only.
+- Does not add new write actions.
+- Safe to merge after Patch 12.

--- a/lib/app-routes.ts
+++ b/lib/app-routes.ts
@@ -49,6 +49,12 @@ export const primaryRoutes: AppRouteItem[] = [
     icon: Inbox,
   },
   {
+    title: "Care Plan",
+    href: "/care-plan",
+    description: "Prioritized next steps across records, alerts, reminders, and visits",
+    icon: ClipboardCheck,
+  },
+  {
     title: "Emergency Card",
     href: "/emergency-card",
     description: "Printable critical care card",

--- a/lib/care-plan.ts
+++ b/lib/care-plan.ts
@@ -1,0 +1,362 @@
+import {
+  AlertSeverity,
+  AlertStatus,
+  AppointmentStatus,
+  CareAccessStatus,
+  LabFlag,
+  MedicationStatus,
+  ReminderState,
+  SymptomSeverity,
+} from "@prisma/client";
+import { db } from "@/lib/db";
+
+export type CarePlanPriority = "critical" | "high" | "medium" | "low";
+export type CarePlanTone = "danger" | "warning" | "info" | "success" | "neutral";
+
+export type CarePlanTask = {
+  id: string;
+  title: string;
+  detail: string;
+  source: "Alert" | "Reminder" | "Appointment" | "Lab" | "Symptom" | "Medication" | "Document" | "Profile";
+  priority: CarePlanPriority;
+  tone: CarePlanTone;
+  dueLabel: string;
+  href: string;
+};
+
+export type CarePlanTimelineItem = {
+  id: string;
+  when: Date;
+  title: string;
+  detail: string;
+  type: "appointment" | "reminder" | "vaccination";
+  href: string;
+  tone: CarePlanTone;
+};
+
+export type CarePlanSection = {
+  title: string;
+  score: number;
+  status: string;
+  tone: CarePlanTone;
+  checks: Array<{ label: string; complete: boolean; detail: string }>;
+};
+
+function clampScore(value: number) {
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function formatDate(value: Date | null | undefined) {
+  if (!value) return "No date";
+  return new Intl.DateTimeFormat("en-PH", { dateStyle: "medium" }).format(value);
+}
+
+function daysFromNow(value: Date) {
+  const now = new Date();
+  const ms = value.getTime() - now.getTime();
+  return Math.ceil(ms / (1000 * 60 * 60 * 24));
+}
+
+function dueLabel(value: Date) {
+  const days = daysFromNow(value);
+  if (days < 0) return `${Math.abs(days)} day${Math.abs(days) === 1 ? "" : "s"} overdue`;
+  if (days === 0) return "Due today";
+  if (days === 1) return "Due tomorrow";
+  return `Due in ${days} days`;
+}
+
+function priorityRank(priority: CarePlanPriority) {
+  return priority === "critical" ? 4 : priority === "high" ? 3 : priority === "medium" ? 2 : 1;
+}
+
+function alertPriority(severity: AlertSeverity): CarePlanPriority {
+  if (severity === AlertSeverity.CRITICAL) return "critical";
+  if (severity === AlertSeverity.HIGH) return "high";
+  if (severity === AlertSeverity.MEDIUM) return "medium";
+  return "low";
+}
+
+function priorityTone(priority: CarePlanPriority): CarePlanTone {
+  if (priority === "critical" || priority === "high") return "danger";
+  if (priority === "medium") return "warning";
+  return "info";
+}
+
+export async function getCarePlanHubData(userId: string) {
+  const now = new Date();
+  const next30Days = new Date(now);
+  next30Days.setDate(next30Days.getDate() + 30);
+
+  const [
+    profile,
+    medications,
+    reminders,
+    appointments,
+    labs,
+    symptoms,
+    vaccinations,
+    documents,
+    alerts,
+    doctors,
+    careInvites,
+    careAccess,
+    latestVitals,
+  ] = await Promise.all([
+    db.healthProfile.findUnique({ where: { userId } }),
+    db.medication.findMany({
+      where: { userId, status: MedicationStatus.ACTIVE },
+      orderBy: { createdAt: "desc" },
+      take: 10,
+      include: { schedules: { orderBy: { timeOfDay: "asc" } } },
+    }),
+    db.reminder.findMany({
+      where: {
+        userId,
+        completed: false,
+        state: { in: [ReminderState.DUE, ReminderState.OVERDUE, ReminderState.MISSED, ReminderState.SENT] },
+      },
+      orderBy: { dueAt: "asc" },
+      take: 12,
+    }),
+    db.appointment.findMany({
+      where: { userId, status: AppointmentStatus.UPCOMING, scheduledAt: { gte: now } },
+      orderBy: { scheduledAt: "asc" },
+      take: 8,
+    }),
+    db.labResult.findMany({ where: { userId }, orderBy: { dateTaken: "desc" }, take: 10 }),
+    db.symptomEntry.findMany({ where: { userId }, orderBy: { startedAt: "desc" }, take: 10 }),
+    db.vaccinationRecord.findMany({ where: { userId }, orderBy: { dateTaken: "desc" }, take: 8 }),
+    db.medicalDocument.findMany({ where: { userId }, orderBy: { createdAt: "desc" }, take: 14 }),
+    db.alertEvent.findMany({
+      where: { userId, status: AlertStatus.OPEN },
+      orderBy: [{ severity: "desc" }, { createdAt: "desc" }],
+      take: 10,
+    }),
+    db.doctor.findMany({ where: { userId }, orderBy: { createdAt: "desc" }, take: 8 }),
+    db.careInvite.findMany({ where: { ownerUserId: userId, status: CareAccessStatus.PENDING }, orderBy: { createdAt: "desc" }, take: 6 }),
+    db.careAccess.findMany({ where: { ownerUserId: userId, status: CareAccessStatus.ACTIVE }, orderBy: { createdAt: "desc" }, take: 6, include: { member: { select: { id: true, name: true, email: true } } } }),
+    db.vitalRecord.findMany({ where: { userId }, orderBy: { recordedAt: "desc" }, take: 3 }),
+  ]);
+
+  const tasks: CarePlanTask[] = [];
+
+  if (!profile) {
+    tasks.push({
+      id: "profile-missing",
+      title: "Complete health profile",
+      detail: "Add baseline identity, emergency contact, allergies, and chronic condition details.",
+      source: "Profile",
+      priority: "high",
+      tone: "danger",
+      dueLabel: "Recommended now",
+      href: "/onboarding",
+    });
+  } else {
+    if (!profile.emergencyContactName || !profile.emergencyContactPhone) {
+      tasks.push({
+        id: "profile-emergency-contact",
+        title: "Add emergency contact",
+        detail: "Your emergency card and doctor handoff packet are stronger when emergency contact details are complete.",
+        source: "Profile",
+        priority: "high",
+        tone: "danger",
+        dueLabel: "Recommended now",
+        href: "/health-profile",
+      });
+    }
+    if (!profile.allergiesSummary) {
+      tasks.push({
+        id: "profile-allergies",
+        title: "Record allergy information",
+        detail: "Add known allergies or explicitly note that there are no known allergies.",
+        source: "Profile",
+        priority: "medium",
+        tone: "warning",
+        dueLabel: "Recommended soon",
+        href: "/health-profile",
+      });
+    }
+  }
+
+  for (const alert of alerts) {
+    const priority = alertPriority(alert.severity);
+    tasks.push({
+      id: `alert-${alert.id}`,
+      title: alert.title,
+      detail: alert.message,
+      source: "Alert",
+      priority,
+      tone: priorityTone(priority),
+      dueLabel: `Opened ${formatDate(alert.createdAt)}`,
+      href: `/alerts/${alert.id}`,
+    });
+  }
+
+  for (const reminder of reminders) {
+    const isOverdue = reminder.dueAt < now || reminder.state === ReminderState.OVERDUE || reminder.state === ReminderState.MISSED;
+    tasks.push({
+      id: `reminder-${reminder.id}`,
+      title: reminder.title,
+      detail: reminder.description || `${reminder.type} reminder through ${reminder.channel}`,
+      source: "Reminder",
+      priority: isOverdue ? "high" : "medium",
+      tone: isOverdue ? "danger" : "warning",
+      dueLabel: dueLabel(reminder.dueAt),
+      href: "/reminders",
+    });
+  }
+
+  for (const lab of labs.filter((item) => item.flag !== LabFlag.NORMAL).slice(0, 4)) {
+    tasks.push({
+      id: `lab-${lab.id}`,
+      title: `Review ${lab.testName}`,
+      detail: `${lab.resultSummary}${lab.referenceRange ? ` • Ref: ${lab.referenceRange}` : ""}`,
+      source: "Lab",
+      priority: lab.flag === LabFlag.BORDERLINE ? "medium" : "high",
+      tone: lab.flag === LabFlag.BORDERLINE ? "warning" : "danger",
+      dueLabel: `Taken ${formatDate(lab.dateTaken)}`,
+      href: "/labs",
+    });
+  }
+
+  for (const symptom of symptoms.filter((item) => !item.resolved && item.severity !== SymptomSeverity.MILD).slice(0, 4)) {
+    tasks.push({
+      id: `symptom-${symptom.id}`,
+      title: `Follow up on ${symptom.title}`,
+      detail: symptom.notes || `${symptom.severity} symptom${symptom.bodyArea ? ` affecting ${symptom.bodyArea}` : ""}`,
+      source: "Symptom",
+      priority: symptom.severity === SymptomSeverity.SEVERE ? "high" : "medium",
+      tone: symptom.severity === SymptomSeverity.SEVERE ? "danger" : "warning",
+      dueLabel: `Started ${formatDate(symptom.startedAt)}`,
+      href: "/symptoms",
+    });
+  }
+
+  const unlinkedDocuments = documents.filter((item) => !item.linkedRecordType || !item.linkedRecordId);
+  if (unlinkedDocuments.length > 0) {
+    tasks.push({
+      id: "documents-unlinked",
+      title: "Link important documents to records",
+      detail: `${unlinkedDocuments.length} document${unlinkedDocuments.length === 1 ? "" : "s"} need record linking for better doctor handoff context.`,
+      source: "Document",
+      priority: "medium",
+      tone: "warning",
+      dueLabel: "Recommended soon",
+      href: "/documents?link=UNLINKED",
+    });
+  }
+
+  if (medications.length === 0) {
+    tasks.push({
+      id: "medications-empty",
+      title: "Add active medications",
+      detail: "Medication history is one of the most useful parts of a doctor visit packet.",
+      source: "Medication",
+      priority: "medium",
+      tone: "warning",
+      dueLabel: "Recommended soon",
+      href: "/medications",
+    });
+  }
+
+  const sortedTasks = tasks.sort((a, b) => priorityRank(b.priority) - priorityRank(a.priority)).slice(0, 12);
+
+  const timeline: CarePlanTimelineItem[] = [
+    ...appointments.map((item) => ({
+      id: `appointment-${item.id}`,
+      when: item.scheduledAt,
+      title: item.purpose,
+      detail: `${item.doctorName} • ${item.clinic}`,
+      type: "appointment" as const,
+      href: "/appointments",
+      tone: "info" as const,
+    })),
+    ...reminders.map((item) => ({
+      id: `reminder-${item.id}`,
+      when: item.dueAt,
+      title: item.title,
+      detail: item.description || `${item.type} reminder`,
+      type: "reminder" as const,
+      href: "/reminders",
+      tone: item.dueAt < now ? "danger" as const : "warning" as const,
+    })),
+    ...vaccinations
+      .filter((item) => item.nextDueDate && item.nextDueDate >= now && item.nextDueDate <= next30Days)
+      .map((item) => ({
+        id: `vaccination-${item.id}`,
+        when: item.nextDueDate as Date,
+        title: `${item.vaccineName} next dose`,
+        detail: item.location || "Vaccination follow-up",
+        type: "vaccination" as const,
+        href: "/vaccinations",
+        tone: "info" as const,
+      })),
+  ].sort((a, b) => a.when.getTime() - b.when.getTime()).slice(0, 10);
+
+  const profileChecks = [
+    { label: "Profile created", complete: Boolean(profile), detail: profile ? "Baseline profile exists" : "Create your profile" },
+    { label: "Emergency contact", complete: Boolean(profile?.emergencyContactName && profile?.emergencyContactPhone), detail: "Required for emergency card readiness" },
+    { label: "Allergy context", complete: Boolean(profile?.allergiesSummary), detail: "Needed for doctor handoff and emergency context" },
+    { label: "Blood type", complete: Boolean(profile?.bloodType), detail: "Useful in emergency packet" },
+  ];
+
+  const recordChecks = [
+    { label: "Active medications", complete: medications.length > 0, detail: `${medications.length} active medication${medications.length === 1 ? "" : "s"}` },
+    { label: "Care providers", complete: doctors.length > 0, detail: `${doctors.length} provider${doctors.length === 1 ? "" : "s"} saved` },
+    { label: "Recent vitals", complete: latestVitals.length > 0, detail: `${latestVitals.length} recent vital snapshot${latestVitals.length === 1 ? "" : "s"}` },
+    { label: "Documents linked", complete: documents.length > 0 && unlinkedDocuments.length === 0, detail: `${unlinkedDocuments.length} unlinked document${unlinkedDocuments.length === 1 ? "" : "s"}` },
+  ];
+
+  const workflowChecks = [
+    { label: "No open high alerts", complete: !alerts.some((item) => item.severity === AlertSeverity.HIGH || item.severity === AlertSeverity.CRITICAL), detail: `${alerts.length} open alert${alerts.length === 1 ? "" : "s"}` },
+    { label: "Reminders under control", complete: reminders.filter((item) => item.dueAt < now).length === 0, detail: `${reminders.filter((item) => item.dueAt < now).length} overdue reminder${reminders.filter((item) => item.dueAt < now).length === 1 ? "" : "s"}` },
+    { label: "Care team visibility", complete: careAccess.length > 0 || careInvites.length > 0, detail: `${careAccess.length} active share${careAccess.length === 1 ? "" : "s"}, ${careInvites.length} pending invite${careInvites.length === 1 ? "" : "s"}` },
+    { label: "Upcoming care plan", complete: timeline.length > 0, detail: `${timeline.length} upcoming care item${timeline.length === 1 ? "" : "s"}` },
+  ];
+
+  const sectionFromChecks = (title: string, checks: typeof profileChecks): CarePlanSection => {
+    const completed = checks.filter((item) => item.complete).length;
+    const score = clampScore((completed / checks.length) * 100);
+    return {
+      title,
+      score,
+      status: score >= 85 ? "Strong" : score >= 60 ? "Needs polish" : "Needs setup",
+      tone: score >= 85 ? "success" : score >= 60 ? "warning" : "danger",
+      checks,
+    };
+  };
+
+  const sections = [
+    sectionFromChecks("Profile readiness", profileChecks),
+    sectionFromChecks("Record readiness", recordChecks),
+    sectionFromChecks("Workflow readiness", workflowChecks),
+  ];
+
+  const overallScore = clampScore(sections.reduce((sum, section) => sum + section.score, 0) / sections.length);
+  const criticalCount = sortedTasks.filter((item) => item.priority === "critical").length;
+  const highCount = sortedTasks.filter((item) => item.priority === "high").length;
+
+  return {
+    profile,
+    overallScore,
+    readinessTone: overallScore >= 85 ? "success" as const : overallScore >= 60 ? "warning" as const : "danger" as const,
+    tasks: sortedTasks,
+    timeline,
+    sections,
+    stats: {
+      criticalCount,
+      highCount,
+      activeMedications: medications.length,
+      openAlerts: alerts.length,
+      upcomingAppointments: appointments.length,
+      pendingInvites: careInvites.length,
+      activeCareMembers: careAccess.length,
+      unlinkedDocuments: unlinkedDocuments.length,
+      abnormalLabs: labs.filter((item) => item.flag !== LabFlag.NORMAL).length,
+      unresolvedSymptoms: symptoms.filter((item) => !item.resolved).length,
+    },
+    medications: medications.slice(0, 5),
+    doctors: doctors.slice(0, 5),
+    latestVitals,
+  };
+}


### PR DESCRIPTION
This PR adds Patch 13: Care Plan Hub.

Changes:
- Adds a protected /care-plan page
- Adds a care-plan readiness score
- Adds profile, record, and workflow readiness sections
- Adds prioritized action items from alerts, reminders, labs, symptoms, documents, medications, and profile gaps
- Adds an upcoming care timeline for appointments, reminders, and vaccination due dates
- Adds a care context snapshot for providers, medications, and latest vitals
- Adds Care Plan to the sidebar navigation
- Reuses existing schema models, so no Prisma migration is required