### PR TITLE
Add symptom review hub

### DIFF
--- a/app/symptom-review/page.tsx
+++ b/app/symptom-review/page.tsx
@@ -1,0 +1,317 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { Activity, AlertTriangle, ClipboardList, Search, ShieldCheck, Stethoscope } from "lucide-react";
+import { SymptomSeverity } from "@prisma/client";
+import { AppShell } from "@/components/app-shell";
+import { EmptyState, PageHeader, StatusPill } from "@/components/common";
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Input,
+  Select,
+  Table,
+  TBody,
+  TD,
+  TH,
+  THead,
+  TR,
+} from "@/components/ui";
+import { requireUser } from "@/lib/session";
+import {
+  getSymptomPriorityTone,
+  getSymptomReviewData,
+  getSymptomSeverityTone,
+  type SymptomCluster,
+  type SymptomTimelineItem,
+} from "@/lib/symptom-review";
+
+function formatDate(value: Date | null | undefined) {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat("en-PH", { dateStyle: "medium" }).format(value);
+}
+
+function readinessTone(value: number): "success" | "warning" | "danger" {
+  if (value >= 80) return "success";
+  if (value >= 55) return "warning";
+  return "danger";
+}
+
+function ProgressBar({ value }: { value: number }) {
+  const safeValue = Math.max(0, Math.min(100, value));
+  return (
+    <div className="h-2 overflow-hidden rounded-full bg-muted">
+      <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${safeValue}%` }} />
+    </div>
+  );
+}
+
+function StatCard({ title, value, description, icon }: { title: string; value: string | number; description: string; icon: ReactNode }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardDescription>{title}</CardDescription>
+            <CardTitle className="mt-2 text-3xl">{value}</CardTitle>
+          </div>
+          <div className="rounded-2xl border border-border/60 bg-background/70 p-2">{icon}</div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ClusterCard({ item }: { item: SymptomCluster }) {
+  return (
+    <div className="rounded-2xl border border-border/60 bg-background/60 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="font-medium">{item.label}</p>
+          <p className="mt-1 text-sm text-muted-foreground">Latest: {formatDate(item.latestAt)}</p>
+        </div>
+        <StatusPill tone={item.tone}>{item.severe > 0 ? "Severe" : item.unresolved > 0 ? "Open" : "Resolved"}</StatusPill>
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
+        <Badge>{item.count} total</Badge>
+        <Badge>{item.unresolved} unresolved</Badge>
+        <Badge>{item.severe} severe</Badge>
+      </div>
+    </div>
+  );
+}
+
+function TimelineRow({ item }: { item: SymptomTimelineItem }) {
+  return (
+    <TR>
+      <TD>
+        <div className="space-y-1">
+          <p className="font-medium">{item.title}</p>
+          <p className="text-xs text-muted-foreground">{item.detail}</p>
+        </div>
+      </TD>
+      <TD><StatusPill tone={getSymptomSeverityTone(item.severity)}>{item.severity}</StatusPill></TD>
+      <TD><StatusPill tone={item.resolved ? "success" : "warning"}>{item.resolved ? "Resolved" : "Open"}</StatusPill></TD>
+      <TD className="text-sm text-muted-foreground">{formatDate(item.at)}</TD>
+      <TD>
+        <Link href={`/symptoms?focus=${item.id}`} className="text-sm font-medium text-primary hover:underline">
+          Open
+        </Link>
+      </TD>
+    </TR>
+  );
+}
+
+export default async function SymptomReviewPage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const user = await requireUser();
+  const params = (await searchParams) ?? {};
+  const q = typeof params.q === "string" ? params.q : "";
+  const severityParam = typeof params.severity === "string" ? params.severity : "ALL";
+  const statusParam = typeof params.status === "string" ? params.status : "ALL";
+  const severity = severityParam === "MILD" || severityParam === "MODERATE" || severityParam === "SEVERE" ? severityParam : "ALL";
+  const status = statusParam === "OPEN" || statusParam === "RESOLVED" ? statusParam : "ALL";
+
+  const data = await getSymptomReviewData(user.id!, { q, severity, status });
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-7xl space-y-6 p-6">
+        <PageHeader
+          title="Symptom Review Hub"
+          description="Review unresolved symptoms, severity patterns, body-area clusters, alerts, and follow-up reminders before care handoffs."
+          action={
+            <div className="flex flex-wrap gap-2">
+              <Link href="/symptoms" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium transition-all hover:border-border hover:bg-muted/60">
+                Open symptoms
+              </Link>
+              <Link href="/visit-prep" className="inline-flex h-10 items-center justify-center rounded-2xl bg-primary px-4 text-sm font-medium text-primary-foreground transition-all hover:opacity-95">
+                Visit prep
+              </Link>
+            </div>
+          }
+        />
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <StatCard title="Readiness score" value={`${data.summary.readinessScore}%`} description="Blends unresolved severity, documentation coverage, alerts, and follow-up state." icon={<ClipboardList className="h-5 w-5 text-primary" />} />
+          <StatCard title="Unresolved" value={data.summary.unresolvedSymptoms} description="Open symptom entries that may need resolution notes or follow-up." icon={<Activity className="h-5 w-5 text-amber-500" />} />
+          <StatCard title="Severe open" value={data.summary.severeUnresolved} description="Severe unresolved symptoms should be reviewed first." icon={<AlertTriangle className="h-5 w-5 text-rose-500" />} />
+          <StatCard title="Notes coverage" value={`${data.summary.documentationCoverage}%`} description="Recent symptom entries with provider-useful context notes." icon={<ShieldCheck className="h-5 w-5 text-emerald-500" />} />
+        </div>
+
+        <div className="grid gap-6 xl:grid-cols-[0.8fr_1.2fr]">
+          <Card>
+            <CardHeader>
+              <CardTitle>Symptom readiness</CardTitle>
+              <CardDescription>Quick signal for whether symptom history is ready for care review.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-center justify-between gap-4">
+                <div>
+                  <p className="text-3xl font-semibold">{data.summary.readinessScore}%</p>
+                  <p className="text-sm text-muted-foreground">{data.summary.recentSymptoms} symptom{data.summary.recentSymptoms === 1 ? "" : "s"} in the last 30 days</p>
+                </div>
+                <StatusPill tone={readinessTone(data.summary.readinessScore)}>
+                  {data.summary.readinessScore >= 80 ? "Ready" : data.summary.readinessScore >= 55 ? "Review" : "Needs follow-up"}
+                </StatusPill>
+              </div>
+              <ProgressBar value={data.summary.readinessScore} />
+              <div className="grid gap-3 text-sm md:grid-cols-3">
+                <div className="rounded-2xl border border-border/60 p-3">
+                  <p className="font-medium">Mild</p>
+                  <p className="text-muted-foreground">{data.severityBreakdown.mild} recent</p>
+                </div>
+                <div className="rounded-2xl border border-border/60 p-3">
+                  <p className="font-medium">Moderate</p>
+                  <p className="text-muted-foreground">{data.severityBreakdown.moderate} recent</p>
+                </div>
+                <div className="rounded-2xl border border-border/60 p-3">
+                  <p className="font-medium">Severe</p>
+                  <p className="text-muted-foreground">{data.severityBreakdown.severe} recent</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Recommended symptom actions</CardTitle>
+              <CardDescription>Highest-value clinical follow-up and documentation tasks.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {data.actions.map((item) => (
+                <div key={item.id} className="rounded-2xl border border-border/60 bg-background/60 p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <StatusPill tone={getSymptomPriorityTone(item.priority)}>{item.priority}</StatusPill>
+                        <p className="font-medium">{item.title}</p>
+                      </div>
+                      <p className="mt-2 text-sm text-muted-foreground">{item.detail}</p>
+                    </div>
+                    <Link href={item.href} className="text-sm font-medium text-primary hover:underline">
+                      Review
+                    </Link>
+                  </div>
+                </div>
+              ))}
+              {data.actions.length === 0 ? <EmptyState title="No urgent symptom actions" description="Your recent symptom history does not show severe unresolved entries, open symptom alerts, or due follow-ups." /> : null}
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Body-area clusters</CardTitle>
+            <CardDescription>Grouped symptom pressure by affected area for faster provider review.</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            {data.clusters.map((item) => <ClusterCard key={item.key} item={item} />)}
+            {data.clusters.length === 0 ? <EmptyState title="No symptom clusters yet" description="Add symptom entries with body areas to see grouped review cards." /> : null}
+          </CardContent>
+        </Card>
+
+        <div className="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+          <Card>
+            <CardHeader>
+              <CardTitle>Symptom register</CardTitle>
+              <CardDescription>Search and filter symptom entries without leaving the review hub.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <form className="grid gap-3 md:grid-cols-[1fr_180px_180px_auto]">
+                <div className="relative">
+                  <Search className="pointer-events-none absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                  <Input name="q" defaultValue={data.filters.q} placeholder="Search symptom, body area, trigger, or notes" className="pl-9" />
+                </div>
+                <Select name="severity" defaultValue={data.filters.severity}>
+                  <option value="ALL">All severity</option>
+                  {Object.values(SymptomSeverity).map((item) => <option key={item} value={item}>{item}</option>)}
+                </Select>
+                <Select name="status" defaultValue={data.filters.status}>
+                  <option value="ALL">All status</option>
+                  <option value="OPEN">Open</option>
+                  <option value="RESOLVED">Resolved</option>
+                </Select>
+                <Button type="submit">Filter</Button>
+              </form>
+
+              <div className="overflow-x-auto">
+                <Table>
+                  <THead>
+                    <TR>
+                      <TH>Symptom</TH>
+                      <TH>Severity</TH>
+                      <TH>Status</TH>
+                      <TH>Started</TH>
+                      <TH>Action</TH>
+                    </TR>
+                  </THead>
+                  <TBody>
+                    {data.timeline.map((item) => <TimelineRow key={item.id} item={item} />)}
+                  </TBody>
+                </Table>
+              </div>
+              {data.timeline.length === 0 ? <EmptyState title="No matching symptoms" description="Try changing the search, severity, or status filters." /> : null}
+            </CardContent>
+          </Card>
+
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Care handoff signals</CardTitle>
+                <CardDescription>Symptom context that should be surfaced during visits or shared-care review.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <div className="flex items-center justify-between rounded-2xl border border-border/60 p-4">
+                  <div>
+                    <p className="font-medium">Open symptom alerts</p>
+                    <p className="text-sm text-muted-foreground">Alert Center items related to symptom severity.</p>
+                  </div>
+                  <StatusPill tone={data.summary.openAlerts > 0 ? "warning" : "success"}>{data.summary.openAlerts}</StatusPill>
+                </div>
+                <div className="flex items-center justify-between rounded-2xl border border-border/60 p-4">
+                  <div>
+                    <p className="font-medium">Follow-up reminders</p>
+                    <p className="text-sm text-muted-foreground">Due, overdue, or missed symptom follow-ups.</p>
+                  </div>
+                  <StatusPill tone={data.summary.followUpReminders > 0 ? "warning" : "success"}>{data.summary.followUpReminders}</StatusPill>
+                </div>
+                <div className="flex items-center justify-between rounded-2xl border border-border/60 p-4">
+                  <div>
+                    <p className="font-medium">Resolution rate</p>
+                    <p className="text-sm text-muted-foreground">Recent symptoms marked resolved.</p>
+                  </div>
+                  <StatusPill tone={data.summary.resolutionRate >= 70 ? "success" : data.summary.resolutionRate >= 40 ? "warning" : "danger"}>{data.summary.resolutionRate}%</StatusPill>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Provider review note</CardTitle>
+                <CardDescription>What to focus on before a doctor visit.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-muted-foreground">
+                <p className="rounded-2xl border border-border/60 bg-background/60 p-4">Start with severe unresolved symptoms, then moderate unresolved items, then repeated body-area clusters.</p>
+                <p className="rounded-2xl border border-border/60 bg-background/60 p-4">Add notes for triggers, timing, duration, self-care steps, and whether the symptom affected work, sleep, or mobility.</p>
+                <Link href="/summary/print?mode=doctor" className="inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline">
+                  <Stethoscope className="h-4 w-4" /> Generate doctor packet
+                </Link>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </div>
+    </AppShell>
+  );
+}

--- a/app/vitals-monitor/page.tsx
+++ b/app/vitals-monitor/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Activity, AlertTriangle, HeartPulse, Smartphone, TrendingUp } from "lucide-react";
+import { Activity, AlertTriangle, HeartPulse, Smartphone } from "lucide-react";
 import { AppShell } from "@/components/app-shell";
 import { EmptyState, PageHeader, StatusPill } from "@/components/common";
 import { Badge, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";

--- a/docs/PATCH_19B_SYMPTOM_REVIEW_TYPECHECK_FIX.md
+++ b/docs/PATCH_19B_SYMPTOM_REVIEW_TYPECHECK_FIX.md
@@ -1,0 +1,20 @@
+# Patch 19B — Symptom Review Typecheck Fix
+
+This hotfix stabilizes Patch 19 after lint/typecheck found a syntax issue in the Symptom Review helper.
+
+## Changes
+
+- Fixes unterminated template literals in `lib/symptom-review.ts`.
+- Removes the unused `TrendingUp` import from `app/vitals-monitor/page.tsx`.
+- Keeps the Symptom Review Hub and Vitals Monitor feature behavior unchanged.
+- Requires no Prisma migration.
+
+## Checks
+
+Run after applying:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:run
+```

--- a/docs/PATCH_19C_SYMPTOM_REVIEW_FINAL_TYPECHECK_FIX.md
+++ b/docs/PATCH_19C_SYMPTOM_REVIEW_FINAL_TYPECHECK_FIX.md
@@ -1,0 +1,19 @@
+# Patch 19C — Symptom Review Final Typecheck Fix
+
+This hotfix resolves the remaining parser/typecheck issue in `lib/symptom-review.ts`.
+
+## Changes
+
+- Fixes remaining template literals that were opened with backticks but closed with double quotes.
+- Keeps the Symptom Review Hub behavior intact.
+- Requires no Prisma migration.
+
+## Validation
+
+Run:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:run
+```

--- a/docs/PATCH_19_SYMPTOM_REVIEW_HUB.md
+++ b/docs/PATCH_19_SYMPTOM_REVIEW_HUB.md
@@ -1,0 +1,43 @@
+# Patch 19 — Symptom Review Hub
+
+## Summary
+Adds a focused symptom review workspace for unresolved symptom tracking, severity pressure, body-area clustering, and provider handoff preparation.
+
+## Files changed
+
+- `app/symptom-review/page.tsx`
+- `lib/symptom-review.ts`
+- `lib/app-routes.ts`
+
+## Product value
+
+This patch turns symptom entries into a practical review surface instead of only a journal list. It helps users identify severe unresolved symptoms, missing notes, repeated body-area clusters, symptom-related alerts, and follow-up reminders before a doctor visit or care-team handoff.
+
+## Added
+
+- Protected `/symptom-review` page
+- Symptom readiness score
+- Recent severity breakdown
+- Unresolved symptom and severe-open metrics
+- Documentation coverage score
+- Body-area cluster cards
+- Recommended symptom action queue
+- Search, severity, and status filters
+- Symptom register timeline
+- Care handoff signal panel
+- Provider review note panel
+- Sidebar navigation entry
+
+## Database impact
+
+No Prisma migration required. The feature reuses existing `SymptomEntry`, `AlertEvent`, and `Reminder` records.
+
+## Validation
+
+Run:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:run
+```

--- a/lib/app-routes.ts
+++ b/lib/app-routes.ts
@@ -153,6 +153,12 @@ export const primaryRoutes: AppRouteItem[] = [
     icon: Activity,
   },
   {
+    title: "Symptom Review",
+    href: "/symptom-review",
+    description: "Unresolved symptoms, body-area clusters, alerts, and care handoff notes",
+    icon: Activity,
+  },
+  {
     title: "Vaccinations",
     href: "/vaccinations",
     description: "Dose history and next due tracking",

--- a/lib/symptom-review.ts
+++ b/lib/symptom-review.ts
@@ -1,0 +1,261 @@
+import { AlertSourceType, AlertStatus, ReminderState, SymptomSeverity } from "@prisma/client";
+import { db } from "@/lib/db";
+
+export type SymptomReviewTone = "neutral" | "info" | "success" | "warning" | "danger";
+export type SymptomReviewPriority = "critical" | "high" | "medium" | "low";
+
+export type SymptomCluster = {
+  key: string;
+  label: string;
+  count: number;
+  unresolved: number;
+  severe: number;
+  latestAt: Date;
+  tone: SymptomReviewTone;
+};
+
+export type SymptomActionItem = {
+  id: string;
+  title: string;
+  detail: string;
+  priority: SymptomReviewPriority;
+  href: string;
+};
+
+export type SymptomTimelineItem = {
+  id: string;
+  title: string;
+  detail: string;
+  at: Date;
+  severity: SymptomSeverity;
+  resolved: boolean;
+  tone: SymptomReviewTone;
+};
+
+export type SymptomReviewFilters = {
+  q: string;
+  severity: SymptomSeverity | "ALL";
+  status: "ALL" | "OPEN" | "RESOLVED";
+};
+
+function daysAgo(days: number) {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return date;
+}
+
+function normalize(value: string | null | undefined) {
+  return (value || "").trim().toLowerCase();
+}
+
+function severityTone(severity: SymptomSeverity): SymptomReviewTone {
+  if (severity === SymptomSeverity.SEVERE) return "danger";
+  if (severity === SymptomSeverity.MODERATE) return "warning";
+  return "info";
+}
+
+export function getSymptomSeverityTone(severity: SymptomSeverity): SymptomReviewTone {
+  return severityTone(severity);
+}
+
+function priorityTone(priority: SymptomReviewPriority): SymptomReviewTone {
+  if (priority === "critical") return "danger";
+  if (priority === "high") return "warning";
+  if (priority === "medium") return "info";
+  return "neutral";
+}
+
+export function getSymptomPriorityTone(priority: SymptomReviewPriority): SymptomReviewTone {
+  return priorityTone(priority);
+}
+
+function clusterTone(unresolved: number, severe: number): SymptomReviewTone {
+  if (severe > 0) return "danger";
+  if (unresolved > 1) return "warning";
+  if (unresolved > 0) return "info";
+  return "success";
+}
+
+function matchesSearch(entry: { title: string; bodyArea: string | null; trigger: string | null; notes: string | null }, q: string) {
+  const query = normalize(q);
+  if (!query) return true;
+  return [entry.title, entry.bodyArea, entry.trigger, entry.notes].some((value) => normalize(value).includes(query));
+}
+
+export async function getSymptomReviewData(userId: string, filters: SymptomReviewFilters) {
+  const thirtyDaysAgo = daysAgo(30);
+  const ninetyDaysAgo = daysAgo(90);
+  const oneHundredEightyDaysAgo = daysAgo(180);
+
+  const [symptoms, openAlerts, followUpReminders] = await Promise.all([
+    db.symptomEntry.findMany({
+      where: { userId, startedAt: { gte: oneHundredEightyDaysAgo } },
+      orderBy: { startedAt: "desc" },
+      take: 160,
+    }),
+    db.alertEvent.findMany({
+      where: {
+        userId,
+        status: AlertStatus.OPEN,
+        OR: [
+          { sourceType: AlertSourceType.SYMPTOM_ENTRY },
+          { title: { contains: "symptom", mode: "insensitive" } },
+          { message: { contains: "symptom", mode: "insensitive" } },
+        ],
+      },
+      orderBy: { createdAt: "desc" },
+      take: 8,
+    }),
+    db.reminder.findMany({
+      where: {
+        userId,
+        state: { in: [ReminderState.DUE, ReminderState.OVERDUE, ReminderState.MISSED] },
+        OR: [
+          { title: { contains: "symptom", mode: "insensitive" } },
+          { description: { contains: "symptom", mode: "insensitive" } },
+        ],
+      },
+      orderBy: { dueAt: "asc" },
+      take: 8,
+    }),
+  ]);
+
+  const recentSymptoms = symptoms.filter((entry) => entry.startedAt >= thirtyDaysAgo);
+  const symptoms90 = symptoms.filter((entry) => entry.startedAt >= ninetyDaysAgo);
+  const unresolvedSymptoms = symptoms.filter((entry) => !entry.resolved);
+  const severeUnresolved = unresolvedSymptoms.filter((entry) => entry.severity === SymptomSeverity.SEVERE);
+  const moderateUnresolved = unresolvedSymptoms.filter((entry) => entry.severity === SymptomSeverity.MODERATE);
+
+  const severityBreakdown = {
+    mild: symptoms90.filter((entry) => entry.severity === SymptomSeverity.MILD).length,
+    moderate: symptoms90.filter((entry) => entry.severity === SymptomSeverity.MODERATE).length,
+    severe: symptoms90.filter((entry) => entry.severity === SymptomSeverity.SEVERE).length,
+  };
+
+  const bodyAreaMap = new Map<string, typeof symptoms>();
+  for (const entry of symptoms90) {
+    const label = entry.bodyArea?.trim() || "General / unspecified";
+    const key = label.toLowerCase();
+    bodyAreaMap.set(key, [...(bodyAreaMap.get(key) ?? []), entry]);
+  }
+
+  const clusters: SymptomCluster[] = Array.from(bodyAreaMap.entries())
+    .map(([key, entries]) => {
+      const unresolved = entries.filter((entry) => !entry.resolved).length;
+      const severe = entries.filter((entry) => entry.severity === SymptomSeverity.SEVERE).length;
+      const latest = entries.reduce((current, entry) => (entry.startedAt > current.startedAt ? entry : current), entries[0]);
+      return {
+        key,
+        label: entries[0].bodyArea?.trim() || "General / unspecified",
+        count: entries.length,
+        unresolved,
+        severe,
+        latestAt: latest.startedAt,
+        tone: clusterTone(unresolved, severe),
+      };
+    })
+    .sort((a, b) => b.severe - a.severe || b.unresolved - a.unresolved || b.count - a.count || b.latestAt.getTime() - a.latestAt.getTime())
+    .slice(0, 8);
+
+  const actions: SymptomActionItem[] = [];
+
+  for (const entry of severeUnresolved.slice(0, 3)) {
+    actions.push({
+      id: `severe-${entry.id}`,
+      title: `Review severe symptom: ${entry.title}`,
+      detail: `${entry.bodyArea || "No body area recorded"} • started ${entry.startedAt.toLocaleDateString("en-PH")}`,
+      priority: "critical",
+      href: `/symptoms?focus=${entry.id}`,
+    });
+  }
+
+  if (moderateUnresolved.length > 0) {
+    actions.push({
+      id: "moderate-unresolved",
+      title: "Moderate symptoms still unresolved",
+      detail: `${moderateUnresolved.length} moderate symptom${moderateUnresolved.length === 1 ? "" : "s"} may need notes, resolution, or provider follow-up.`,
+      priority: "high",
+      href: "/symptoms",
+    });
+  }
+
+  if (openAlerts.length > 0) {
+    actions.push({
+      id: "symptom-alerts",
+      title: "Open symptom alert events",
+      detail: `${openAlerts.length} open symptom-related alert${openAlerts.length === 1 ? "" : "s"} should be reviewed from the Alert Center.`,
+      priority: "high",
+      href: "/alerts",
+    });
+  }
+
+  if (followUpReminders.length > 0) {
+    actions.push({
+      id: "symptom-reminders",
+      title: "Symptom follow-up reminders are due",
+      detail: `${followUpReminders.length} symptom-related reminder${followUpReminders.length === 1 ? "" : "s"} are due, overdue, or missed.`,
+      priority: "medium",
+      href: "/reminders",
+    });
+  }
+
+  const symptomsWithoutNotes = symptoms90.filter((entry) => !entry.notes?.trim()).length;
+  if (symptomsWithoutNotes > 0) {
+    actions.push({
+      id: "missing-notes",
+      title: "Add notes to symptom entries",
+      detail: `${symptomsWithoutNotes} recent symptom entr${symptomsWithoutNotes === 1 ? "y" : "ies"} do not include context notes for triggers, timing, or care actions.`,
+      priority: "low",
+      href: "/symptoms",
+    });
+  }
+
+  const filteredSymptoms = symptoms.filter((entry) => {
+    if (!matchesSearch(entry, filters.q)) return false;
+    if (filters.severity !== "ALL" && entry.severity !== filters.severity) return false;
+    if (filters.status === "OPEN" && entry.resolved) return false;
+    if (filters.status === "RESOLVED" && !entry.resolved) return false;
+    return true;
+  });
+
+  const timeline: SymptomTimelineItem[] = filteredSymptoms.slice(0, 40).map((entry) => ({
+    id: entry.id,
+    title: entry.title,
+    detail: [entry.bodyArea, entry.trigger ? `Trigger: ${entry.trigger}` : null, entry.duration ? `Duration: ${entry.duration}` : null]
+      .filter(Boolean)
+      .join(" • ") || "No additional context recorded",
+    at: entry.startedAt,
+    severity: entry.severity,
+    resolved: entry.resolved,
+    tone: entry.resolved ? "success" : severityTone(entry.severity),
+  }));
+
+  const documentationCoverage = symptoms90.length > 0 ? Math.round(((symptoms90.length - symptomsWithoutNotes) / symptoms90.length) * 100) : 0;
+  const resolutionRate = symptoms90.length > 0 ? Math.round((symptoms90.filter((entry) => entry.resolved).length / symptoms90.length) * 100) : 0;
+  const riskLoad = severeUnresolved.length * 25 + moderateUnresolved.length * 10 + openAlerts.length * 15 + followUpReminders.length * 5;
+  const readinessScore = Math.max(0, Math.min(100, 100 - riskLoad + Math.round(documentationCoverage * 0.15) + Math.round(resolutionRate * 0.15)));
+
+  return {
+    filters,
+    summary: {
+      readinessScore,
+      totalSymptoms: symptoms.length,
+      recentSymptoms: recentSymptoms.length,
+      unresolvedSymptoms: unresolvedSymptoms.length,
+      severeUnresolved: severeUnresolved.length,
+      openAlerts: openAlerts.length,
+      followUpReminders: followUpReminders.length,
+      documentationCoverage,
+      resolutionRate,
+    },
+    severityBreakdown,
+    clusters,
+    actions: actions.sort((a, b) => {
+      const order: Record<SymptomReviewPriority, number> = { critical: 0, high: 1, medium: 2, low: 3 };
+      return order[a.priority] - order[b.priority];
+    }).slice(0, 8),
+    openAlerts,
+    followUpReminders,
+    timeline,
+  };
+}


### PR DESCRIPTION
This PR adds Patch 19: Symptom Review Hub.

Changes:
- Adds a protected /symptom-review page
- Adds symptom readiness scoring
- Adds recent severity breakdown for mild, moderate, and severe symptoms
- Adds unresolved symptom and severe-open metrics
- Adds documentation coverage for symptom notes
- Adds body-area cluster cards for repeated symptom patterns
- Adds a recommended symptom action queue from severe unresolved symptoms, moderate unresolved symptoms, symptom alerts, reminders, and missing notes
- Adds search, severity, and status filters
- Adds a symptom register timeline
- Adds care handoff signals and provider review notes
- Adds Symptom Review to the sidebar navigation
- Reuses existing schema models, so no Prisma migration is required