### PR TITLE
Add lab review hub

### DIFF
--- a/app/lab-review/page.tsx
+++ b/app/lab-review/page.tsx
@@ -1,0 +1,323 @@
+import Link from "next/link";
+import { Beaker, ClipboardList, FileText, FlaskConical, Search, TrendingUp } from "lucide-react";
+import { LabFlag } from "@prisma/client";
+import { AppShell } from "@/components/app-shell";
+import { EmptyState, PageHeader, StatusPill } from "@/components/common";
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Input,
+  Select,
+  Table,
+  TBody,
+  TD,
+  TH,
+  THead,
+  TR,
+} from "@/components/ui";
+import { requireUser } from "@/lib/session";
+import { getLabFlagTone, getLabPriorityTone, getLabReviewData, type LabTrendCard } from "@/lib/lab-review";
+
+function formatDate(value: Date | null | undefined) {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat("en-PH", { dateStyle: "medium" }).format(value);
+}
+
+function readinessTone(value: number): "success" | "warning" | "danger" {
+  if (value >= 80) return "success";
+  if (value >= 55) return "warning";
+  return "danger";
+}
+
+function ProgressBar({ value }: { value: number }) {
+  const safeValue = Math.max(0, Math.min(100, value));
+  return (
+    <div className="h-2 overflow-hidden rounded-full bg-muted">
+      <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${safeValue}%` }} />
+    </div>
+  );
+}
+
+function StatCard({ title, value, description, icon }: { title: string; value: string | number; description: string; icon: React.ReactNode }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardDescription>{title}</CardDescription>
+            <CardTitle className="mt-2 text-3xl">{value}</CardTitle>
+          </div>
+          <div className="rounded-2xl border border-border/60 bg-background/70 p-2">{icon}</div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function TrendCard({ item }: { item: LabTrendCard }) {
+  const directionTone =
+    item.direction === "improved" ? "success" : item.direction === "worse" ? "danger" : item.direction === "watch" ? "warning" : "info";
+
+  return (
+    <div className="rounded-2xl border border-border/60 bg-background/60 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="font-medium">{item.testName}</p>
+          <p className="mt-1 text-sm text-muted-foreground">Latest: {item.latestValue}</p>
+          {item.previousValue ? <p className="mt-1 text-xs text-muted-foreground">Previous: {item.previousValue}</p> : null}
+        </div>
+        <div className="flex flex-col items-end gap-2">
+          <StatusPill tone={getLabFlagTone(item.latestFlag)}>{item.latestFlag}</StatusPill>
+          <StatusPill tone={directionTone}>{item.direction}</StatusPill>
+        </div>
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
+        <Badge>{item.count} result{item.count === 1 ? "" : "s"}</Badge>
+        <Badge>{formatDate(item.latestDate)}</Badge>
+      </div>
+    </div>
+  );
+}
+
+export default async function LabReviewPage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const user = await requireUser();
+  const params = (await searchParams) ?? {};
+  const q = typeof params.q === "string" ? params.q : "";
+  const flagParam = typeof params.flag === "string" ? params.flag : "ALL";
+  const flag = flagParam === "NORMAL" || flagParam === "BORDERLINE" || flagParam === "HIGH" || flagParam === "LOW" ? flagParam : "ALL";
+
+  const data = await getLabReviewData(user.id!, { q, flag });
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-7xl space-y-6 p-6">
+        <PageHeader
+          title="Lab Review Hub"
+          description="Review abnormal results, trend movement, follow-up reminders, and document linkage before your next appointment."
+          action={
+            <div className="flex flex-wrap gap-2">
+              <Link href="/labs" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium transition-all hover:border-border hover:bg-muted/60">
+                Open labs
+              </Link>
+              <Link href="/summary/print?mode=doctor" className="inline-flex h-10 items-center justify-center rounded-2xl bg-primary px-4 text-sm font-medium text-primary-foreground transition-all hover:opacity-95">
+                Doctor packet
+              </Link>
+            </div>
+          }
+        />
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <StatCard title="Readiness score" value={`${data.summary.readinessScore}%`} description="Blends lab freshness, flag pressure, and document coverage." icon={<ClipboardList className="h-5 w-5 text-primary" />} />
+          <StatCard title="Flagged results" value={data.summary.abnormalLabs + data.summary.borderlineLabs} description={`${data.summary.flaggedRate}% of lab history needs watch or review.`} icon={<Beaker className="h-5 w-5 text-amber-500" />} />
+          <StatCard title="Document coverage" value={`${data.summary.documentCoverage}%`} description="Lab records with linked report files for handoff context." icon={<FileText className="h-5 w-5 text-sky-500" />} />
+          <StatCard title="Follow-ups" value={data.summary.labReminders} description="Due, overdue, or missed lab follow-up reminders." icon={<TrendingUp className="h-5 w-5 text-emerald-500" />} />
+        </div>
+
+        <div className="grid gap-6 xl:grid-cols-[0.8fr_1.2fr]">
+          <Card>
+            <CardHeader>
+              <CardTitle>Lab readiness</CardTitle>
+              <CardDescription>Quick signal for whether lab data is ready for review or provider handoff.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-center justify-between gap-4">
+                <div>
+                  <p className="text-3xl font-semibold">{data.summary.readinessScore}%</p>
+                  <p className="text-sm text-muted-foreground">{data.summary.totalLabs} total result{data.summary.totalLabs === 1 ? "" : "s"}</p>
+                </div>
+                <StatusPill tone={readinessTone(data.summary.readinessScore)}>
+                  {data.summary.readinessScore >= 80 ? "Ready" : data.summary.readinessScore >= 55 ? "Review" : "Needs cleanup"}
+                </StatusPill>
+              </div>
+              <ProgressBar value={data.summary.readinessScore} />
+              <div className="grid gap-3 text-sm md:grid-cols-2">
+                <div className="rounded-2xl border border-border/60 p-3">
+                  <p className="font-medium">Normal</p>
+                  <p className="text-muted-foreground">{data.flagBreakdown.normal} results</p>
+                </div>
+                <div className="rounded-2xl border border-border/60 p-3">
+                  <p className="font-medium">Borderline</p>
+                  <p className="text-muted-foreground">{data.flagBreakdown.borderline} results</p>
+                </div>
+                <div className="rounded-2xl border border-border/60 p-3">
+                  <p className="font-medium">High</p>
+                  <p className="text-muted-foreground">{data.flagBreakdown.high} results</p>
+                </div>
+                <div className="rounded-2xl border border-border/60 p-3">
+                  <p className="font-medium">Low</p>
+                  <p className="text-muted-foreground">{data.flagBreakdown.low} results</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Recommended lab actions</CardTitle>
+              <CardDescription>Highest-value cleanup and follow-up items from your lab history.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {data.actions.map((item) => (
+                <div key={item.id} className="rounded-2xl border border-border/60 bg-background/60 p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <StatusPill tone={getLabPriorityTone(item.priority)}>{item.priority}</StatusPill>
+                        <p className="font-medium">{item.title}</p>
+                      </div>
+                      <p className="mt-2 text-sm text-muted-foreground">{item.detail}</p>
+                    </div>
+                    <Link href={item.href} className="text-sm font-medium text-primary hover:underline">
+                      Review
+                    </Link>
+                  </div>
+                </div>
+              ))}
+              {data.actions.length === 0 ? <EmptyState title="No urgent lab actions" description="Your lab records do not currently show abnormal results, missed follow-ups, or document cleanup work." /> : null}
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Lab trend cards</CardTitle>
+            <CardDescription>Latest result per test with previous-result context when available.</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            {data.trendCards.map((item) => <TrendCard key={item.testName} item={item} />)}
+            {data.trendCards.length === 0 ? <EmptyState title="No lab trends yet" description="Add lab results to see trend cards and provider-ready review notes." /> : null}
+          </CardContent>
+        </Card>
+
+        <div className="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+          <Card>
+            <CardHeader>
+              <CardTitle>Lab result register</CardTitle>
+              <CardDescription>Search and filter lab results without leaving the review hub.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <form className="grid gap-3 md:grid-cols-[1fr_180px_auto]">
+                <div className="relative">
+                  <Search className="pointer-events-none absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                  <Input name="q" defaultValue={data.filters.q} placeholder="Search test, result, range, or file" className="pl-9" />
+                </div>
+                <Select name="flag" defaultValue={data.filters.flag}>
+                  <option value="ALL">All flags</option>
+                  {Object.values(LabFlag).map((item) => <option key={item} value={item}>{item}</option>)}
+                </Select>
+                <Button type="submit">Filter</Button>
+              </form>
+
+              <div className="overflow-x-auto">
+                <Table>
+                  <THead>
+                    <TR>
+                      <TH>Test</TH>
+                      <TH>Result</TH>
+                      <TH>Flag</TH>
+                      <TH>Reference</TH>
+                      <TH>Date</TH>
+                    </TR>
+                  </THead>
+                  <TBody>
+                    {data.labs.map((lab) => (
+                      <TR key={lab.id}>
+                        <TD className="font-medium">{lab.testName}</TD>
+                        <TD>{lab.resultSummary}</TD>
+                        <TD><StatusPill tone={getLabFlagTone(lab.flag)}>{lab.flag}</StatusPill></TD>
+                        <TD className="text-muted-foreground">{lab.referenceRange || "—"}</TD>
+                        <TD className="text-muted-foreground">{formatDate(lab.dateTaken)}</TD>
+                      </TR>
+                    ))}
+                  </TBody>
+                </Table>
+              </div>
+              {data.labs.length === 0 ? <EmptyState title="No matching labs" description="Try another search term or filter to review your lab history." /> : null}
+            </CardContent>
+          </Card>
+
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Lab document coverage</CardTitle>
+                <CardDescription>Recent lab files and whether they are ready to support records and visits.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {data.labDocuments.map((document) => (
+                  <div key={document.id} className="rounded-2xl border border-border/60 bg-background/60 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="font-medium">{document.title}</p>
+                        <p className="mt-1 text-xs text-muted-foreground">{document.fileName} • {formatDate(document.createdAt)}</p>
+                      </div>
+                      <StatusPill tone={document.linkedRecordId ? "success" : "warning"}>{document.linkedRecordId ? "Linked" : "Unlinked"}</StatusPill>
+                    </div>
+                  </div>
+                ))}
+                {data.labDocuments.length === 0 ? <EmptyState title="No lab documents" description="Upload lab files or link existing documents to lab results." /> : null}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Lab follow-up reminders</CardTitle>
+                <CardDescription>Due, overdue, and missed lab follow-up tasks.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {data.labReminders.map((reminder) => (
+                  <div key={reminder.id} className="rounded-2xl border border-border/60 bg-background/60 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="font-medium">{reminder.title}</p>
+                        <p className="mt-1 text-xs text-muted-foreground">Due {formatDate(reminder.dueAt)}</p>
+                      </div>
+                      <StatusPill tone={reminder.state === "OVERDUE" || reminder.state === "MISSED" ? "danger" : "warning"}>{reminder.state}</StatusPill>
+                    </div>
+                    {reminder.description ? <p className="mt-2 text-sm text-muted-foreground">{reminder.description}</p> : null}
+                  </div>
+                ))}
+                {data.labReminders.length === 0 ? <EmptyState title="No lab reminders" description="Lab follow-up reminders will appear here when they are due or overdue." /> : null}
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Provider review note</CardTitle>
+            <CardDescription>Use this hub before visits to identify which lab results need explanation, follow-up, or file cleanup.</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-3 md:grid-cols-3">
+            <div className="rounded-2xl border border-border/60 bg-background/60 p-4">
+              <FlaskConical className="h-5 w-5 text-primary" />
+              <p className="mt-3 font-medium">Review flagged results first</p>
+              <p className="mt-1 text-sm text-muted-foreground">High, low, and borderline labs are sorted into the action queue.</p>
+            </div>
+            <div className="rounded-2xl border border-border/60 bg-background/60 p-4">
+              <FileText className="h-5 w-5 text-primary" />
+              <p className="mt-3 font-medium">Attach source files</p>
+              <p className="mt-1 text-sm text-muted-foreground">Linked lab documents make the doctor packet more complete.</p>
+            </div>
+            <div className="rounded-2xl border border-border/60 bg-background/60 p-4">
+              <ClipboardList className="h-5 w-5 text-primary" />
+              <p className="mt-3 font-medium">Close the loop</p>
+              <p className="mt-1 text-sm text-muted-foreground">Follow-up reminders help track repeat tests and pending provider review.</p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </AppShell>
+  );
+}

--- a/docs/PATCH_17_LAB_REVIEW_HUB.md
+++ b/docs/PATCH_17_LAB_REVIEW_HUB.md
@@ -1,0 +1,42 @@
+# Patch 17 — Lab Review Hub
+
+## Summary
+
+This patch adds a protected Lab Review Hub to make VitaVault's lab results more actionable for appointments, provider handoffs, and follow-up tracking.
+
+## Added
+
+- New `/lab-review` page
+- Lab readiness score
+- Lab flag breakdown
+- Abnormal and borderline action queue
+- Lab document coverage signal
+- Lab follow-up reminder visibility
+- Trend cards by test name
+- Search and flag filter for lab history
+- Provider review note panel
+- Sidebar navigation entry
+
+## Safety
+
+- No Prisma migration required
+- Uses existing `LabResult`, `MedicalDocument`, and `Reminder` records
+- Does not change existing lab CRUD behavior
+- Does not add new server actions
+
+## Manual checks
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:run
+```
+
+## Manual routes
+
+```txt
+/lab-review
+/lab-review?flag=HIGH
+/lab-review?flag=BORDERLINE
+/lab-review?q=cholesterol
+```

--- a/lib/app-routes.ts
+++ b/lib/app-routes.ts
@@ -129,6 +129,12 @@ export const primaryRoutes: AppRouteItem[] = [
     icon: ClipboardList,
   },
   {
+    title: "Lab Review",
+    href: "/lab-review",
+    description: "Abnormal results, lab trends, documents, and follow-up readiness",
+    icon: ClipboardList,
+  },
+  {
     title: "Vitals",
     href: "/vitals",
     description: "BP, sugar, oxygen, weight, and trends",

--- a/lib/lab-review.ts
+++ b/lib/lab-review.ts
@@ -1,0 +1,264 @@
+import { DocumentLinkType, DocumentType, LabFlag, ReminderState, ReminderType } from "@prisma/client";
+import { db } from "@/lib/db";
+
+export type LabReviewPriority = "critical" | "high" | "medium" | "low";
+export type LabReviewTone = "neutral" | "info" | "success" | "warning" | "danger";
+
+export type LabReviewFilter = {
+  q?: string;
+  flag?: "ALL" | LabFlag;
+};
+
+export type LabReviewAction = {
+  id: string;
+  title: string;
+  detail: string;
+  priority: LabReviewPriority;
+  href: string;
+};
+
+export type LabTrendCard = {
+  testName: string;
+  latestValue: string;
+  latestFlag: LabFlag;
+  latestDate: Date;
+  previousValue: string | null;
+  previousFlag: LabFlag | null;
+  direction: "new" | "improved" | "worse" | "stable" | "watch";
+  count: number;
+};
+
+function daysAgo(days: number) {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return date;
+}
+
+function normalize(value: string | null | undefined) {
+  return (value ?? "").trim().toLowerCase();
+}
+
+function labFlagTone(flag: LabFlag): LabReviewTone {
+  if (flag === LabFlag.HIGH || flag === LabFlag.LOW) return "danger";
+  if (flag === LabFlag.BORDERLINE) return "warning";
+  return "success";
+}
+
+export function getLabFlagTone(flag: LabFlag): LabReviewTone {
+  return labFlagTone(flag);
+}
+
+function priorityTone(priority: LabReviewPriority): LabReviewTone {
+  if (priority === "critical") return "danger";
+  if (priority === "high") return "warning";
+  if (priority === "medium") return "info";
+  return "neutral";
+}
+
+export function getLabPriorityTone(priority: LabReviewPriority): LabReviewTone {
+  return priorityTone(priority);
+}
+
+function scoreLabFlag(flag: LabFlag) {
+  if (flag === LabFlag.NORMAL) return 0;
+  if (flag === LabFlag.BORDERLINE) return 1;
+  return 2;
+}
+
+function getTrendDirection(latest: LabFlag, previous: LabFlag | null): LabTrendCard["direction"] {
+  if (!previous) return "new";
+  const latestScore = scoreLabFlag(latest);
+  const previousScore = scoreLabFlag(previous);
+  if (latestScore < previousScore) return "improved";
+  if (latestScore > previousScore) return "worse";
+  if (latest === LabFlag.BORDERLINE) return "watch";
+  return "stable";
+}
+
+export async function getLabReviewData(userId: string, filters: LabReviewFilter = {}) {
+  const now = new Date();
+  const ninetyDaysAgo = daysAgo(90);
+  const oneYearAgo = daysAgo(365);
+
+  const [labs, labDocuments, labReminders] = await Promise.all([
+    db.labResult.findMany({
+      where: { userId },
+      orderBy: { dateTaken: "desc" },
+      take: 80,
+    }),
+    db.medicalDocument.findMany({
+      where: {
+        userId,
+        OR: [
+          { type: DocumentType.LAB_RESULT },
+          { linkedRecordType: DocumentLinkType.LAB_RESULT },
+        ],
+      },
+      orderBy: { createdAt: "desc" },
+      take: 40,
+    }),
+    db.reminder.findMany({
+      where: {
+        userId,
+        type: ReminderType.LAB_FOLLOW_UP,
+        state: { in: [ReminderState.DUE, ReminderState.OVERDUE, ReminderState.MISSED] },
+      },
+      orderBy: { dueAt: "asc" },
+      take: 10,
+    }),
+  ]);
+
+  const q = normalize(filters.q);
+  const flag = filters.flag ?? "ALL";
+
+  const linkedLabIds = new Set(
+    labDocuments
+      .filter((document) => document.linkedRecordType === DocumentLinkType.LAB_RESULT && document.linkedRecordId)
+      .map((document) => document.linkedRecordId as string)
+  );
+
+  const filteredLabs = labs.filter((lab) => {
+    const matchesFlag = flag === "ALL" || lab.flag === flag;
+    const matchesSearch =
+      !q ||
+      normalize(lab.testName).includes(q) ||
+      normalize(lab.resultSummary).includes(q) ||
+      normalize(lab.referenceRange).includes(q) ||
+      normalize(lab.fileName).includes(q);
+    return matchesFlag && matchesSearch;
+  });
+
+  const recentLabs = labs.filter((lab) => lab.dateTaken >= ninetyDaysAgo);
+  const yearlyLabs = labs.filter((lab) => lab.dateTaken >= oneYearAgo);
+  const abnormalLabs = labs.filter((lab) => lab.flag === LabFlag.HIGH || lab.flag === LabFlag.LOW);
+  const borderlineLabs = labs.filter((lab) => lab.flag === LabFlag.BORDERLINE);
+  const recentAbnormalLabs = recentLabs.filter((lab) => lab.flag === LabFlag.HIGH || lab.flag === LabFlag.LOW);
+  const unlinkedLabs = labs.filter((lab) => !linkedLabIds.has(lab.id));
+  const unlinkedLabDocuments = labDocuments.filter((document) => !document.linkedRecordId);
+
+  const groupedLabs = new Map<string, typeof labs>();
+  for (const lab of labs) {
+    const key = lab.testName.trim().toLowerCase();
+    const current = groupedLabs.get(key) ?? [];
+    current.push(lab);
+    groupedLabs.set(key, current);
+  }
+
+  const trendCards: LabTrendCard[] = Array.from(groupedLabs.entries())
+    .map(([, group]) => {
+      const sorted = [...group].sort((a, b) => b.dateTaken.getTime() - a.dateTaken.getTime());
+      const latest = sorted[0];
+      const previous = sorted[1] ?? null;
+      return {
+        testName: latest.testName,
+        latestValue: latest.resultSummary,
+        latestFlag: latest.flag,
+        latestDate: latest.dateTaken,
+        previousValue: previous?.resultSummary ?? null,
+        previousFlag: previous?.flag ?? null,
+        direction: getTrendDirection(latest.flag, previous?.flag ?? null),
+        count: sorted.length,
+      };
+    })
+    .sort((a, b) => {
+      const riskDelta = scoreLabFlag(b.latestFlag) - scoreLabFlag(a.latestFlag);
+      if (riskDelta !== 0) return riskDelta;
+      return b.latestDate.getTime() - a.latestDate.getTime();
+    })
+    .slice(0, 8);
+
+  const actions: LabReviewAction[] = [];
+
+  for (const lab of recentAbnormalLabs.slice(0, 5)) {
+    actions.push({
+      id: `abnormal-${lab.id}`,
+      title: `Review ${lab.testName}`,
+      detail: `${lab.flag} result logged on ${lab.dateTaken.toLocaleDateString("en-PH")}: ${lab.resultSummary}`,
+      priority: lab.flag === LabFlag.HIGH ? "high" : "medium",
+      href: `/labs?focus=${lab.id}`,
+    });
+  }
+
+  for (const lab of borderlineLabs.slice(0, 3)) {
+    actions.push({
+      id: `borderline-${lab.id}`,
+      title: `Watch borderline ${lab.testName}`,
+      detail: `${lab.resultSummary}${lab.referenceRange ? ` • reference: ${lab.referenceRange}` : ""}`,
+      priority: "medium",
+      href: `/labs?focus=${lab.id}`,
+    });
+  }
+
+  if (unlinkedLabs.length > 0) {
+    actions.push({
+      id: "unlinked-labs",
+      title: "Link lab uploads to lab records",
+      detail: `${unlinkedLabs.length} lab result${unlinkedLabs.length === 1 ? "" : "s"} do not have a linked document yet.`,
+      priority: "low",
+      href: "/documents?type=LAB_RESULT",
+    });
+  }
+
+  if (unlinkedLabDocuments.length > 0) {
+    actions.push({
+      id: "unlinked-lab-documents",
+      title: "Clean up unlinked lab documents",
+      detail: `${unlinkedLabDocuments.length} lab document${unlinkedLabDocuments.length === 1 ? "" : "s"} should be connected to a lab record for visit prep.`,
+      priority: "low",
+      href: "/documents?link=UNLINKED",
+    });
+  }
+
+  for (const reminder of labReminders.slice(0, 4)) {
+    actions.push({
+      id: `reminder-${reminder.id}`,
+      title: reminder.state === ReminderState.OVERDUE || reminder.dueAt < now ? "Overdue lab follow-up" : "Upcoming lab follow-up",
+      detail: `${reminder.title} • due ${reminder.dueAt.toLocaleDateString("en-PH")}`,
+      priority: reminder.state === ReminderState.OVERDUE || reminder.dueAt < now ? "high" : "medium",
+      href: "/reminders",
+    });
+  }
+
+  const sortedActions = actions.sort((a, b) => {
+    const weights: Record<LabReviewPriority, number> = { critical: 4, high: 3, medium: 2, low: 1 };
+    return weights[b.priority] - weights[a.priority];
+  });
+
+  const flaggedRate = labs.length > 0 ? Math.round(((abnormalLabs.length + borderlineLabs.length) / labs.length) * 100) : 0;
+  const documentCoverage = labs.length > 0 ? Math.round(((labs.length - unlinkedLabs.length) / labs.length) * 100) : 0;
+  const recentCoverage = yearlyLabs.length > 0 ? Math.min(100, Math.round((yearlyLabs.length / 6) * 100)) : 0;
+  const readinessScore = Math.max(0, Math.min(100, Math.round((documentCoverage * 0.35) + ((100 - flaggedRate) * 0.35) + (recentCoverage * 0.3))));
+
+  const flagBreakdown = {
+    normal: labs.filter((lab) => lab.flag === LabFlag.NORMAL).length,
+    borderline: borderlineLabs.length,
+    high: labs.filter((lab) => lab.flag === LabFlag.HIGH).length,
+    low: labs.filter((lab) => lab.flag === LabFlag.LOW).length,
+  };
+
+  return {
+    summary: {
+      totalLabs: labs.length,
+      visibleLabs: filteredLabs.length,
+      recentLabs: recentLabs.length,
+      abnormalLabs: abnormalLabs.length,
+      borderlineLabs: borderlineLabs.length,
+      linkedLabDocuments: linkedLabIds.size,
+      unlinkedLabs: unlinkedLabs.length,
+      labReminders: labReminders.length,
+      readinessScore,
+      documentCoverage,
+      flaggedRate,
+    },
+    filters: {
+      q: filters.q ?? "",
+      flag,
+    },
+    flagBreakdown,
+    labs: filteredLabs,
+    trendCards,
+    actions: sortedActions.slice(0, 10),
+    labDocuments: labDocuments.slice(0, 8),
+    labReminders,
+  };
+}


### PR DESCRIPTION
This PR adds Patch 17: Lab Review Hub.

Changes:
- Adds a protected /lab-review page
- Adds a lab readiness score
- Adds abnormal, borderline, high, low, and normal result breakdowns
- Adds a prioritized lab action queue
- Adds lab trend cards grouped by test name
- Adds latest vs previous result context
- Adds lab document coverage visibility
- Adds lab follow-up reminder visibility
- Adds search and flag filtering for lab history
- Adds provider review guidance for appointments and handoffs
- Adds Lab Review to the sidebar navigation
- Reuses existing schema models, so no Prisma migration is required