### PR TITLE
Add medication safety hub

### DIFF
--- a/app/medication-safety/page.tsx
+++ b/app/medication-safety/page.tsx
@@ -1,0 +1,240 @@
+import Link from "next/link";
+import { AlertTriangle, BellRing, CalendarClock, CheckCircle2, Pill, ShieldCheck, Stethoscope } from "lucide-react";
+import { AppShell } from "@/components/app-shell";
+import { EmptyState, PageHeader, StatusPill } from "@/components/common";
+import { Badge, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
+import { requireUser } from "@/lib/session";
+import { getMedicationSafetyData, type MedicationSafetyTone } from "@/lib/medication-safety";
+import { formatDate, formatDateTime } from "@/lib/utils";
+
+function toneFromScore(value: number): MedicationSafetyTone {
+  if (value >= 85) return "success";
+  if (value >= 65) return "warning";
+  return "danger";
+}
+
+function priorityTone(priority: string): MedicationSafetyTone {
+  if (priority === "Critical" || priority === "High") return "danger";
+  if (priority === "Medium") return "warning";
+  return "info";
+}
+
+function ProgressBar({ value }: { value: number }) {
+  const safeValue = Math.max(0, Math.min(100, value));
+  return (
+    <div className="h-2 overflow-hidden rounded-full bg-muted">
+      <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${safeValue}%` }} />
+    </div>
+  );
+}
+
+function MetricCard({ title, value, description, icon }: { title: string; value: string | number; description: string; icon: React.ReactNode }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardDescription>{title}</CardDescription>
+            <CardTitle className="mt-2 text-3xl">{value}</CardTitle>
+          </div>
+          <div className="rounded-2xl border border-border/60 bg-background/70 p-2">{icon}</div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default async function MedicationSafetyPage() {
+  const user = await requireUser();
+  const data = await getMedicationSafetyData(user.id);
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-7xl space-y-6 p-6">
+        <PageHeader
+          title="Medication Safety"
+          description="Review active medications, today&apos;s dose coverage, adherence signals, safety gaps, and refill/follow-up risk from one medication-focused workspace."
+          action={
+            <div className="flex flex-wrap gap-2">
+              <Link href="/medications" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium transition-all hover:border-border hover:bg-muted/60">Manage medications</Link>
+              <Link href="/reminders" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium transition-all hover:border-border hover:bg-muted/60">Reminders</Link>
+              <Link href="/alerts" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium transition-all hover:border-border hover:bg-muted/60">Alerts</Link>
+            </div>
+          }
+        />
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+          <MetricCard title="Safety readiness" value={`${data.summary.readinessScore}%`} description="Medication setup quality across schedules, logs, alerts, and expired active records." icon={<ShieldCheck className="h-5 w-5 text-primary" />} />
+          <MetricCard title="Active meds" value={data.summary.activeMedications} description="Medication records currently marked active." icon={<Pill className="h-5 w-5 text-violet-500" />} />
+          <MetricCard title="Today&apos;s completion" value={`${data.summary.todayCompletionRate}%`} description={`${data.summary.todayTaken} taken, ${data.summary.todayMissedOrSkipped} missed/skipped, ${data.summary.todayUnlogged} unlogged.`} icon={<CheckCircle2 className="h-5 w-5 text-emerald-500" />} />
+          <MetricCard title="30-day adherence" value={`${data.summary.adherenceRate}%`} description={`${data.summary.missedRate}% of logged doses were missed or skipped.`} icon={<CalendarClock className="h-5 w-5 text-sky-500" />} />
+          <MetricCard title="Open med alerts" value={data.summary.openMedicationAlerts} description={`${data.summary.highSeverityMedicationAlerts} high-risk medication alert(s) currently open.`} icon={<AlertTriangle className="h-5 w-5 text-amber-500" />} />
+        </div>
+
+        <div className="grid gap-6 xl:grid-cols-[0.9fr_1.1fr]">
+          <Card>
+            <CardHeader>
+              <CardTitle>Medication readiness checklist</CardTitle>
+              <CardDescription>Quick review of the records needed for safe tracking and care handoff.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-sm font-medium">Readiness score</span>
+                  <StatusPill tone={toneFromScore(data.summary.readinessScore)}>{data.summary.readinessScore}%</StatusPill>
+                </div>
+                <ProgressBar value={data.summary.readinessScore} />
+              </div>
+              <div className="space-y-3">
+                {data.readinessChecks.map((check) => (
+                  <div key={check.label} className="flex items-start justify-between gap-3 rounded-2xl border border-border/60 bg-background/60 p-3">
+                    <div>
+                      <p className="font-medium">{check.label}</p>
+                      <p className="text-sm text-muted-foreground">{check.detail}</p>
+                    </div>
+                    <StatusPill tone={check.complete ? "success" : "warning"}>{check.complete ? "Ready" : "Review"}</StatusPill>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Safety action queue</CardTitle>
+              <CardDescription>Prioritized issues that can improve medication safety and reporting quality.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {data.safetyItems.map((item) => (
+                <div key={item.id} className="rounded-2xl border border-border/60 bg-background/60 p-4">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <StatusPill tone={priorityTone(item.priority)}>{item.priority}</StatusPill>
+                    <StatusPill tone={item.tone}>{item.tone === "danger" ? "Risk" : item.tone === "warning" ? "Needs setup" : item.tone === "info" ? "Upcoming" : "Context"}</StatusPill>
+                  </div>
+                  <div className="mt-3 space-y-1">
+                    <p className="font-medium">{item.title}</p>
+                    <p className="text-sm text-muted-foreground">{item.description}</p>
+                    <p className="text-sm text-foreground/80">Next step: {item.action}</p>
+                  </div>
+                </div>
+              ))}
+              {data.safetyItems.length === 0 ? <EmptyState title="No medication safety gaps" description="Your active medication records do not have urgent setup or adherence gaps right now." /> : null}
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Today&apos;s dose board</CardTitle>
+            <CardDescription>Schedule-level view for active medication doses due today.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+              {data.todayDoseRows.map((row) => (
+                <div key={row.id} className="rounded-2xl border border-border/60 bg-background/60 p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="font-medium">{row.medicationName}</p>
+                      <p className="text-sm text-muted-foreground">{row.dosage} • {row.scheduleTime}</p>
+                    </div>
+                    <StatusPill tone={row.tone}>{row.status}</StatusPill>
+                  </div>
+                  <div className="mt-3 space-y-1 text-sm text-muted-foreground">
+                    <p>Provider: {row.doctorName}</p>
+                    <p>Logged: {row.loggedAt ? formatDateTime(row.loggedAt) : "Not logged today"}</p>
+                  </div>
+                </div>
+              ))}
+              {data.todayDoseRows.length === 0 ? <EmptyState title="No scheduled doses" description="Add schedule times to active medications to populate today&apos;s dose board." /> : null}
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="grid gap-6 xl:grid-cols-[1.15fr_0.85fr]">
+          <Card>
+            <CardHeader>
+              <CardTitle>Medication adherence cards</CardTitle>
+              <CardDescription>Thirty-day adherence signal per active medication.</CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-3 md:grid-cols-2">
+              {data.medicationCards.map((medication) => (
+                <div key={medication.id} className="rounded-2xl border border-border/60 bg-background/60 p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="font-medium">{medication.name}</p>
+                      <p className="text-sm text-muted-foreground">{medication.dosage} • {medication.frequency}</p>
+                    </div>
+                    <StatusPill tone={medication.tone}>{medication.logged > 0 ? `${medication.adherence}%` : "No logs"}</StatusPill>
+                  </div>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <Badge>{medication.scheduleCount} schedule(s)</Badge>
+                    <Badge>{medication.taken} taken</Badge>
+                    <Badge>{medication.missed} missed</Badge>
+                    <Badge>{medication.skipped} skipped</Badge>
+                  </div>
+                  <div className="mt-3 space-y-1 text-sm text-muted-foreground">
+                    <p>Provider: {medication.doctorName ?? "No linked doctor"}</p>
+                    {medication.endDate ? <p>End date: {formatDate(medication.endDate)} {medication.daysUntilEnd !== null ? `(${medication.daysUntilEnd} day(s))` : ""}</p> : <p>No end date set</p>}
+                    {medication.instructions ? <p>Instructions: {medication.instructions}</p> : null}
+                  </div>
+                </div>
+              ))}
+              {data.medicationCards.length === 0 ? <EmptyState title="No active medication cards" description="Active medications will appear here once added." /> : null}
+            </CardContent>
+          </Card>
+
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Medication reminders</CardTitle>
+                <CardDescription>Due, overdue, or missed medication reminders in the next 30 days.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {data.medicationReminders.map((reminder) => (
+                  <div key={reminder.id} className="rounded-2xl border border-border/60 bg-background/60 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="font-medium">{reminder.title}</p>
+                        <p className="text-sm text-muted-foreground">{reminder.description ?? "Medication reminder"}</p>
+                      </div>
+                      <StatusPill tone={reminder.state === "OVERDUE" || reminder.state === "MISSED" ? "danger" : "warning"}>{reminder.state}</StatusPill>
+                    </div>
+                    <p className="mt-2 text-xs text-muted-foreground">Due: {formatDateTime(reminder.dueAt)}</p>
+                  </div>
+                ))}
+                {data.medicationReminders.length === 0 ? <EmptyState title="No medication reminders" description="Medication reminders due soon will appear here." /> : null}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Open medication alerts</CardTitle>
+                <CardDescription>Adherence and medication-log alerts requiring review.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {data.openMedicationAlerts.map((alert) => (
+                  <div key={alert.id} className="rounded-2xl border border-border/60 bg-background/60 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="font-medium">{alert.title}</p>
+                        <p className="text-sm text-muted-foreground">{alert.message}</p>
+                      </div>
+                      <StatusPill tone={alert.severity === "CRITICAL" || alert.severity === "HIGH" ? "danger" : "warning"}>{alert.severity}</StatusPill>
+                    </div>
+                    <p className="mt-2 text-xs text-muted-foreground">Opened: {formatDateTime(alert.createdAt)}</p>
+                  </div>
+                ))}
+                {data.openMedicationAlerts.length === 0 ? <EmptyState title="No open medication alerts" description="Medication adherence alerts will appear here when monitoring rules create them." /> : null}
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+
+        <p className="text-xs text-muted-foreground">Generated {formatDateTime(data.generatedAt)}. This page summarizes tracking quality and workflow signals only. It does not replace professional medical advice.</p>
+      </div>
+    </AppShell>
+  );
+}

--- a/docs/PATCH_15_MEDICATION_SAFETY.md
+++ b/docs/PATCH_15_MEDICATION_SAFETY.md
@@ -1,0 +1,53 @@
+# Patch 15 — Medication Safety Hub
+
+## Summary
+
+This patch adds a medication-focused safety workspace that turns the existing medication, schedule, adherence-log, reminder, alert, and doctor data into a practical review surface.
+
+## Files changed
+
+- `app/medication-safety/page.tsx`
+- `lib/medication-safety.ts`
+- `lib/app-routes.ts`
+- `docs/PATCH_15_MEDICATION_SAFETY.md`
+
+## What was added
+
+- Protected `/medication-safety` page
+- Medication safety readiness score
+- Today dose board for scheduled active medications
+- 30-day adherence signal
+- Missed/skipped dose percentage
+- Active medication cards with schedule count, provider context, end-date review, and adherence signal
+- Safety action queue for:
+  - high-risk medication alerts
+  - active medications past their end date
+  - medications with no schedule times
+  - medications ending in the next 30 days
+  - medications without a linked doctor/provider
+- Medication reminder panel
+- Open medication alert panel
+- Sidebar navigation entry
+
+## Safety notes
+
+- No Prisma migration is required.
+- No medication advice is generated.
+- The feature only summarizes existing records and workflow gaps.
+- The page includes a disclaimer that it is not a substitute for professional medical advice.
+
+## Validation checklist
+
+Run:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:run
+```
+
+Manual route:
+
+```txt
+/medication-safety
+```

--- a/lib/app-routes.ts
+++ b/lib/app-routes.ts
@@ -104,6 +104,12 @@ export const primaryRoutes: AppRouteItem[] = [
     icon: Pill,
   },
   {
+    title: "Medication Safety",
+    href: "/medication-safety",
+    description: "Adherence, dose coverage, refill risk, and medication safety review",
+    icon: ShieldCheck,
+  },
+  {
     title: "Appointments",
     href: "/appointments",
     description: "Visits, follow-ups, doctors, and notes",

--- a/lib/medication-safety.ts
+++ b/lib/medication-safety.ts
@@ -1,0 +1,328 @@
+import {
+  AlertRuleCategory,
+  AlertSeverity,
+  AlertSourceType,
+  AlertStatus,
+  MedicationLogStatus,
+  MedicationStatus,
+  ReminderState,
+  ReminderType,
+} from "@prisma/client";
+import { addDays, differenceInCalendarDays, endOfDay, startOfDay, subDays } from "date-fns";
+import { db } from "@/lib/db";
+
+export type MedicationSafetyTone = "success" | "warning" | "danger" | "info" | "neutral";
+
+export type MedicationSafetyItem = {
+  id: string;
+  title: string;
+  description: string;
+  tone: MedicationSafetyTone;
+  priority: "Critical" | "High" | "Medium" | "Low";
+  action: string;
+};
+
+export type MedicationDoseRow = {
+  id: string;
+  medicationId: string;
+  medicationName: string;
+  dosage: string;
+  scheduleTime: string;
+  doctorName: string;
+  status: "TAKEN" | "MISSED" | "SKIPPED" | "UNLOGGED";
+  loggedAt: Date | null;
+  tone: MedicationSafetyTone;
+};
+
+export type MedicationSafetyData = Awaited<ReturnType<typeof getMedicationSafetyData>>;
+
+type LogLite = {
+  medicationId: string;
+  scheduleTime: string | null;
+  loggedAt: Date;
+  status: MedicationLogStatus;
+};
+
+function doseKey(medicationId: string, scheduleTime: string | null) {
+  return `${medicationId}__${scheduleTime ?? "unscheduled"}`;
+}
+
+function adherenceTone(value: number): MedicationSafetyTone {
+  if (value >= 85) return "success";
+  if (value >= 65) return "warning";
+  return "danger";
+}
+
+function statusTone(status: MedicationDoseRow["status"]): MedicationSafetyTone {
+  if (status === "TAKEN") return "success";
+  if (status === "MISSED") return "danger";
+  if (status === "SKIPPED") return "warning";
+  return "neutral";
+}
+
+function buildLatestLogMap(logs: LogLite[]) {
+  const map = new Map<string, LogLite>();
+  for (const log of logs) {
+    const key = doseKey(log.medicationId, log.scheduleTime);
+    const existing = map.get(key);
+    if (!existing || existing.loggedAt < log.loggedAt) {
+      map.set(key, log);
+    }
+  }
+  return map;
+}
+
+export async function getMedicationSafetyData(userId: string) {
+  const now = new Date();
+  const todayStart = startOfDay(now);
+  const todayEnd = endOfDay(now);
+  const thirtyDaysAgo = startOfDay(subDays(now, 29));
+  const nextThirtyDays = endOfDay(addDays(now, 30));
+
+  const [medications, logs30Days, todayLogs, openMedicationAlerts, medicationReminders] = await Promise.all([
+    db.medication.findMany({
+      where: { userId },
+      include: {
+        schedules: { orderBy: { timeOfDay: "asc" } },
+        doctor: { select: { id: true, name: true, specialty: true } },
+      },
+      orderBy: [{ status: "asc" }, { createdAt: "desc" }],
+    }),
+    db.medicationLog.findMany({
+      where: { userId, loggedAt: { gte: thirtyDaysAgo } },
+      orderBy: { loggedAt: "desc" },
+      select: {
+        medicationId: true,
+        scheduleTime: true,
+        loggedAt: true,
+        status: true,
+      },
+    }),
+    db.medicationLog.findMany({
+      where: { userId, loggedAt: { gte: todayStart, lte: todayEnd } },
+      orderBy: { loggedAt: "desc" },
+      select: {
+        medicationId: true,
+        scheduleTime: true,
+        loggedAt: true,
+        status: true,
+      },
+    }),
+    db.alertEvent.findMany({
+      where: {
+        userId,
+        status: AlertStatus.OPEN,
+        OR: [
+          { category: AlertRuleCategory.MEDICATION_ADHERENCE },
+          { sourceType: AlertSourceType.MEDICATION_LOG },
+        ],
+      },
+      orderBy: { createdAt: "desc" },
+      take: 8,
+      select: {
+        id: true,
+        title: true,
+        message: true,
+        severity: true,
+        createdAt: true,
+      },
+    }),
+    db.reminder.findMany({
+      where: {
+        userId,
+        type: ReminderType.MEDICATION,
+        dueAt: { lte: nextThirtyDays },
+        state: { in: [ReminderState.DUE, ReminderState.OVERDUE, ReminderState.MISSED] },
+      },
+      orderBy: { dueAt: "asc" },
+      take: 12,
+      select: {
+        id: true,
+        title: true,
+        description: true,
+        dueAt: true,
+        state: true,
+      },
+    }),
+  ]);
+
+  const activeMedications = medications.filter(
+    (item) => item.active && item.status === MedicationStatus.ACTIVE
+  );
+
+  const scheduledDoseSlots = activeMedications.reduce(
+    (sum, medication) => sum + Math.max(1, medication.schedules.length),
+    0
+  );
+
+  const thirtyDayTaken = logs30Days.filter((log) => log.status === MedicationLogStatus.TAKEN).length;
+  const thirtyDayMissed = logs30Days.filter((log) => log.status === MedicationLogStatus.MISSED).length;
+  const thirtyDaySkipped = logs30Days.filter((log) => log.status === MedicationLogStatus.SKIPPED).length;
+  const thirtyDayLogged = thirtyDayTaken + thirtyDayMissed + thirtyDaySkipped;
+  const adherenceRate = thirtyDayLogged > 0 ? Math.round((thirtyDayTaken / thirtyDayLogged) * 100) : 0;
+  const missedRate = thirtyDayLogged > 0 ? Math.round(((thirtyDayMissed + thirtyDaySkipped) / thirtyDayLogged) * 100) : 0;
+
+  const todayLogMap = buildLatestLogMap(todayLogs);
+  const todayDoseRows: MedicationDoseRow[] = activeMedications.flatMap((medication) => {
+    const scheduleTimes = medication.schedules.length ? medication.schedules.map((schedule) => schedule.timeOfDay) : ["Unscheduled"];
+
+    return scheduleTimes.map((scheduleTime) => {
+      const normalizedSchedule = scheduleTime === "Unscheduled" ? null : scheduleTime;
+      const log = todayLogMap.get(doseKey(medication.id, normalizedSchedule));
+      const status = log?.status ?? "UNLOGGED";
+
+      return {
+        id: `${medication.id}-${scheduleTime}`,
+        medicationId: medication.id,
+        medicationName: medication.name,
+        dosage: medication.dosage,
+        scheduleTime,
+        doctorName: medication.doctor?.name ?? "No linked doctor",
+        status,
+        loggedAt: log?.loggedAt ?? null,
+        tone: statusTone(status),
+      };
+    });
+  });
+
+  const todayTaken = todayDoseRows.filter((row) => row.status === "TAKEN").length;
+  const todayMissedOrSkipped = todayDoseRows.filter((row) => row.status === "MISSED" || row.status === "SKIPPED").length;
+  const todayUnlogged = todayDoseRows.filter((row) => row.status === "UNLOGGED").length;
+  const todayCompletionRate = todayDoseRows.length > 0 ? Math.round((todayTaken / todayDoseRows.length) * 100) : 0;
+
+  const medsWithoutSchedules = activeMedications.filter((medication) => medication.schedules.length === 0);
+  const medsWithoutDoctor = activeMedications.filter((medication) => !medication.doctorId);
+  const endingSoon = activeMedications
+    .filter((medication) => medication.endDate && medication.endDate >= now && medication.endDate <= nextThirtyDays)
+    .sort((a, b) => Number(a.endDate) - Number(b.endDate));
+  const expiredButActive = activeMedications.filter((medication) => medication.endDate && medication.endDate < now);
+
+  const highSeverityMedicationAlerts = openMedicationAlerts.filter(
+    (alert) => alert.severity === AlertSeverity.HIGH || alert.severity === AlertSeverity.CRITICAL
+  );
+
+  const safetyItems: MedicationSafetyItem[] = [
+    ...highSeverityMedicationAlerts.map((alert) => ({
+      id: `alert-${alert.id}`,
+      title: alert.title,
+      description: alert.message,
+      tone: "danger" as const,
+      priority: alert.severity === AlertSeverity.CRITICAL ? "Critical" as const : "High" as const,
+      action: "Review the adherence alert and resolve or acknowledge it from the Alert Center.",
+    })),
+    ...expiredButActive.map((medication) => ({
+      id: `expired-${medication.id}`,
+      title: `${medication.name} is still active after its end date`,
+      description: `This medication ended on ${medication.endDate?.toLocaleDateString("en-PH") ?? "a past date"} but is still marked active.`,
+      tone: "danger" as const,
+      priority: "High" as const,
+      action: "Confirm whether the medication should be completed, renewed, or updated.",
+    })),
+    ...medsWithoutSchedules.map((medication) => ({
+      id: `schedule-${medication.id}`,
+      title: `${medication.name} has no dose schedule`,
+      description: "A medication without schedule times is harder to track for adherence.",
+      tone: "warning" as const,
+      priority: "Medium" as const,
+      action: "Add at least one schedule time or clarify that this is an as-needed medication.",
+    })),
+    ...endingSoon.slice(0, 5).map((medication) => ({
+      id: `ending-${medication.id}`,
+      title: `${medication.name} ends soon`,
+      description: `Current end date is ${medication.endDate?.toLocaleDateString("en-PH")}.`,
+      tone: "info" as const,
+      priority: "Low" as const,
+      action: "Prepare a refill, renewal, or doctor follow-up if this medication should continue.",
+    })),
+    ...medsWithoutDoctor.slice(0, 5).map((medication) => ({
+      id: `doctor-${medication.id}`,
+      title: `${medication.name} has no linked doctor`,
+      description: "Linking a prescribing doctor improves handoff reports and care-team review.",
+      tone: "neutral" as const,
+      priority: "Low" as const,
+      action: "Attach a doctor/provider to the medication record when available.",
+    })),
+  ];
+
+  const readinessChecks = [
+    {
+      label: "Active medications documented",
+      complete: activeMedications.length > 0,
+      detail: activeMedications.length > 0 ? `${activeMedications.length} active medication(s)` : "No active medications yet",
+    },
+    {
+      label: "Dose schedules configured",
+      complete: activeMedications.length > 0 && medsWithoutSchedules.length === 0,
+      detail: medsWithoutSchedules.length === 0 ? "Every active medication has a schedule" : `${medsWithoutSchedules.length} medication(s) need schedule times`,
+    },
+    {
+      label: "Today has adherence activity",
+      complete: todayTaken + todayMissedOrSkipped > 0 || todayDoseRows.length === 0,
+      detail: todayDoseRows.length === 0 ? "No scheduled dose rows today" : `${todayTaken + todayMissedOrSkipped} logged dose(s) today`,
+    },
+    {
+      label: "No high-risk medication alerts",
+      complete: highSeverityMedicationAlerts.length === 0,
+      detail: highSeverityMedicationAlerts.length === 0 ? "No high-risk medication alerts open" : `${highSeverityMedicationAlerts.length} high-risk alert(s) open`,
+    },
+    {
+      label: "No active expired medications",
+      complete: expiredButActive.length === 0,
+      detail: expiredButActive.length === 0 ? "No expired active medications" : `${expiredButActive.length} medication(s) need review`,
+    },
+  ];
+
+  const readinessScore = Math.round((readinessChecks.filter((check) => check.complete).length / readinessChecks.length) * 100);
+
+  const medicationCards = activeMedications.map((medication) => {
+    const medLogs = logs30Days.filter((log) => log.medicationId === medication.id);
+    const taken = medLogs.filter((log) => log.status === MedicationLogStatus.TAKEN).length;
+    const missed = medLogs.filter((log) => log.status === MedicationLogStatus.MISSED).length;
+    const skipped = medLogs.filter((log) => log.status === MedicationLogStatus.SKIPPED).length;
+    const logged = taken + missed + skipped;
+    const adherence = logged > 0 ? Math.round((taken / logged) * 100) : 0;
+    const daysUntilEnd = medication.endDate ? differenceInCalendarDays(medication.endDate, now) : null;
+
+    return {
+      id: medication.id,
+      name: medication.name,
+      dosage: medication.dosage,
+      frequency: medication.frequency,
+      instructions: medication.instructions,
+      scheduleCount: medication.schedules.length,
+      doctorName: medication.doctor?.name ?? null,
+      endDate: medication.endDate,
+      daysUntilEnd,
+      adherence,
+      logged,
+      taken,
+      missed,
+      skipped,
+      tone: logged === 0 ? "neutral" as const : adherenceTone(adherence),
+    };
+  });
+
+  return {
+    generatedAt: now,
+    summary: {
+      activeMedications: activeMedications.length,
+      scheduledDoseSlots,
+      todayCompletionRate,
+      todayTaken,
+      todayMissedOrSkipped,
+      todayUnlogged,
+      adherenceRate,
+      missedRate,
+      openMedicationAlerts: openMedicationAlerts.length,
+      highSeverityMedicationAlerts: highSeverityMedicationAlerts.length,
+      medicationReminders: medicationReminders.length,
+      readinessScore,
+    },
+    readinessChecks,
+    safetyItems: safetyItems.slice(0, 12),
+    todayDoseRows,
+    medicationCards,
+    medicationReminders,
+    openMedicationAlerts,
+  };
+}


### PR DESCRIPTION
This PR adds Patch 15: Medication Safety Hub.

Changes:
- Adds a protected /medication-safety page
- Adds medication safety readiness scoring
- Adds today’s dose board for scheduled active medications
- Adds 30-day adherence, missed-dose, and skipped-dose signals
- Adds active medication cards with schedule, provider, end-date, and adherence context
- Adds a prioritized safety action queue for alerts, expired active meds, missing schedules, ending-soon meds, and missing provider links
- Adds medication reminders and open medication alerts panels
- Adds Medication Safety to the sidebar navigation
- Reuses existing schema models, so no Prisma migration is required