### PR TITLE
Organize sidebar navigation by workflow

### DIFF
--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -13,13 +13,13 @@ import {
   SunMedium,
   X,
 } from "lucide-react";
-import { motion, AnimatePresence } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 import { signOut } from "next-auth/react";
 import { useTheme } from "next-themes";
 import { cn } from "@/lib/utils";
 import {
-  primaryRoutes,
-  utilityRoutes,
+  allAppRoutes,
+  navigationSections,
   type AppRouteItem,
 } from "@/lib/app-routes";
 
@@ -128,60 +128,21 @@ export function AppShell({ children }: AppShellProps) {
     } catch {}
   }, [desktopCollapsed, hasMounted]);
 
-  const activeTitle = useMemo(() => {
-    const all = [...primaryRoutes, ...utilityRoutes];
-    return (
-      all.find(
-        (item) => pathname === item.href || pathname.startsWith(`${item.href}/`)
-      )?.title ?? "VitaVault"
+  const activeRoute = useMemo(() => {
+    return allAppRoutes.find(
+      (item) => pathname === item.href || pathname.startsWith(`${item.href}/`)
     );
   }, [pathname]);
 
-  const routeMap = useMemo(() => {
-    const all = [...primaryRoutes, ...utilityRoutes];
-    return new Map(all.map((r) => [r.href, r]));
-  }, []);
+  const activeSection = useMemo(() => {
+    return navigationSections.find((section) =>
+      section.items.some(
+        (item) => pathname === item.href || pathname.startsWith(`${item.href}/`)
+      )
+    );
+  }, [pathname]);
 
-  const groups = useMemo(() => {
-    const pick = (hrefs: string[]) =>
-      hrefs.map((h) => routeMap.get(h)).filter(Boolean) as AppRouteItem[];
-
-    const overview = pick(["/dashboard", "/onboarding", "/notifications", "/care-plan", "/trends"]);
-    const collaboration = pick([
-      "/ai-insights",
-      "/care-team",
-      "/alerts",
-      "/device-connection",
-    ]);
-
-    const records = primaryRoutes.filter(
-      (r) =>
-        ![
-          "/dashboard",
-          "/onboarding",
-          "/notifications",
-          "/care-plan",
-          "/trends",
-          "/ai-insights",
-          "/care-team",
-          "/alerts",
-          "/device-connection",
-          "/summary",
-        ].includes(r.href)
-    ) as AppRouteItem[];
-
-    const utilities = pick([
-      "/summary",
-      ...utilityRoutes.map((r) => r.href),
-    ]);
-
-    return [
-      { label: "Overview", items: overview },
-      { label: "Flagship", items: collaboration },
-      { label: "Records", items: records },
-      { label: "Utilities", items: utilities },
-    ];
-  }, [routeMap]);
+  const activeTitle = activeRoute?.title ?? "VitaVault";
 
   const Sidebar = ({
     collapsed = false,
@@ -223,7 +184,7 @@ export function AppShell({ children }: AppShellProps) {
                       VitaVault
                     </p>
                     <p className="truncate text-xs text-muted-foreground">
-                      Patient workspace
+                      Health command center
                     </p>
                   </motion.div>
                 ) : null}
@@ -241,8 +202,7 @@ export function AppShell({ children }: AppShellProps) {
                 transition={{ duration: 0.18 }}
                 className="mt-3 text-xs leading-relaxed text-muted-foreground"
               >
-                Secure records, care-team collaboration, and AI-backed
-                summaries.
+                Records, monitoring, care-team workflows, reports, and operations in one organized workspace.
               </motion.p>
             ) : null}
           </AnimatePresence>
@@ -250,27 +210,31 @@ export function AppShell({ children }: AppShellProps) {
       </div>
 
       <div className={cn("mt-6 flex-1 overflow-y-auto pb-6", collapsed ? "px-2" : "px-3")}>
-        {groups.map((group) => (
-          <div key={group.label} className="mb-5">
+        {navigationSections.map((section) => (
+          <div key={section.label} className="mb-5">
             <AnimatePresence initial={false}>
               {!collapsed ? (
-                <motion.p
-                  key={`${group.label}-title`}
+                <motion.div
+                  key={`${section.label}-title`}
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}
                   exit={{ opacity: 0 }}
                   transition={{ duration: 0.15 }}
-                  className="px-2 pb-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground"
+                  className="px-2 pb-2"
                 >
-                  {group.label}
-                </motion.p>
+                  <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    {section.label}
+                  </p>
+                  <p className="mt-0.5 truncate text-[11px] text-muted-foreground/80">
+                    {section.description}
+                  </p>
+                </motion.div>
               ) : null}
             </AnimatePresence>
 
             <div className="space-y-1">
-              {group.items.map((item) => {
-                const active =
-                  pathname === item.href || pathname.startsWith(`${item.href}/`);
+              {section.items.map((item) => {
+                const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
 
                 return (
                   <NavItem
@@ -335,17 +299,21 @@ export function AppShell({ children }: AppShellProps) {
 
         <AnimatePresence initial={false}>
           {!collapsed ? (
-            <motion.p
+            <motion.div
               key="security-note"
               initial={{ opacity: 0, y: -4 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -4 }}
               transition={{ duration: 0.18 }}
-              className="mt-3 text-xs text-muted-foreground"
+              className="mt-3 rounded-2xl border border-border/60 bg-background/50 p-3"
             >
-              Your workspace is authenticated and protected by server-side
-              checks.
-            </motion.p>
+              <p className="text-xs font-medium text-foreground/90">
+                {activeSection?.label ?? "Protected workspace"}
+              </p>
+              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                {activeSection?.description ?? "Authenticated and protected by server-side checks."}
+              </p>
+            </motion.div>
           ) : null}
         </AnimatePresence>
       </div>
@@ -356,7 +324,7 @@ export function AppShell({ children }: AppShellProps) {
     <div className="min-h-screen bg-background">
       <div className="hidden min-h-screen lg:flex">
         <motion.div
-          animate={{ width: desktopCollapsed ? 96 : 340 }}
+          animate={{ width: desktopCollapsed ? 96 : 360 }}
           transition={{ duration: 0.24, ease: "easeOut" }}
           className="border-r border-border/60 bg-background/70"
         >
@@ -373,9 +341,7 @@ export function AppShell({ children }: AppShellProps) {
                   type="button"
                   className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-border/60 bg-background/60 hover:bg-muted/50 transition-colors"
                   onClick={() => setDesktopCollapsed((prev) => !prev)}
-                  aria-label={
-                    desktopCollapsed ? "Expand sidebar" : "Collapse sidebar"
-                  }
+                  aria-label={desktopCollapsed ? "Expand sidebar" : "Collapse sidebar"}
                   title={desktopCollapsed ? "Expand sidebar" : "Collapse sidebar"}
                 >
                   {desktopCollapsed ? (
@@ -387,14 +353,14 @@ export function AppShell({ children }: AppShellProps) {
 
                 <div>
                   <p className="text-xs font-medium text-muted-foreground">
-                    Current section
+                    {activeSection?.label ?? "Current section"}
                   </p>
                   <p className="text-sm font-semibold">{activeTitle}</p>
                 </div>
               </div>
 
               <div className="text-xs text-muted-foreground">
-                Premium healthcare SaaS shell • Dark mode supported
+                Organized healthcare workspace • Navigation grouped by workflow
               </div>
             </div>
           </div>
@@ -423,7 +389,9 @@ export function AppShell({ children }: AppShellProps) {
 
             <div className="min-w-0 text-center">
               <p className="truncate text-sm font-semibold">{activeTitle}</p>
-              <p className="truncate text-xs text-muted-foreground">VitaVault</p>
+              <p className="truncate text-xs text-muted-foreground">
+                {activeSection?.label ?? "VitaVault"}
+              </p>
             </div>
 
             <button
@@ -465,10 +433,13 @@ export function AppShell({ children }: AppShellProps) {
                 animate={{ x: 0 }}
                 exit={{ x: "-100%" }}
                 transition={{ duration: 0.22, ease: "easeOut" }}
-                className="absolute left-0 top-0 h-full w-[88%] max-w-[360px] border-r border-border/60 bg-background"
+                className="absolute left-0 top-0 h-full w-[88%] max-w-[380px] border-r border-border/60 bg-background"
               >
                 <div className="flex items-center justify-between px-4 py-4">
-                  <p className="text-sm font-semibold">Navigation</p>
+                  <div>
+                    <p className="text-sm font-semibold">Navigation</p>
+                    <p className="text-xs text-muted-foreground">Grouped by product workflow</p>
+                  </div>
                   <button
                     type="button"
                     className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-border/60 bg-background/60"
@@ -479,7 +450,7 @@ export function AppShell({ children }: AppShellProps) {
                   </button>
                 </div>
 
-                <div className="h-[calc(100%-64px)]">
+                <div className="h-[calc(100%-72px)]">
                   <Sidebar onNavigate={() => setMobileOpen(false)} />
                 </div>
               </motion.div>

--- a/docs/PATCH_21_NAVIGATION_UX_CLEANUP.md
+++ b/docs/PATCH_21_NAVIGATION_UX_CLEANUP.md
@@ -1,0 +1,38 @@
+# Patch 21 — Navigation UX Cleanup
+
+Patch 21 reorganizes the authenticated VitaVault navigation so the larger Patch 1–20 product surface is easier to browse.
+
+## Why this patch exists
+
+VitaVault now includes many product hubs: notifications, care plan, trends, medication safety, visit prep, lab review, vitals monitor, symptom review, admin, ops, API docs, and more. A flat sidebar made the app feel more crowded than necessary.
+
+This patch groups the navigation by user workflow instead of by patch order.
+
+## Navigation groups
+
+### Overview
+Daily workspace, triage, onboarding, care planning, and visit preparation.
+
+### Records
+Core patient-owned health records and longitudinal history.
+
+### Monitoring
+Safety review, alerts, reminders, device connections, and focused clinical review hubs.
+
+### Sharing & Reports
+Care-team collaboration, AI summaries, emergency card, patient summary, and exports.
+
+### Admin & Ops
+Security, audit log, admin workspace, job monitoring, operations, and API docs.
+
+## Files changed
+
+- `components/app-shell.tsx`
+- `lib/app-routes.ts`
+
+## Notes
+
+- No Prisma migration is required.
+- No server actions are changed.
+- Existing route exports remain available through `primaryRoutes` and `utilityRoutes` for compatibility.
+- New route groups are exported as `navigationSections` for cleaner future UI work.

--- a/lib/app-routes.ts
+++ b/lib/app-routes.ts
@@ -2,24 +2,27 @@ import type { LucideIcon } from "lucide-react";
 import {
   Activity,
   BellRing,
+  BookOpen,
   CalendarClock,
-  Inbox,
+  ClipboardCheck,
   ClipboardList,
   FileBarChart2,
   FileHeart,
   HeartPulse,
+  Inbox,
   LayoutDashboard,
-  ClipboardCheck,
   Pill,
+  ScrollText,
+  ServerCog,
   ShieldAlert,
-  ShieldPlus,
   ShieldCheck,
+  ShieldPlus,
   Smartphone,
   Sparkles,
   Stethoscope,
   Syringe,
-  Users,
   TrendingUp,
+  Users,
   Workflow,
 } from "lucide-react";
 
@@ -30,7 +33,13 @@ export type AppRouteItem = {
   icon: LucideIcon;
 };
 
-export const primaryRoutes: AppRouteItem[] = [
+export type AppRouteSection = {
+  label: string;
+  description: string;
+  items: AppRouteItem[];
+};
+
+export const overviewRoutes: AppRouteItem[] = [
   {
     title: "Dashboard",
     href: "/dashboard",
@@ -55,49 +64,15 @@ export const primaryRoutes: AppRouteItem[] = [
     description: "Prioritized next steps across records, alerts, reminders, and visits",
     icon: ClipboardCheck,
   },
-
   {
     title: "Visit Prep",
     href: "/visit-prep",
     description: "Provider-ready visit packet, prep tasks, and care context",
     icon: ClipboardList,
   },
-  {
-    title: "Health Trends",
-    href: "/trends",
-    description: "Longitudinal vitals, labs, symptoms, and adherence analytics",
-    icon: TrendingUp,
-  },
-  {
-    title: "Emergency Card",
-    href: "/emergency-card",
-    description: "Printable critical care card",
-    icon: ShieldAlert,
-  },
-  {
-    title: "AI Insights",
-    href: "/ai-insights",
-    description: "Generate concise summaries from your records",
-    icon: Sparkles,
-  },
-  {
-    title: "Care Team",
-    href: "/care-team",
-    description: "Invite caregivers and manage shared access",
-    icon: Users,
-  },
-  {
-    title: "Alert Center",
-    href: "/alerts",
-    description: "Foundational alert view for future monitoring",
-    icon: BellRing,
-  },
-  {
-    title: "Device Connections",
-    href: "/device-connection",
-    description: "Integration roadmap for phone and health devices",
-    icon: Smartphone,
-  },
+];
+
+export const recordRoutes: AppRouteItem[] = [
   {
     title: "Health Profile",
     href: "/health-profile",
@@ -109,12 +84,6 @@ export const primaryRoutes: AppRouteItem[] = [
     href: "/medications",
     description: "Schedules, adherence logs, and reminders",
     icon: Pill,
-  },
-  {
-    title: "Medication Safety",
-    href: "/medication-safety",
-    description: "Adherence, dose coverage, refill risk, and medication safety review",
-    icon: ShieldCheck,
   },
   {
     title: "Appointments",
@@ -129,33 +98,15 @@ export const primaryRoutes: AppRouteItem[] = [
     icon: ClipboardList,
   },
   {
-    title: "Lab Review",
-    href: "/lab-review",
-    description: "Abnormal results, lab trends, documents, and follow-up readiness",
-    icon: ClipboardList,
-  },
-  {
     title: "Vitals",
     href: "/vitals",
     description: "BP, sugar, oxygen, weight, and trends",
     icon: HeartPulse,
   },
   {
-    title: "Vitals Monitor",
-    href: "/vitals-monitor",
-    description: "Focused vital signs, device coverage, and urgent reading review",
-    icon: HeartPulse,
-  },
-  {
     title: "Symptoms",
     href: "/symptoms",
     description: "Symptom journal and severity history",
-    icon: Activity,
-  },
-  {
-    title: "Symptom Review",
-    href: "/symptom-review",
-    description: "Unresolved symptoms, body-area clusters, alerts, and care handoff notes",
     icon: Activity,
   },
   {
@@ -177,10 +128,49 @@ export const primaryRoutes: AppRouteItem[] = [
     icon: Stethoscope,
   },
   {
-    title: "Summary",
-    href: "/summary",
-    description: "Printable patient summary view",
-    icon: FileBarChart2,
+    title: "Timeline",
+    href: "/timeline",
+    description: "Longitudinal view of records and care events",
+    icon: Workflow,
+  },
+];
+
+export const monitoringRoutes: AppRouteItem[] = [
+  {
+    title: "Health Trends",
+    href: "/trends",
+    description: "Longitudinal vitals, labs, symptoms, and adherence analytics",
+    icon: TrendingUp,
+  },
+  {
+    title: "Medication Safety",
+    href: "/medication-safety",
+    description: "Adherence, dose coverage, refill risk, and medication safety review",
+    icon: ShieldCheck,
+  },
+  {
+    title: "Lab Review",
+    href: "/lab-review",
+    description: "Abnormal results, lab trends, documents, and follow-up readiness",
+    icon: ClipboardList,
+  },
+  {
+    title: "Vitals Monitor",
+    href: "/vitals-monitor",
+    description: "Focused vital signs, device coverage, and urgent reading review",
+    icon: HeartPulse,
+  },
+  {
+    title: "Symptom Review",
+    href: "/symptom-review",
+    description: "Unresolved symptoms, body-area clusters, alerts, and care handoff notes",
+    icon: Activity,
+  },
+  {
+    title: "Alert Center",
+    href: "/alerts",
+    description: "Alert events, thresholds, and follow-up workflows",
+    icon: BellRing,
   },
   {
     title: "Reminders",
@@ -188,14 +178,65 @@ export const primaryRoutes: AppRouteItem[] = [
     description: "In-app reminder center for due and overdue tasks",
     icon: BellRing,
   },
+  {
+    title: "Review Queue",
+    href: "/review-queue",
+    description: "Focused review list for care follow-ups and print workflows",
+    icon: ClipboardCheck,
+  },
+  {
+    title: "Device Connections",
+    href: "/device-connection",
+    description: "Integration roadmap for phone and health devices",
+    icon: Smartphone,
+  },
 ];
 
-export const utilityRoutes: AppRouteItem[] = [
+export const sharingReportRoutes: AppRouteItem[] = [
+  {
+    title: "Care Team",
+    href: "/care-team",
+    description: "Invite caregivers and manage shared access",
+    icon: Users,
+  },
+  {
+    title: "AI Insights",
+    href: "/ai-insights",
+    description: "Generate concise summaries from your records",
+    icon: Sparkles,
+  },
+  {
+    title: "Emergency Card",
+    href: "/emergency-card",
+    description: "Printable critical care card",
+    icon: ShieldAlert,
+  },
+  {
+    title: "Summary",
+    href: "/summary",
+    description: "Printable patient summary view",
+    icon: FileBarChart2,
+  },
+  {
+    title: "Exports",
+    href: "/exports",
+    description: "Export records and reports",
+    icon: FileBarChart2,
+  },
+];
+
+export const adminOpsRoutes: AppRouteItem[] = [
   {
     title: "Security",
     href: "/security",
     description: "Password rotation and mobile session visibility",
     icon: ShieldCheck,
+  },
+  {
+    title: "Audit Log",
+    href: "/audit-log",
+    description: "Unified audit trail across access, alerts, reminders, jobs, and sessions",
+    icon: ScrollText,
   },
   {
     title: "Admin",
@@ -204,15 +245,60 @@ export const utilityRoutes: AppRouteItem[] = [
     icon: Users,
   },
   {
-    title: "Exports",
-    href: "/exports",
-    description: "Export records and reports",
-    icon: FileBarChart2,
-  },
-  {
     title: "Jobs",
     href: "/jobs",
     description: "Inspect worker queues, retries, and job runs",
     icon: Workflow,
   },
+  {
+    title: "Operations",
+    href: "/ops",
+    description: "Deployment readiness, workload risk, and operational runbooks",
+    icon: ServerCog,
+  },
+  {
+    title: "API Docs",
+    href: "/api-docs",
+    description: "Mobile and device API reference for reviewers and future clients",
+    icon: BookOpen,
+  },
 ];
+
+export const navigationSections: AppRouteSection[] = [
+  {
+    label: "Overview",
+    description: "Daily workspace, triage, and preparation",
+    items: overviewRoutes,
+  },
+  {
+    label: "Records",
+    description: "Core health record modules",
+    items: recordRoutes,
+  },
+  {
+    label: "Monitoring",
+    description: "Safety, trends, reviews, and follow-up queues",
+    items: monitoringRoutes,
+  },
+  {
+    label: "Sharing & Reports",
+    description: "Care collaboration, packets, summaries, and exports",
+    items: sharingReportRoutes,
+  },
+  {
+    label: "Admin & Ops",
+    description: "Security, audit, admin, jobs, ops, and API visibility",
+    items: adminOpsRoutes,
+  },
+];
+
+export const primaryRoutes: AppRouteItem[] = [
+  ...overviewRoutes,
+  ...recordRoutes,
+  ...monitoringRoutes,
+  ...sharingReportRoutes,
+];
+
+export const utilityRoutes: AppRouteItem[] = [...adminOpsRoutes];
+
+export const allAppRoutes: AppRouteItem[] = navigationSections.flatMap((section) => section.items);


### PR DESCRIPTION
This PR adds Patch 21: Navigation UX Cleanup.

Changes:
- Reorganizes VitaVault's sidebar into workflow-based groups
- Adds Overview, Records, Monitoring, Sharing & Reports, and Admin & Ops sections
- Adds missing navigation entries for Timeline, Review Queue, Audit Log, Operations, and API Docs
- Updates the app shell top bar to show the active navigation group
- Updates mobile navigation copy for the grouped product structure
- Preserves primaryRoutes and utilityRoutes exports for compatibility
- Requires no Prisma migration