### PR TITLE
Add visit prep hub

### DIFF
--- a/app/api-docs/page.tsx
+++ b/app/api-docs/page.tsx
@@ -7,7 +7,6 @@ import {
   DatabaseZap,
   KeyRound,
   LockKeyhole,
-  LogOut,
   ServerCog,
   ShieldCheck,
   Smartphone,

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -37,13 +37,6 @@ function formatDateTime(value: Date) {
   });
 }
 
-function severityTone(severity: string) {
-  if (severity === "CRITICAL") return "danger";
-  if (severity === "HIGH") return "danger";
-  if (severity === "MEDIUM") return "warning";
-  return "info";
-}
-
 function completionTone(value: number) {
   if (value >= 85) return "success";
   if (value >= 60) return "info";

--- a/app/demo/ai-insights/page.tsx
+++ b/app/demo/ai-insights/page.tsx
@@ -1,4 +1,4 @@
-import { BulletList, DemoHeader, DemoSection, MetricGrid, StatCards, ToneBadge } from "@/components/demo-primitives";
+import { BulletList, DemoHeader, DemoSection, MetricGrid, StatCards } from "@/components/demo-primitives";
 import { demoAiInsights } from "@/lib/demo-data";
 
 export default function DemoAiInsightsPage() {

--- a/app/medication-safety/page.tsx
+++ b/app/medication-safety/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { AlertTriangle, BellRing, CalendarClock, CheckCircle2, Pill, ShieldCheck, Stethoscope } from "lucide-react";
+import { AlertTriangle, CalendarClock, CheckCircle2, Pill, ShieldCheck } from "lucide-react";
 import { AppShell } from "@/components/app-shell";
 import { EmptyState, PageHeader, StatusPill } from "@/components/common";
 import { Badge, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";

--- a/app/patient/[ownerUserId]/page.tsx
+++ b/app/patient/[ownerUserId]/page.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import {
-  Activity,
   AlertTriangle,
   Brain,
   CalendarDays,

--- a/app/visit-prep/page.tsx
+++ b/app/visit-prep/page.tsx
@@ -1,0 +1,275 @@
+import Link from "next/link";
+import {
+  AlertTriangle,
+  CalendarCheck2,
+  ClipboardCheck,
+  FileText,
+  HeartPulse,
+  Pill,
+  Stethoscope,
+} from "lucide-react";
+import { AppShell } from "@/components/app-shell";
+import { EmptyState, PageHeader, StatusPill } from "@/components/common";
+import { Badge, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
+import { requireUser } from "@/lib/session";
+import { getVisitPrepData, type VisitPrepPriority, type VisitPrepTimelineItem } from "@/lib/visit-prep";
+
+function formatDateTime(value: Date | null | undefined) {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat("en-PH", { dateStyle: "medium", timeStyle: "short" }).format(value);
+}
+
+function priorityTone(priority: VisitPrepPriority) {
+  if (priority === "critical") return "danger" as const;
+  if (priority === "high") return "warning" as const;
+  if (priority === "medium") return "info" as const;
+  return "neutral" as const;
+}
+
+function sourceTone(source: VisitPrepTimelineItem["source"]) {
+  if (source === "appointment") return "success" as const;
+  if (source === "reminder") return "warning" as const;
+  if (source === "lab") return "danger" as const;
+  if (source === "symptom") return "info" as const;
+  if (source === "vital") return "success" as const;
+  return "neutral" as const;
+}
+
+function ProgressBar({ value }: { value: number }) {
+  const safeValue = Math.max(0, Math.min(100, value));
+  return (
+    <div className="h-2 overflow-hidden rounded-full bg-muted">
+      <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${safeValue}%` }} />
+    </div>
+  );
+}
+
+function StatCard({ title, value, description, icon }: { title: string; value: string | number; description: string; icon: React.ReactNode }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardDescription>{title}</CardDescription>
+            <CardTitle className="mt-2 text-3xl">{value}</CardTitle>
+          </div>
+          <div className="rounded-2xl border border-border/60 bg-background/70 p-2">{icon}</div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function DetailCard({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-2xl border border-border/60 bg-background/60 p-4">
+      <p className="mb-2 font-medium">{title}</p>
+      <div className="text-sm text-muted-foreground">{children}</div>
+    </div>
+  );
+}
+
+export default async function VisitPrepPage() {
+  const user = await requireUser();
+  const data = await getVisitPrepData(user.id);
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-7xl space-y-6 p-6">
+        <PageHeader
+          title="Visit Prep Hub"
+          description="Prepare a cleaner doctor visit packet from your appointments, medications, labs, vitals, symptoms, documents, reminders, and alerts."
+          action={
+            <div className="flex flex-wrap gap-2">
+              <Link href="/summary/print?mode=doctor" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium transition-all hover:border-border hover:bg-muted/60">
+                Doctor packet
+              </Link>
+              <Link href="/appointments" className="inline-flex h-10 items-center justify-center rounded-2xl bg-primary px-4 text-sm font-medium text-primary-foreground transition-all hover:opacity-95">
+                Appointments
+              </Link>
+            </div>
+          }
+        />
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+          <StatCard title="Prep readiness" value={`${data.readinessScore}%`} description="How complete the next visit packet is based on core context." icon={<ClipboardCheck className="h-5 w-5 text-primary" />} />
+          <StatCard title="Critical tasks" value={data.summary.criticalTasks} description="Items that should be discussed before or during the next visit." icon={<AlertTriangle className="h-5 w-5 text-rose-500" />} />
+          <StatCard title="Flagged labs" value={data.summary.abnormalLabs} description="Recent lab results with borderline, high, or low flags." icon={<FileText className="h-5 w-5 text-amber-500" />} />
+          <StatCard title="Active meds" value={data.summary.activeMedications} description="Current medications to confirm with the provider." icon={<Pill className="h-5 w-5 text-sky-500" />} />
+          <StatCard title="Packet items" value={data.summary.packetItems} description="Recent records available for the visit packet." icon={<CalendarCheck2 className="h-5 w-5 text-emerald-500" />} />
+        </div>
+
+        <div className="grid gap-6 xl:grid-cols-[0.88fr_1.12fr]">
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Next visit context</CardTitle>
+                <CardDescription>The appointment this workspace is currently preparing around.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                {data.nextAppointment ? (
+                  <div className="space-y-4">
+                    <div>
+                      <p className="text-2xl font-semibold">{data.nextAppointment.purpose}</p>
+                      <p className="mt-1 text-sm text-muted-foreground">{formatDateTime(data.nextAppointment.scheduledAt)}</p>
+                    </div>
+                    <div className="grid gap-3 md:grid-cols-2">
+                      <DetailCard title="Provider">
+                        {data.nextAppointment.doctorName}
+                        <br />
+                        {data.nextAppointment.specialty || data.nextAppointment.doctor?.specialty || "Specialty not set"}
+                      </DetailCard>
+                      <DetailCard title="Clinic">
+                        {data.nextAppointment.clinic}
+                        <br />
+                        {data.nextAppointment.doctor?.phone || "No phone recorded"}
+                      </DetailCard>
+                    </div>
+                    {data.nextAppointment.notes ? <p className="rounded-2xl bg-muted/50 p-4 text-sm text-muted-foreground">{data.nextAppointment.notes}</p> : null}
+                  </div>
+                ) : (
+                  <EmptyState title="No upcoming visit yet" description="Add an appointment so VitaVault can build a provider-ready packet around the visit date." />
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Readiness checklist</CardTitle>
+                <CardDescription>Quick checks that improve the quality of the visit packet.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="font-medium">Overall readiness</span>
+                    <span className="text-muted-foreground">{data.readinessScore}%</span>
+                  </div>
+                  <ProgressBar value={data.readinessScore} />
+                </div>
+                <div className="space-y-2">
+                  {data.readinessChecks.map((item) => (
+                    <Link key={item.label} href={item.href} className="flex items-center justify-between gap-3 rounded-2xl border border-border/60 bg-background/60 p-3 transition-all hover:bg-muted/40">
+                      <span className="text-sm font-medium">{item.label}</span>
+                      <StatusPill tone={item.complete ? "success" : "warning"}>{item.complete ? "Ready" : "Missing"}</StatusPill>
+                    </Link>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Priority visit prep queue</CardTitle>
+              <CardDescription>Tasks generated from gaps, abnormal records, severe symptoms, open alerts, and unlinked documents.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {data.tasks.map((task) => (
+                <Link key={`${task.priority}-${task.title}`} href={task.href} className="block rounded-2xl border border-border/60 bg-background/60 p-4 transition-all hover:bg-muted/40">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="space-y-1">
+                      <p className="font-medium">{task.title}</p>
+                      <p className="text-sm text-muted-foreground">{task.detail}</p>
+                    </div>
+                    <StatusPill tone={priorityTone(task.priority)}>{task.priority}</StatusPill>
+                  </div>
+                </Link>
+              ))}
+              {data.tasks.length === 0 ? <EmptyState title="Visit packet looks ready" description="No urgent visit-prep gaps were detected from the available records." /> : null}
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
+          <Card>
+            <CardHeader>
+              <CardTitle>Provider timeline</CardTitle>
+              <CardDescription>Near-term appointments, reminders, labs, symptoms, vitals, and documents sorted by relevance to the visit window.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {data.timeline.map((item) => (
+                <Link key={item.id} href={item.href} className="flex flex-wrap items-start justify-between gap-3 rounded-2xl border border-border/60 bg-background/60 p-4 transition-all hover:bg-muted/40">
+                  <div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <StatusPill tone={sourceTone(item.source)}>{item.source}</StatusPill>
+                      <p className="font-medium">{item.title}</p>
+                    </div>
+                    <p className="mt-2 text-sm text-muted-foreground">{item.detail}</p>
+                  </div>
+                  <span className="text-xs text-muted-foreground">{formatDateTime(item.at)}</span>
+                </Link>
+              ))}
+              {data.timeline.length === 0 ? <EmptyState title="No timeline items yet" description="Appointments, labs, vitals, documents, reminders, and symptoms will appear here once records exist." /> : null}
+            </CardContent>
+          </Card>
+
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Medication snapshot</CardTitle>
+                <CardDescription>Active medications to confirm before the provider conversation.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {data.activeMedications.slice(0, 6).map((medication) => (
+                  <div key={medication.id} className="rounded-2xl border border-border/60 bg-background/60 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="font-medium">{medication.name}</p>
+                        <p className="text-sm text-muted-foreground">{medication.dosage} • {medication.frequency}</p>
+                      </div>
+                      <Badge>{medication.schedules.length} schedules</Badge>
+                    </div>
+                    <p className="mt-2 text-xs text-muted-foreground">Provider: {medication.doctor?.name || "No linked provider"}</p>
+                  </div>
+                ))}
+                {data.activeMedications.length === 0 ? <EmptyState title="No active medications" description="Add active medications before generating a provider packet." /> : null}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Care context</CardTitle>
+                <CardDescription>Provider and safety context that can strengthen the visit handoff.</CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-3">
+                <DetailCard title="Emergency contact">
+                  {data.profile?.emergencyContactName ? `${data.profile.emergencyContactName} • ${data.profile.emergencyContactPhone || "No phone"}` : "Not recorded"}
+                </DetailCard>
+                <DetailCard title="Allergies">
+                  {data.profile?.allergiesSummary || "No allergy context recorded"}
+                </DetailCard>
+                <DetailCard title="Doctors on file">
+                  {data.doctors.length ? `${data.doctors.length} provider${data.doctors.length === 1 ? "" : "s"} available` : "No doctors recorded"}
+                </DetailCard>
+                <DetailCard title="Recent documents">
+                  {data.recentDocuments.length ? `${data.recentDocuments.length} recent file${data.recentDocuments.length === 1 ? "" : "s"}; ${data.unlinkedDocuments.length} unlinked` : "No recent documents"}
+                </DetailCard>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Review signals</CardTitle>
+                <CardDescription>What should be called out during the appointment.</CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-3 md:grid-cols-2 xl:grid-cols-1">
+                <DetailCard title="Symptoms">
+                  <div className="flex items-center gap-2"><HeartPulse className="h-4 w-4" /> {data.summary.unresolvedSevereSymptoms} unresolved severe</div>
+                </DetailCard>
+                <DetailCard title="Alerts">
+                  <div className="flex items-center gap-2"><AlertTriangle className="h-4 w-4" /> {data.openAlerts.length} open alerts</div>
+                </DetailCard>
+                <DetailCard title="Providers">
+                  <div className="flex items-center gap-2"><Stethoscope className="h-4 w-4" /> {data.doctors.length} contacts</div>
+                </DetailCard>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </div>
+    </AppShell>
+  );
+}

--- a/docs/PATCH_16B_VISIT_PREP_LINT_TYPECHECK_FIX.md
+++ b/docs/PATCH_16B_VISIT_PREP_LINT_TYPECHECK_FIX.md
@@ -1,0 +1,24 @@
+# Patch 16B — Visit Prep Lint and Typecheck Fix
+
+This hotfix stabilizes Patch 16 after CI/local checks reported a parser error in `lib/visit-prep.ts` and several unused import warnings.
+
+## Fixes
+
+- Corrects the unterminated template literal in `lib/visit-prep.ts`.
+- Removes unused `LogOut` import from `app/api-docs/page.tsx`.
+- Removes unused `severityTone` helper from `app/dashboard/page.tsx`.
+- Removes unused `ToneBadge` import from `app/demo/ai-insights/page.tsx`.
+- Removes unused `BellRing` and `Stethoscope` imports from `app/medication-safety/page.tsx`.
+- Removes unused `Activity` import from `app/patient/[ownerUserId]/page.tsx`.
+
+## Validation
+
+Run:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:run
+```
+
+No Prisma migration is required.

--- a/docs/PATCH_16_VISIT_PREP_HUB.md
+++ b/docs/PATCH_16_VISIT_PREP_HUB.md
@@ -1,0 +1,49 @@
+# Patch 16 — Visit Prep Hub
+
+## Files changed
+
+- `app/visit-prep/page.tsx`
+- `lib/visit-prep.ts`
+- `lib/app-routes.ts`
+
+## Summary
+
+This patch adds a protected Visit Prep Hub that helps patients prepare for provider appointments using existing VitaVault records.
+
+## Added
+
+- Protected `/visit-prep` route
+- Visit readiness score
+- Next appointment context panel
+- Provider-ready prep task queue
+- Readiness checklist for emergency contact, allergies, medications, labs, vitals, doctors, symptoms, and appointments
+- Provider timeline from appointments, reminders, labs, symptoms, vitals, and documents
+- Medication snapshot for active medications
+- Care context panel for allergies, emergency contact, doctors, and document hygiene
+- Review signals for open alerts and unresolved severe symptoms
+- Sidebar navigation entry
+
+## Implementation notes
+
+- Uses existing Prisma models only
+- Requires no database migration
+- Does not add schema-level account, care, or admin changes
+- Can be paired with the existing `/summary/print?mode=doctor` route for a printable handoff packet
+
+## Manual checks
+
+Visit:
+
+```txt
+/visit-prep
+/appointments
+/summary/print?mode=doctor
+```
+
+Run:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:run
+```

--- a/lib/app-routes.ts
+++ b/lib/app-routes.ts
@@ -55,6 +55,13 @@ export const primaryRoutes: AppRouteItem[] = [
     description: "Prioritized next steps across records, alerts, reminders, and visits",
     icon: ClipboardCheck,
   },
+
+  {
+    title: "Visit Prep",
+    href: "/visit-prep",
+    description: "Provider-ready visit packet, prep tasks, and care context",
+    icon: ClipboardList,
+  },
   {
     title: "Health Trends",
     href: "/trends",

--- a/lib/visit-prep.ts
+++ b/lib/visit-prep.ts
@@ -1,0 +1,329 @@
+import {
+  AlertSeverity,
+  AlertStatus,
+  AppointmentStatus,
+  LabFlag,
+  MedicationStatus,
+  ReminderState,
+} from "@prisma/client";
+import { db } from "@/lib/db";
+
+export type VisitPrepPriority = "critical" | "high" | "medium" | "low";
+
+export type VisitPrepTask = {
+  title: string;
+  detail: string;
+  priority: VisitPrepPriority;
+  href: string;
+};
+
+export type VisitPrepTimelineItem = {
+  id: string;
+  title: string;
+  detail: string;
+  at: Date;
+  source: "appointment" | "reminder" | "lab" | "symptom" | "vital" | "document";
+  href: string;
+};
+
+function addDays(date: Date, days: number) {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+function priorityRank(priority: VisitPrepPriority) {
+  if (priority === "critical") return 4;
+  if (priority === "high") return 3;
+  if (priority === "medium") return 2;
+  return 1;
+}
+
+function getAlertPriority(severity: AlertSeverity): VisitPrepPriority {
+  if (severity === AlertSeverity.CRITICAL) return "critical";
+  if (severity === AlertSeverity.HIGH) return "high";
+  if (severity === AlertSeverity.MEDIUM) return "medium";
+  return "low";
+}
+
+export async function getVisitPrepData(userId: string) {
+  const now = new Date();
+  const ninetyDaysAgo = addDays(now, -90);
+  const thirtyDaysAgo = addDays(now, -30);
+  const nextNinetyDays = addDays(now, 90);
+
+  const [
+    profile,
+    upcomingAppointments,
+    activeMedications,
+    recentLabs,
+    recentVitals,
+    recentSymptoms,
+    unresolvedSevereSymptoms,
+    recentDocuments,
+    unlinkedDocuments,
+    doctors,
+    dueReminders,
+    openAlerts,
+  ] = await Promise.all([
+    db.healthProfile.findUnique({ where: { userId } }),
+    db.appointment.findMany({
+      where: {
+        userId,
+        status: AppointmentStatus.UPCOMING,
+        scheduledAt: { gte: now, lte: nextNinetyDays },
+      },
+      orderBy: { scheduledAt: "asc" },
+      take: 8,
+      include: { doctor: true },
+    }),
+    db.medication.findMany({
+      where: { userId, status: MedicationStatus.ACTIVE, active: true },
+      orderBy: { name: "asc" },
+      take: 12,
+      include: {
+        doctor: { select: { name: true, specialty: true, clinic: true } },
+        schedules: { orderBy: { timeOfDay: "asc" } },
+      },
+    }),
+    db.labResult.findMany({
+      where: { userId, dateTaken: { gte: ninetyDaysAgo } },
+      orderBy: { dateTaken: "desc" },
+      take: 12,
+    }),
+    db.vitalRecord.findMany({
+      where: { userId, recordedAt: { gte: ninetyDaysAgo } },
+      orderBy: { recordedAt: "desc" },
+      take: 8,
+    }),
+    db.symptomEntry.findMany({
+      where: { userId, startedAt: { gte: ninetyDaysAgo } },
+      orderBy: { startedAt: "desc" },
+      take: 12,
+    }),
+    db.symptomEntry.findMany({
+      where: { userId, severity: "SEVERE", resolved: false },
+      orderBy: { startedAt: "desc" },
+      take: 8,
+    }),
+    db.medicalDocument.findMany({
+      where: { userId, createdAt: { gte: ninetyDaysAgo } },
+      orderBy: { createdAt: "desc" },
+      take: 12,
+    }),
+    db.medicalDocument.findMany({
+      where: { userId, linkedRecordType: null },
+      orderBy: { createdAt: "desc" },
+      take: 8,
+    }),
+    db.doctor.findMany({
+      where: { userId },
+      orderBy: { updatedAt: "desc" },
+      take: 8,
+    }),
+    db.reminder.findMany({
+      where: {
+        userId,
+        state: { in: [ReminderState.DUE, ReminderState.OVERDUE, ReminderState.SENT] },
+        dueAt: { gte: thirtyDaysAgo, lte: nextNinetyDays },
+      },
+      orderBy: { dueAt: "asc" },
+      take: 8,
+    }),
+    db.alertEvent.findMany({
+      where: { userId, status: AlertStatus.OPEN },
+      orderBy: [{ severity: "desc" }, { createdAt: "desc" }],
+      take: 8,
+    }),
+  ]);
+
+  const nextAppointment = upcomingAppointments[0] ?? null;
+  const abnormalLabs = recentLabs.filter((lab) => lab.flag !== LabFlag.NORMAL);
+  const severeSymptoms = unresolvedSevereSymptoms;
+  const hasEmergencyContext = Boolean(profile?.emergencyContactName && profile?.emergencyContactPhone);
+  const hasAllergyContext = Boolean(profile?.allergiesSummary?.trim());
+  const hasMedicationContext = activeMedications.length > 0;
+  const hasRecentVitals = recentVitals.length > 0;
+  const hasRecentLabs = recentLabs.length > 0;
+  const hasSymptoms = recentSymptoms.length > 0;
+  const hasDoctors = doctors.length > 0;
+
+  const readinessChecks = [
+    { label: "Upcoming appointment selected", complete: Boolean(nextAppointment), href: "/appointments" },
+    { label: "Emergency contact available", complete: hasEmergencyContext, href: "/health-profile" },
+    { label: "Allergy context documented", complete: hasAllergyContext, href: "/health-profile" },
+    { label: "Active medication list available", complete: hasMedicationContext, href: "/medications" },
+    { label: "Recent vitals available", complete: hasRecentVitals, href: "/vitals" },
+    { label: "Recent labs available", complete: hasRecentLabs, href: "/labs" },
+    { label: "Provider directory available", complete: hasDoctors, href: "/doctors" },
+    { label: "Recent symptom journal reviewed", complete: hasSymptoms, href: "/symptoms" },
+  ];
+
+  const readinessScore = Math.round(
+    (readinessChecks.filter((item) => item.complete).length / readinessChecks.length) * 100
+  );
+
+  const tasks: VisitPrepTask[] = [];
+
+  if (!nextAppointment) {
+    tasks.push({
+      title: "Schedule or record the next visit",
+      detail: "Add the upcoming appointment so VitaVault can organize the packet around the visit date.",
+      priority: "high",
+      href: "/appointments",
+    });
+  }
+
+  if (!hasEmergencyContext) {
+    tasks.push({
+      title: "Complete emergency contact details",
+      detail: "Emergency contact name and phone help make the visit packet safer for handoff situations.",
+      priority: "high",
+      href: "/health-profile",
+    });
+  }
+
+  if (!hasAllergyContext) {
+    tasks.push({
+      title: "Document allergies or no-known-allergies note",
+      detail: "Medication and lab review is stronger when allergies are clearly documented.",
+      priority: "medium",
+      href: "/health-profile",
+    });
+  }
+
+  if (!hasMedicationContext) {
+    tasks.push({
+      title: "Add active medications",
+      detail: "A current medication list is one of the most important parts of a doctor visit packet.",
+      priority: "high",
+      href: "/medications",
+    });
+  }
+
+  abnormalLabs.slice(0, 4).forEach((lab) => {
+    tasks.push({
+      title: `Review flagged lab: ${lab.testName}`,
+      detail: `${lab.flag} result from ${lab.dateTaken.toLocaleDateString("en-PH")}: ${lab.resultSummary}`,
+      priority: lab.flag === LabFlag.BORDERLINE ? "medium" : "high",
+      href: `/labs?focus=${lab.id}`,
+    });
+  });
+
+  severeSymptoms.slice(0, 4).forEach((symptom) => {
+    tasks.push({
+      title: `Discuss severe symptom: ${symptom.title}`,
+      detail: symptom.notes || "Unresolved severe symptom should be raised during the next provider conversation.",
+      priority: "critical",
+      href: `/symptoms?focus=${symptom.id}`,
+    });
+  });
+
+  openAlerts.slice(0, 4).forEach((alert) => {
+    tasks.push({
+      title: alert.title,
+      detail: alert.message,
+      priority: getAlertPriority(alert.severity),
+      href: `/alerts/${alert.id}`,
+    });
+  });
+
+  if (unlinkedDocuments.length > 0) {
+    tasks.push({
+      title: "Link recent medical documents",
+      detail: `${unlinkedDocuments.length} document${unlinkedDocuments.length === 1 ? "" : "s"} still need a linked appointment, lab result, or doctor context.`,
+      priority: "medium",
+      href: "/documents?link=UNLINKED",
+    });
+  }
+
+  const sortedTasks = tasks.sort((a, b) => priorityRank(b.priority) - priorityRank(a.priority)).slice(0, 10);
+
+  const timeline: VisitPrepTimelineItem[] = [
+    ...upcomingAppointments.map((appointment) => ({
+      id: `appointment-${appointment.id}`,
+      title: appointment.purpose,
+      detail: `${appointment.doctorName} • ${appointment.clinic}`,
+      at: appointment.scheduledAt,
+      source: "appointment" as const,
+      href: "/appointments",
+    })),
+    ...dueReminders.map((reminder) => ({
+      id: `reminder-${reminder.id}`,
+      title: reminder.title,
+      detail: reminder.description || reminder.type,
+      at: reminder.dueAt,
+      source: "reminder" as const,
+      href: "/reminders",
+    })),
+    ...recentLabs.slice(0, 5).map((lab) => ({
+      id: `lab-${lab.id}`,
+      title: lab.testName,
+      detail: `${lab.flag} • ${lab.resultSummary}`,
+      at: lab.dateTaken,
+      source: "lab" as const,
+      href: `/labs?focus=${lab.id}`,
+    })),
+    ...recentSymptoms.slice(0, 5).map((symptom) => ({
+      id: `symptom-${symptom.id}`,
+      title: symptom.title,
+      detail: `${symptom.severity}${symptom.resolved ? " • resolved" : " • unresolved"}`,
+      at: symptom.startedAt,
+      source: "symptom" as const,
+      href: `/symptoms?focus=${symptom.id}`,
+    })),
+    ...recentVitals.slice(0, 4).map((vital) => ({
+      id: `vital-${vital.id}`,
+      title: "Vitals snapshot",
+      detail: [
+        vital.systolic && vital.diastolic ? `${vital.systolic}/${vital.diastolic} BP` : null,
+        vital.heartRate ? `${vital.heartRate} bpm` : null,
+        vital.oxygenSaturation ? `${vital.oxygenSaturation}% SpO2` : null,
+        vital.bloodSugar ? `${vital.bloodSugar} glucose` : null,
+      ].filter(Boolean).join(" • ") || "Vitals recorded",
+      at: vital.recordedAt,
+      source: "vital" as const,
+      href: "/vitals",
+    })),
+    ...recentDocuments.slice(0, 4).map((document) => ({
+      id: `document-${document.id}`,
+      title: document.title,
+      detail: `${document.type} • ${document.fileName}`,
+      at: document.createdAt,
+      source: "document" as const,
+      href: "/documents",
+    })),
+  ]
+    .sort((a, b) => Math.abs(a.at.getTime() - now.getTime()) - Math.abs(b.at.getTime() - now.getTime()))
+    .slice(0, 14);
+
+  return {
+    profile,
+    nextAppointment,
+    upcomingAppointments,
+    activeMedications,
+    recentLabs,
+    abnormalLabs,
+    recentVitals,
+    recentSymptoms,
+    unresolvedSevereSymptoms,
+    recentDocuments,
+    unlinkedDocuments,
+    doctors,
+    dueReminders,
+    openAlerts,
+    readinessChecks,
+    readinessScore,
+    tasks: sortedTasks,
+    timeline,
+    summary: {
+      criticalTasks: sortedTasks.filter((task) => task.priority === "critical").length,
+      highTasks: sortedTasks.filter((task) => task.priority === "high").length,
+      abnormalLabs: abnormalLabs.length,
+      unresolvedSevereSymptoms: severeSymptoms.length,
+      activeMedications: activeMedications.length,
+      packetItems:
+        activeMedications.length + recentLabs.length + recentVitals.length + recentSymptoms.length + recentDocuments.length,
+    },
+  };
+}


### PR DESCRIPTION
This PR adds Patch 16: Visit Prep Hub.

Changes:
- Adds a protected /visit-prep page
- Adds a visit readiness score
- Adds next appointment context for provider preparation
- Adds a prioritized prep task queue from missing profile context, abnormal labs, severe symptoms, open alerts, and unlinked documents
- Adds a readiness checklist for appointment, emergency contact, allergies, medications, vitals, labs, providers, and symptoms
- Adds a provider timeline from appointments, reminders, labs, symptoms, vitals, and documents
- Adds medication snapshot and care context panels
- Adds Visit Prep to the sidebar navigation
- Reuses existing schema models, so no Prisma migration is required