### PR TITLE
Add health trends analytics

### DIFF
--- a/app/trends/page.tsx
+++ b/app/trends/page.tsx
@@ -1,0 +1,324 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import {
+  AlertTriangle,
+  BarChart3,
+  CalendarClock,
+  Pill,
+  TrendingDown,
+  TrendingUp,
+} from "lucide-react";
+
+import { AppShell } from "@/components/app-shell";
+import { EmptyState, PageHeader, StatusPill } from "@/components/common";
+import { Badge, Card, CardContent, CardDescription, CardHeader, CardTitle, Table, TBody, TD, TH, THead, TR } from "@/components/ui";
+import { getHealthTrendsData, type TrendDirection, type TrendTone, type VitalTrendMetric } from "@/lib/health-trends";
+import { requireUser } from "@/lib/session";
+
+function formatDateTime(value: Date | null | undefined) {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat("en-PH", { dateStyle: "medium", timeStyle: "short" }).format(value);
+}
+
+function toneToPill(tone: TrendTone) {
+  if (tone === "danger") return "danger" as const;
+  if (tone === "warning") return "warning" as const;
+  if (tone === "success") return "success" as const;
+  if (tone === "info") return "info" as const;
+  return "neutral" as const;
+}
+
+function directionLabel(direction: TrendDirection) {
+  if (direction === "up") return "Up";
+  if (direction === "down") return "Down";
+  if (direction === "flat") return "Stable";
+  return "New";
+}
+
+function directionIcon(direction: TrendDirection) {
+  if (direction === "up") return <TrendingUp className="h-4 w-4" />;
+  if (direction === "down") return <TrendingDown className="h-4 w-4" />;
+  return <BarChart3 className="h-4 w-4" />;
+}
+
+function ProgressBar({ value }: { value: number }) {
+  const safeValue = Math.max(0, Math.min(100, value));
+  return (
+    <div className="h-2 overflow-hidden rounded-full bg-muted">
+      <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${safeValue}%` }} />
+    </div>
+  );
+}
+
+function StatCard({ title, value, description, icon }: { title: string; value: number | string; description: string; icon: ReactNode }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardDescription>{title}</CardDescription>
+            <CardTitle className="mt-2 text-3xl">{value}</CardTitle>
+          </div>
+          <div className="rounded-2xl border border-border/60 bg-background/70 p-2">{icon}</div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function VitalMetricCard({ metric }: { metric: VitalTrendMetric }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardDescription>{metric.label}</CardDescription>
+            <CardTitle className="mt-2 text-2xl">
+              {metric.latest === null ? "—" : `${metric.latest} ${metric.unit}`}
+            </CardTitle>
+          </div>
+          <StatusPill tone={toneToPill(metric.tone)}>
+            <span className="inline-flex items-center gap-1">
+              {directionIcon(metric.direction)}
+              {directionLabel(metric.direction)}
+            </span>
+          </StatusPill>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-sm text-muted-foreground">{metric.message}</p>
+        <div className="grid grid-cols-2 gap-2 text-xs text-muted-foreground">
+          <div className="rounded-2xl border border-border/60 bg-background/60 p-3">
+            <p>Previous</p>
+            <p className="mt-1 font-medium text-foreground">{metric.previous === null ? "—" : metric.previous}</p>
+          </div>
+          <div className="rounded-2xl border border-border/60 bg-background/60 p-3">
+            <p>Delta</p>
+            <p className="mt-1 font-medium text-foreground">{metric.delta === null ? "—" : metric.delta > 0 ? `+${metric.delta}` : metric.delta}</p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default async function TrendsPage() {
+  const user = await requireUser();
+  const data = await getHealthTrendsData(user.id);
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-7xl space-y-6 p-6">
+        <PageHeader
+          title="Health Trends"
+          description="A longitudinal trend workspace for vitals, labs, symptoms, medication adherence, and upcoming care signals. Built from existing VitaVault records with no extra setup required."
+          action={
+            <div className="flex flex-wrap gap-2">
+              <Link href="/vitals" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium transition-all hover:border-border hover:bg-muted/60">Add vitals</Link>
+              <Link href="/labs" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium transition-all hover:border-border hover:bg-muted/60">Review labs</Link>
+              <Link href="/care-plan" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium transition-all hover:border-border hover:bg-muted/60">Care plan</Link>
+            </div>
+          }
+        />
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <StatCard title="Trend coverage" value={`${data.summary.dataCoverageScore}%`} description="Coverage across vitals, labs, symptoms, medication logs, and appointments." icon={<BarChart3 className="h-5 w-5 text-primary" />} />
+          <StatCard title="Risk score" value={`${data.summary.riskScore}%`} description="Weighted signal from abnormal labs, unresolved symptoms, missed meds, and vital warnings." icon={<AlertTriangle className="h-5 w-5 text-amber-500" />} />
+          <StatCard title="Medication adherence" value={`${data.summary.adherenceRate}%`} description={`${data.medications.takenLogs} taken, ${data.medications.missedLogs} missed, ${data.medications.skippedLogs} skipped in 30 days.`} icon={<Pill className="h-5 w-5 text-emerald-500" />} />
+          <StatCard title="Upcoming visits" value={data.summary.upcomingAppointments} description="Upcoming appointments connected to the current care window." icon={<CalendarClock className="h-5 w-5 text-sky-500" />} />
+        </div>
+
+        <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
+          <Card>
+            <CardHeader>
+              <CardTitle>Trend readiness</CardTitle>
+              <CardDescription>How much recent data VitaVault has for meaningful trend review.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-center justify-between gap-4">
+                <div>
+                  <p className="text-3xl font-semibold">{data.summary.dataCoverageScore}%</p>
+                  <p className="text-sm text-muted-foreground">Based on 90-day records and 30-day medication logs.</p>
+                </div>
+                <StatusPill tone={data.summary.dataCoverageScore >= 75 ? "success" : data.summary.dataCoverageScore >= 45 ? "warning" : "danger"}>
+                  {data.summary.dataCoverageScore >= 75 ? "Strong baseline" : data.summary.dataCoverageScore >= 45 ? "Partial baseline" : "Needs records"}
+                </StatusPill>
+              </div>
+              <ProgressBar value={data.summary.dataCoverageScore} />
+              <div className="grid gap-3 md:grid-cols-5">
+                <Badge>{data.summary.vitalReadings} vitals</Badge>
+                <Badge>{data.summary.labResults} labs</Badge>
+                <Badge>{data.summary.symptoms} symptoms</Badge>
+                <Badge>{data.summary.medicationLogs} med logs</Badge>
+                <Badge>{data.summary.upcomingAppointments} visits</Badge>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Recommended review notes</CardTitle>
+              <CardDescription>Priority interpretation from the latest health data.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {data.insights.map((insight) => (
+                <div key={insight.title} className="rounded-2xl border border-border/60 bg-background/60 p-4">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <StatusPill tone={toneToPill(insight.tone)}>{insight.tone}</StatusPill>
+                    <p className="font-medium">{insight.title}</p>
+                  </div>
+                  <p className="mt-2 text-sm text-muted-foreground">{insight.detail}</p>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {data.vitalMetrics.map((metric) => <VitalMetricCard key={metric.key} metric={metric} />)}
+        </div>
+
+        <div className="grid gap-6 xl:grid-cols-[0.95fr_1.05fr]">
+          <Card>
+            <CardHeader>
+              <CardTitle>30-day vital averages</CardTitle>
+              <CardDescription>Recent average values from manual and device-linked readings.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="rounded-2xl border border-border/60 bg-background/60 p-4"><p className="text-sm text-muted-foreground">Blood pressure</p><p className="mt-1 text-xl font-semibold">{data.vitalAverages.systolic ?? "—"}/{data.vitalAverages.diastolic ?? "—"}</p></div>
+                <div className="rounded-2xl border border-border/60 bg-background/60 p-4"><p className="text-sm text-muted-foreground">Heart rate</p><p className="mt-1 text-xl font-semibold">{data.vitalAverages.heartRate ?? "—"} bpm</p></div>
+                <div className="rounded-2xl border border-border/60 bg-background/60 p-4"><p className="text-sm text-muted-foreground">Oxygen</p><p className="mt-1 text-xl font-semibold">{data.vitalAverages.oxygenSaturation ?? "—"}%</p></div>
+                <div className="rounded-2xl border border-border/60 bg-background/60 p-4"><p className="text-sm text-muted-foreground">Blood sugar</p><p className="mt-1 text-xl font-semibold">{data.vitalAverages.bloodSugar ?? "—"}</p></div>
+                <div className="rounded-2xl border border-border/60 bg-background/60 p-4"><p className="text-sm text-muted-foreground">Temperature</p><p className="mt-1 text-xl font-semibold">{data.vitalAverages.temperatureC ?? "—"}°C</p></div>
+                <div className="rounded-2xl border border-border/60 bg-background/60 p-4"><p className="text-sm text-muted-foreground">Weight</p><p className="mt-1 text-xl font-semibold">{data.vitalAverages.weightKg ?? "—"} kg</p></div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Lab flag breakdown</CardTitle>
+              <CardDescription>Latest 90-day lab posture by result flag.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid gap-3 sm:grid-cols-4">
+                <div className="rounded-2xl border border-border/60 bg-background/60 p-3"><p className="text-xs text-muted-foreground">Normal</p><p className="text-2xl font-semibold">{data.labs.normalCount}</p></div>
+                <div className="rounded-2xl border border-border/60 bg-background/60 p-3"><p className="text-xs text-muted-foreground">Borderline</p><p className="text-2xl font-semibold">{data.labs.borderlineCount}</p></div>
+                <div className="rounded-2xl border border-border/60 bg-background/60 p-3"><p className="text-xs text-muted-foreground">High</p><p className="text-2xl font-semibold">{data.labs.highCount}</p></div>
+                <div className="rounded-2xl border border-border/60 bg-background/60 p-3"><p className="text-xs text-muted-foreground">Low</p><p className="text-2xl font-semibold">{data.labs.lowCount}</p></div>
+              </div>
+              <div className="space-y-3">
+                {data.labs.abnormal.map((lab) => (
+                  <div key={lab.id} className="rounded-2xl border border-border/60 bg-background/60 p-4">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <StatusPill tone="warning">{lab.flag}</StatusPill>
+                      <p className="font-medium">{lab.testName}</p>
+                    </div>
+                    <p className="mt-2 text-sm text-muted-foreground">{lab.resultSummary}</p>
+                    <p className="mt-1 text-xs text-muted-foreground">{formatDateTime(lab.dateTaken)}{lab.referenceRange ? ` • Ref: ${lab.referenceRange}` : ""}</p>
+                  </div>
+                ))}
+                {data.labs.abnormal.length === 0 ? <EmptyState title="No abnormal labs in window" description="Flagged lab results will appear here for quick review." /> : null}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="grid gap-6 xl:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <CardTitle>Symptom signal</CardTitle>
+              <CardDescription>Severity mix and unresolved symptoms from the last 90 days.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid gap-3 sm:grid-cols-3">
+                <div className="rounded-2xl border border-border/60 bg-background/60 p-3"><p className="text-xs text-muted-foreground">Mild</p><p className="text-2xl font-semibold">{data.symptoms.mildCount}</p></div>
+                <div className="rounded-2xl border border-border/60 bg-background/60 p-3"><p className="text-xs text-muted-foreground">Moderate</p><p className="text-2xl font-semibold">{data.symptoms.moderateCount}</p></div>
+                <div className="rounded-2xl border border-border/60 bg-background/60 p-3"><p className="text-xs text-muted-foreground">Severe</p><p className="text-2xl font-semibold">{data.symptoms.severeCount}</p></div>
+              </div>
+              <div className="space-y-3">
+                {data.symptoms.unresolved.map((symptom) => (
+                  <div key={symptom.id} className="rounded-2xl border border-border/60 bg-background/60 p-4">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <StatusPill tone={symptom.severity === "SEVERE" ? "danger" : "warning"}>{symptom.severity}</StatusPill>
+                      <p className="font-medium">{symptom.title}</p>
+                    </div>
+                    <p className="mt-1 text-sm text-muted-foreground">{symptom.bodyArea || "No body area"} • {formatDateTime(symptom.startedAt)}</p>
+                  </div>
+                ))}
+                {data.symptoms.unresolved.length === 0 ? <EmptyState title="No unresolved symptoms" description="Open symptom entries will appear here." /> : null}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Medication log signal</CardTitle>
+              <CardDescription>30-day logged adherence and latest medication actions.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-center justify-between gap-4">
+                <div>
+                  <p className="text-3xl font-semibold">{data.medications.adherenceRate}%</p>
+                  <p className="text-sm text-muted-foreground">{data.medications.takenLogs} taken • {data.medications.missedLogs} missed • {data.medications.skippedLogs} skipped</p>
+                </div>
+                <StatusPill tone={data.medications.adherenceRate >= 90 ? "success" : data.medications.adherenceRate >= 75 ? "warning" : "danger"}>30-day adherence</StatusPill>
+              </div>
+              <ProgressBar value={data.medications.adherenceRate} />
+              <div className="space-y-3">
+                {data.medications.logs.map((log) => (
+                  <div key={log.id} className="flex items-center justify-between gap-3 rounded-2xl border border-border/60 bg-background/60 p-3">
+                    <div>
+                      <p className="font-medium">{log.medication.name}</p>
+                      <p className="text-xs text-muted-foreground">{log.medication.dosage} • {log.scheduleTime || "unscheduled"} • {formatDateTime(log.loggedAt)}</p>
+                    </div>
+                    <StatusPill tone={log.status === "TAKEN" ? "success" : log.status === "MISSED" ? "danger" : "warning"}>{log.status}</StatusPill>
+                  </div>
+                ))}
+                {data.medications.logs.length === 0 ? <EmptyState title="No medication logs" description="Log medication actions to calculate adherence trends." /> : null}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Recent health timeline</CardTitle>
+            <CardDescription>Latest vitals, labs, and symptoms merged into one trend review stream.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto">
+              <Table>
+                <THead>
+                  <TR>
+                    <TH>Type</TH>
+                    <TH>Title</TH>
+                    <TH>Detail</TH>
+                    <TH>When</TH>
+                    <TH>Status</TH>
+                  </TR>
+                </THead>
+                <TBody>
+                  {data.recentTimeline.map((item) => (
+                    <TR key={item.id}>
+                      <TD>{item.type}</TD>
+                      <TD>{item.title}</TD>
+                      <TD>{item.detail}</TD>
+                      <TD>{formatDateTime(item.at)}</TD>
+                      <TD><StatusPill tone={toneToPill(item.tone)}>{item.tone}</StatusPill></TD>
+                    </TR>
+                  ))}
+                </TBody>
+              </Table>
+            </div>
+            {data.recentTimeline.length === 0 ? <EmptyState title="No trend timeline yet" description="Vitals, labs, and symptoms will appear here once records are added." /> : null}
+          </CardContent>
+        </Card>
+      </div>
+    </AppShell>
+  );
+}

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -146,7 +146,7 @@ export function AppShell({ children }: AppShellProps) {
     const pick = (hrefs: string[]) =>
       hrefs.map((h) => routeMap.get(h)).filter(Boolean) as AppRouteItem[];
 
-    const overview = pick(["/dashboard", "/onboarding", "/notifications", "/care-plan"]);
+    const overview = pick(["/dashboard", "/onboarding", "/notifications", "/care-plan", "/trends"]);
     const collaboration = pick([
       "/ai-insights",
       "/care-team",
@@ -161,6 +161,7 @@ export function AppShell({ children }: AppShellProps) {
           "/onboarding",
           "/notifications",
           "/care-plan",
+          "/trends",
           "/ai-insights",
           "/care-team",
           "/alerts",

--- a/docs/PATCH_14_HEALTH_TRENDS.md
+++ b/docs/PATCH_14_HEALTH_TRENDS.md
@@ -1,0 +1,26 @@
+# Patch 14 — Health Trends Analytics
+
+## Summary
+
+Adds a protected `/trends` workspace that turns existing VitaVault records into a longitudinal health analytics surface.
+
+## Added
+
+- Health Trends page at `/trends`
+- Data coverage score across vitals, labs, symptoms, medication logs, and appointments
+- Risk score from abnormal labs, unresolved severe symptoms, medication misses, and vital warnings
+- Vitals trend cards with latest value, previous value, delta, direction, tone, and message
+- 30-day vital averages
+- 90-day lab flag breakdown
+- Symptom severity and unresolved symptom review
+- 30-day medication adherence signal
+- Recent health timeline merging vitals, labs, and symptoms
+- Recommended review notes from recent data
+- Sidebar navigation entry
+
+## Safety
+
+- No Prisma migration required
+- No new database tables
+- No risky admin or auth changes
+- Read-only analytics layer using existing records

--- a/lib/app-routes.ts
+++ b/lib/app-routes.ts
@@ -19,6 +19,7 @@ import {
   Stethoscope,
   Syringe,
   Users,
+  TrendingUp,
   Workflow,
 } from "lucide-react";
 
@@ -53,6 +54,12 @@ export const primaryRoutes: AppRouteItem[] = [
     href: "/care-plan",
     description: "Prioritized next steps across records, alerts, reminders, and visits",
     icon: ClipboardCheck,
+  },
+  {
+    title: "Health Trends",
+    href: "/trends",
+    description: "Longitudinal vitals, labs, symptoms, and adherence analytics",
+    icon: TrendingUp,
   },
   {
     title: "Emergency Card",

--- a/lib/health-trends.ts
+++ b/lib/health-trends.ts
@@ -1,0 +1,350 @@
+import {
+  AppointmentStatus,
+  LabFlag,
+  MedicationLogStatus,
+  SymptomSeverity,
+} from "@prisma/client";
+import { db } from "@/lib/db";
+
+export type TrendTone = "neutral" | "info" | "success" | "warning" | "danger";
+export type TrendDirection = "up" | "down" | "flat" | "new";
+
+export type VitalTrendMetric = {
+  key: string;
+  label: string;
+  unit: string;
+  latest: number | null;
+  previous: number | null;
+  delta: number | null;
+  direction: TrendDirection;
+  tone: TrendTone;
+  message: string;
+};
+
+export type TrendInsight = {
+  title: string;
+  detail: string;
+  tone: TrendTone;
+};
+
+export type HealthTrendsData = Awaited<ReturnType<typeof getHealthTrendsData>>;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function startOfWindow(days: number) {
+  return new Date(Date.now() - days * DAY_MS);
+}
+
+function roundNumber(value: number | null | undefined, decimals = 1) {
+  if (value === null || value === undefined || Number.isNaN(value)) return null;
+  const multiplier = 10 ** decimals;
+  return Math.round(value * multiplier) / multiplier;
+}
+
+function average(values: Array<number | null | undefined>) {
+  const clean = values.filter((value): value is number => typeof value === "number" && !Number.isNaN(value));
+  if (clean.length === 0) return null;
+  return clean.reduce((sum, value) => sum + value, 0) / clean.length;
+}
+
+function directionFromDelta(delta: number | null): TrendDirection {
+  if (delta === null) return "new";
+  if (Math.abs(delta) < 0.1) return "flat";
+  return delta > 0 ? "up" : "down";
+}
+
+function metricTone(key: string, latest: number | null): TrendTone {
+  if (latest === null) return "neutral";
+
+  if (key === "bloodPressure") {
+    return latest >= 140 ? "danger" : latest >= 130 ? "warning" : "success";
+  }
+
+  if (key === "heartRate") {
+    return latest < 50 || latest > 110 ? "warning" : "success";
+  }
+
+  if (key === "oxygenSaturation") {
+    return latest < 92 ? "danger" : latest < 95 ? "warning" : "success";
+  }
+
+  if (key === "bloodSugar") {
+    return latest >= 200 ? "danger" : latest >= 140 ? "warning" : "success";
+  }
+
+  if (key === "temperatureC") {
+    return latest >= 38 ? "danger" : latest >= 37.5 ? "warning" : "success";
+  }
+
+  return "info";
+}
+
+function metricMessage(key: string, latest: number | null, delta: number | null) {
+  if (latest === null) return "No readings yet for this signal.";
+  const direction = directionFromDelta(delta);
+  const movement = direction === "new" ? "first reading captured" : direction === "flat" ? "stable" : direction === "up" ? "trending up" : "trending down";
+
+  if (key === "bloodPressure") return `Latest systolic reading is ${latest}. The recent average is ${movement}.`;
+  if (key === "heartRate") return `Latest heart rate is ${latest} bpm and is ${movement}.`;
+  if (key === "oxygenSaturation") return `Latest oxygen saturation is ${latest}% and is ${movement}.`;
+  if (key === "bloodSugar") return `Latest blood sugar is ${latest} and is ${movement}.`;
+  if (key === "temperatureC") return `Latest temperature is ${latest}°C and is ${movement}.`;
+  if (key === "weightKg") return `Latest weight is ${latest} kg and is ${movement}.`;
+  return `Latest value is ${latest} and is ${movement}.`;
+}
+
+function makeVitalMetric({
+  key,
+  label,
+  unit,
+  values,
+}: {
+  key: string;
+  label: string;
+  unit: string;
+  values: Array<number | null | undefined>;
+}): VitalTrendMetric {
+  const clean = values.filter((value): value is number => typeof value === "number" && !Number.isNaN(value));
+  const latest = roundNumber(clean[0] ?? null);
+  const previous = roundNumber(clean[1] ?? null);
+  const delta = latest !== null && previous !== null ? roundNumber(latest - previous) : null;
+
+  return {
+    key,
+    label,
+    unit,
+    latest,
+    previous,
+    delta,
+    direction: directionFromDelta(delta),
+    tone: metricTone(key, latest),
+    message: metricMessage(key, latest, delta),
+  };
+}
+
+function percentage(part: number, total: number) {
+  if (total <= 0) return 0;
+  return Math.round((part / total) * 100);
+}
+
+export async function getHealthTrendsData(userId: string) {
+  const thirtyDaysAgo = startOfWindow(30);
+  const ninetyDaysAgo = startOfWindow(90);
+  const now = new Date();
+
+  const [vitals, labs, symptoms, medicationLogs, upcomingAppointments] = await Promise.all([
+    db.vitalRecord.findMany({
+      where: { userId, recordedAt: { gte: ninetyDaysAgo } },
+      orderBy: { recordedAt: "desc" },
+      take: 80,
+      select: {
+        id: true,
+        recordedAt: true,
+        systolic: true,
+        diastolic: true,
+        heartRate: true,
+        bloodSugar: true,
+        oxygenSaturation: true,
+        temperatureC: true,
+        weightKg: true,
+        readingSource: true,
+      },
+    }),
+    db.labResult.findMany({
+      where: { userId, dateTaken: { gte: ninetyDaysAgo } },
+      orderBy: { dateTaken: "desc" },
+      take: 50,
+      select: {
+        id: true,
+        testName: true,
+        dateTaken: true,
+        flag: true,
+        resultSummary: true,
+        referenceRange: true,
+      },
+    }),
+    db.symptomEntry.findMany({
+      where: { userId, startedAt: { gte: ninetyDaysAgo } },
+      orderBy: { startedAt: "desc" },
+      take: 60,
+      select: {
+        id: true,
+        title: true,
+        severity: true,
+        startedAt: true,
+        resolved: true,
+        bodyArea: true,
+      },
+    }),
+    db.medicationLog.findMany({
+      where: { userId, loggedAt: { gte: thirtyDaysAgo } },
+      orderBy: { loggedAt: "desc" },
+      take: 120,
+      select: {
+        id: true,
+        loggedAt: true,
+        status: true,
+        scheduleTime: true,
+        medication: { select: { id: true, name: true, dosage: true } },
+      },
+    }),
+    db.appointment.findMany({
+      where: { userId, scheduledAt: { gte: now }, status: AppointmentStatus.UPCOMING },
+      orderBy: { scheduledAt: "asc" },
+      take: 5,
+      select: {
+        id: true,
+        doctorName: true,
+        clinic: true,
+        purpose: true,
+        scheduledAt: true,
+        status: true,
+      },
+    }),
+  ]);
+
+  const vitalMetrics = [
+    makeVitalMetric({ key: "bloodPressure", label: "Blood pressure", unit: "systolic", values: vitals.map((item) => item.systolic) }),
+    makeVitalMetric({ key: "heartRate", label: "Heart rate", unit: "bpm", values: vitals.map((item) => item.heartRate) }),
+    makeVitalMetric({ key: "oxygenSaturation", label: "Oxygen saturation", unit: "%", values: vitals.map((item) => item.oxygenSaturation) }),
+    makeVitalMetric({ key: "bloodSugar", label: "Blood sugar", unit: "mg/dL", values: vitals.map((item) => item.bloodSugar) }),
+    makeVitalMetric({ key: "temperatureC", label: "Temperature", unit: "°C", values: vitals.map((item) => item.temperatureC) }),
+    makeVitalMetric({ key: "weightKg", label: "Weight", unit: "kg", values: vitals.map((item) => item.weightKg) }),
+  ];
+
+  const abnormalLabs = labs.filter((lab) => lab.flag !== LabFlag.NORMAL);
+  const severeSymptoms = symptoms.filter((symptom) => symptom.severity === SymptomSeverity.SEVERE && !symptom.resolved);
+  const unresolvedSymptoms = symptoms.filter((symptom) => !symptom.resolved);
+  const takenLogs = medicationLogs.filter((log) => log.status === MedicationLogStatus.TAKEN).length;
+  const missedLogs = medicationLogs.filter((log) => log.status === MedicationLogStatus.MISSED).length;
+  const skippedLogs = medicationLogs.filter((log) => log.status === MedicationLogStatus.SKIPPED).length;
+  const adherenceRate = percentage(takenLogs, medicationLogs.length);
+
+  const latestVitals = vitals[0] ?? null;
+  const recentVitals = vitals.filter((vital) => vital.recordedAt >= thirtyDaysAgo);
+  const dataCoverageScore = Math.min(
+    100,
+    Math.round(
+      (vitals.length ? 25 : 0) +
+        (labs.length ? 20 : 0) +
+        (symptoms.length ? 20 : 0) +
+        (medicationLogs.length ? 20 : 0) +
+        (upcomingAppointments.length ? 15 : 0)
+    )
+  );
+
+  const riskScore = Math.min(
+    100,
+    abnormalLabs.length * 12 + severeSymptoms.length * 18 + missedLogs * 6 + vitalMetrics.filter((metric) => metric.tone === "danger").length * 20 + vitalMetrics.filter((metric) => metric.tone === "warning").length * 10
+  );
+
+  const insights: TrendInsight[] = [];
+
+  if (vitals.length === 0) {
+    insights.push({ title: "No vital trend baseline yet", detail: "Add a few vital readings to unlock trend direction, averages, and out-of-range signals.", tone: "warning" });
+  }
+
+  if (abnormalLabs.length > 0) {
+    insights.push({ title: "Abnormal lab results need review", detail: `${abnormalLabs.length} lab result${abnormalLabs.length === 1 ? "" : "s"} in the last 90 days are flagged outside normal range.`, tone: "danger" });
+  }
+
+  if (severeSymptoms.length > 0) {
+    insights.push({ title: "Severe unresolved symptoms", detail: `${severeSymptoms.length} severe unresolved symptom${severeSymptoms.length === 1 ? "" : "s"} should be brought into the next care review.`, tone: "danger" });
+  }
+
+  if (medicationLogs.length > 0 && adherenceRate < 80) {
+    insights.push({ title: "Medication adherence below target", detail: `The 30-day logged adherence rate is ${adherenceRate}%. Review missed/skipped logs and reminder timing.`, tone: "warning" });
+  }
+
+  if (upcomingAppointments.length === 0) {
+    insights.push({ title: "No upcoming care visit scheduled", detail: "There are no upcoming appointments in the current trend window. Add follow-up visits to keep the care plan active.", tone: "info" });
+  }
+
+  if (insights.length === 0) {
+    insights.push({ title: "Trend posture looks stable", detail: "No major trend risk was detected from recent vitals, labs, symptoms, and medication logs.", tone: "success" });
+  }
+
+  const recentTimeline = [
+    ...vitals.slice(0, 6).map((item) => ({
+      id: `vital-${item.id}`,
+      type: "Vital" as const,
+      title: item.systolic && item.diastolic ? `BP ${item.systolic}/${item.diastolic}` : "Vital reading",
+      detail: [
+        item.heartRate ? `${item.heartRate} bpm` : null,
+        item.oxygenSaturation ? `${item.oxygenSaturation}% SpO₂` : null,
+        item.readingSource !== "MANUAL" ? item.readingSource : null,
+      ].filter(Boolean).join(" • ") || "Manual vital record",
+      at: item.recordedAt,
+      tone: "info" as TrendTone,
+    })),
+    ...labs.slice(0, 6).map((item) => ({
+      id: `lab-${item.id}`,
+      type: "Lab" as const,
+      title: item.testName,
+      detail: `${item.flag} • ${item.resultSummary}`,
+      at: item.dateTaken,
+      tone: item.flag === LabFlag.NORMAL ? "success" as TrendTone : "warning" as TrendTone,
+    })),
+    ...symptoms.slice(0, 6).map((item) => ({
+      id: `symptom-${item.id}`,
+      type: "Symptom" as const,
+      title: item.title,
+      detail: `${item.severity}${item.resolved ? " • resolved" : " • unresolved"}`,
+      at: item.startedAt,
+      tone: item.severity === SymptomSeverity.SEVERE && !item.resolved ? "danger" as TrendTone : "warning" as TrendTone,
+    })),
+  ].sort((a, b) => b.at.getTime() - a.at.getTime()).slice(0, 12);
+
+  return {
+    summary: {
+      dataCoverageScore,
+      riskScore,
+      vitalReadings: vitals.length,
+      recentVitalReadings: recentVitals.length,
+      labResults: labs.length,
+      abnormalLabs: abnormalLabs.length,
+      symptoms: symptoms.length,
+      unresolvedSymptoms: unresolvedSymptoms.length,
+      severeSymptoms: severeSymptoms.length,
+      medicationLogs: medicationLogs.length,
+      adherenceRate,
+      upcomingAppointments: upcomingAppointments.length,
+    },
+    vitalMetrics,
+    latestVitals,
+    vitalAverages: {
+      systolic: roundNumber(average(recentVitals.map((item) => item.systolic)), 0),
+      diastolic: roundNumber(average(recentVitals.map((item) => item.diastolic)), 0),
+      heartRate: roundNumber(average(recentVitals.map((item) => item.heartRate)), 0),
+      oxygenSaturation: roundNumber(average(recentVitals.map((item) => item.oxygenSaturation)), 0),
+      bloodSugar: roundNumber(average(recentVitals.map((item) => item.bloodSugar)), 1),
+      temperatureC: roundNumber(average(recentVitals.map((item) => item.temperatureC)), 1),
+      weightKg: roundNumber(average(recentVitals.map((item) => item.weightKg)), 1),
+    },
+    labs: {
+      latest: labs.slice(0, 6),
+      abnormal: abnormalLabs.slice(0, 6),
+      normalCount: labs.filter((lab) => lab.flag === LabFlag.NORMAL).length,
+      borderlineCount: labs.filter((lab) => lab.flag === LabFlag.BORDERLINE).length,
+      highCount: labs.filter((lab) => lab.flag === LabFlag.HIGH).length,
+      lowCount: labs.filter((lab) => lab.flag === LabFlag.LOW).length,
+    },
+    symptoms: {
+      latest: symptoms.slice(0, 6),
+      unresolved: unresolvedSymptoms.slice(0, 6),
+      mildCount: symptoms.filter((symptom) => symptom.severity === SymptomSeverity.MILD).length,
+      moderateCount: symptoms.filter((symptom) => symptom.severity === SymptomSeverity.MODERATE).length,
+      severeCount: symptoms.filter((symptom) => symptom.severity === SymptomSeverity.SEVERE).length,
+    },
+    medications: {
+      logs: medicationLogs.slice(0, 8),
+      takenLogs,
+      missedLogs,
+      skippedLogs,
+      adherenceRate,
+    },
+    upcomingAppointments,
+    insights,
+    recentTimeline,
+  };
+}


### PR DESCRIPTION
This PR adds Patch 14: Health Trends Analytics.

Changes:
- Adds a protected /trends page
- Adds health trend coverage scoring
- Adds a risk score from abnormal labs, unresolved severe symptoms, medication misses, and vital warnings
- Adds vitals trend cards with latest value, previous value, delta, and direction
- Adds 30-day vital averages
- Adds 90-day lab flag breakdown
- Adds symptom severity and unresolved symptom review
- Adds 30-day medication adherence signal
- Adds a recent merged timeline for vitals, labs, and symptoms
- Adds recommended review notes
- Adds Health Trends to the sidebar navigation
- Reuses existing schema models, so no Prisma migration is required