### PR TITLE
Add admin account lifecycle controls

### DIFF
--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -39,6 +39,99 @@ async function writeAdminAuditLog(args: {
   });
 }
 
+async function revokeMobileSessionsForUser(userId: string) {
+  return db.mobileSessionToken.updateMany({
+    where: {
+      userId,
+      revokedAt: null,
+    },
+    data: {
+      revokedAt: new Date(),
+    },
+  });
+}
+
+export async function deactivateUserAction(formData: FormData) {
+  const actor = await requireAdminActor();
+  const userId = formString(formData, "userId");
+  const reason = formString(formData, "reason");
+
+  if (!userId) throw new Error("User id is required.");
+  if (userId === actor.id) throw new Error("You cannot deactivate your own admin account.");
+
+  const target = await db.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      role: true,
+      deactivatedAt: true,
+    },
+  });
+
+  if (!target) throw new Error("User not found.");
+  if (target.deactivatedAt) throw new Error("User is already deactivated.");
+
+  await db.user.update({
+    where: { id: userId },
+    data: {
+      deactivatedAt: new Date(),
+      deactivatedReason: reason || "Deactivated by administrator.",
+    },
+  });
+
+  const revoked = await revokeMobileSessionsForUser(userId);
+
+  await writeAdminAuditLog({
+    ownerUserId: target.id,
+    actorUserId: actor.id,
+    action: "ADMIN_DEACTIVATED_USER",
+    note: `Deactivated ${target.email}. Reason: ${reason || "No reason provided"}. Revoked ${revoked.count} mobile/API session(s).`,
+  });
+
+  revalidatePath("/admin");
+  revalidatePath("/security");
+}
+
+export async function reactivateUserAction(formData: FormData) {
+  const actor = await requireAdminActor();
+  const userId = formString(formData, "userId");
+
+  if (!userId) throw new Error("User id is required.");
+
+  const target = await db.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      deactivatedAt: true,
+    },
+  });
+
+  if (!target) throw new Error("User not found.");
+  if (!target.deactivatedAt) throw new Error("User is already active.");
+
+  await db.user.update({
+    where: { id: userId },
+    data: {
+      deactivatedAt: null,
+      deactivatedReason: null,
+    },
+  });
+
+  await writeAdminAuditLog({
+    ownerUserId: target.id,
+    actorUserId: actor.id,
+    action: "ADMIN_REACTIVATED_USER",
+    note: `Reactivated ${target.email}.`,
+  });
+
+  revalidatePath("/admin");
+  revalidatePath("/security");
+}
+
 export async function resendVerificationForUserAction(formData: FormData) {
   const actor = await requireAdminActor();
   const userId = formString(formData, "userId");
@@ -55,10 +148,12 @@ export async function resendVerificationForUserAction(formData: FormData) {
       email: true,
       name: true,
       emailVerified: true,
+      deactivatedAt: true,
     },
   });
 
   if (!target) throw new Error("User not found.");
+  if (target.deactivatedAt) throw new Error("Reactivate the user before resending verification.");
   if (target.emailVerified) throw new Error("User is already verified.");
 
   await sendEmailVerificationEmail({
@@ -69,7 +164,7 @@ export async function resendVerificationForUserAction(formData: FormData) {
 
   await writeAdminAuditLog({
     ownerUserId: target.id,
-    actorUserId: actor.id!,
+    actorUserId: actor.id,
     action: "ADMIN_RESENT_VERIFICATION",
     note: `Verification email resent to ${target.email}`,
   });
@@ -82,21 +177,23 @@ export async function revokeUserMobileSessionsAction(formData: FormData) {
   const userId = formString(formData, "userId");
   if (!userId) throw new Error("User id is required.");
 
-  const result = await db.mobileSessionToken.updateMany({
-    where: {
-      userId,
-      revokedAt: null,
-    },
-    data: {
-      revokedAt: new Date(),
+  const target = await db.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      email: true,
     },
   });
 
+  if (!target) throw new Error("User not found.");
+
+  const result = await revokeMobileSessionsForUser(userId);
+
   await writeAdminAuditLog({
     ownerUserId: userId,
-    actorUserId: actor.id!,
+    actorUserId: actor.id,
     action: "ADMIN_REVOKED_MOBILE_SESSIONS",
-    note: `Revoked ${result.count} mobile session(s).`,
+    note: `Revoked ${result.count} mobile/API session(s) for ${target.email}.`,
   });
 
   revalidatePath("/admin");

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -2,16 +2,16 @@ import type { ReactNode } from "react";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { AppRole } from "@prisma/client";
-import { AlertTriangle, CheckCircle2, Cpu, MailCheck, Shield, UserCog, UserPlus, Users } from "lucide-react";
+import { AlertTriangle, Ban, CheckCircle2, Cpu, MailCheck, RotateCcw, Shield, UserCog, UserPlus, Users } from "lucide-react";
 
 import { AppShell } from "@/components/app-shell";
 import { EmptyState, PageHeader, StatusPill } from "@/components/common";
-import { Badge, Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Table, TBody, TD, TH, THead, TR } from "@/components/ui";
+import { Badge, Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Table, TBody, TD, Textarea, TH, THead, TR } from "@/components/ui";
 import { isEmailDeliveryConfigured } from "@/lib/account-email";
 import { getAdminWorkspaceData } from "@/lib/admin-dashboard";
 import { APP_ROLES } from "@/lib/domain/enums";
 import { requireUser } from "@/lib/session";
-import { resendVerificationForUserAction, revokeUserMobileSessionsAction } from "./actions";
+import { deactivateUserAction, reactivateUserAction, resendVerificationForUserAction, revokeUserMobileSessionsAction } from "./actions";
 
 type AdminWorkspaceData = Awaited<ReturnType<typeof getAdminWorkspaceData>>;
 type UserRosterItem = AdminWorkspaceData["userRoster"][number];
@@ -34,7 +34,7 @@ function statusTone(status: string) {
   if (["FAILED", "REVOKED", "DECLINED", "EXPIRED", "DEACTIVATED"].includes(status)) return "danger" as const;
   if (["PENDING", "RETRYING", "ERROR"].includes(status)) return "warning" as const;
   if (["OPEN", "ACTIVE"].includes(status)) return "info" as const;
-  if (["COMPLETED", "RESOLVED", "VERIFIED", "SENT"].includes(status)) return "success" as const;
+  if (["COMPLETED", "RESOLVED", "VERIFIED", "SENT", "REACTIVATED"].includes(status)) return "success" as const;
   return "neutral" as const;
 }
 
@@ -72,18 +72,45 @@ function ProgressBar({ value }: { value: number }) {
   );
 }
 
-function UserActions({ item, emailEnabled }: { item: UserRosterItem; emailEnabled: boolean }) {
+function UserActions({ item, emailEnabled, currentUserId }: { item: UserRosterItem; emailEnabled: boolean; currentUserId: string }) {
+  const isDeactivated = Boolean(item.deactivatedAt);
+  const isSelf = item.id === currentUserId;
+
   return (
-    <div className="space-y-2">
+    <div className="min-w-[230px] space-y-2">
+      {isDeactivated ? (
+        <form action={reactivateUserAction}>
+          <input type="hidden" name="userId" value={item.id} />
+          <Button type="submit" size="sm" className="w-full">
+            <RotateCcw className="h-4 w-4" />
+            Reactivate account
+          </Button>
+        </form>
+      ) : (
+        <form action={deactivateUserAction} className="space-y-2">
+          <input type="hidden" name="userId" value={item.id} />
+          <Textarea
+            name="reason"
+            rows={2}
+            placeholder={isSelf ? "You cannot deactivate yourself" : "Reason for deactivation"}
+            disabled={isSelf}
+          />
+          <Button type="submit" size="sm" variant="destructive" className="w-full" disabled={isSelf}>
+            <Ban className="h-4 w-4" />
+            Deactivate account
+          </Button>
+        </form>
+      )}
+
       <form action={revokeUserMobileSessionsAction}>
         <input type="hidden" name="userId" value={item.id} />
-        <Button type="submit" size="sm" variant="outline">Revoke sessions</Button>
+        <Button type="submit" size="sm" variant="outline" className="w-full">Revoke sessions</Button>
       </form>
 
-      {!item.emailVerified ? (
+      {!item.emailVerified && !isDeactivated ? (
         <form action={resendVerificationForUserAction}>
           <input type="hidden" name="userId" value={item.id} />
-          <Button type="submit" size="sm" variant="secondary" disabled={!emailEnabled}>Resend verification</Button>
+          <Button type="submit" size="sm" variant="secondary" className="w-full" disabled={!emailEnabled}>Resend verification</Button>
         </form>
       ) : null}
     </div>
@@ -139,7 +166,7 @@ export default async function AdminPage() {
       <div className="mx-auto max-w-7xl space-y-6 p-6">
         <PageHeader
           title="Admin Command Center"
-          description="Review user growth, account verification, care-team activity, audit signals, and operational risks from one business-facing admin workspace."
+          description="Review user growth, account verification, account lifecycle state, care-team activity, audit signals, and operational risks from one business-facing admin workspace."
           action={(
             <div className="flex flex-wrap gap-2">
               <Link href="/ops" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium transition-all hover:border-border hover:bg-muted/60">Operations</Link>
@@ -153,8 +180,8 @@ export default async function AdminPage() {
           <StatCard title="Total users" value={data.summary.totalUsers} description="All accounts currently provisioned inside VitaVault." icon={<Users className="h-5 w-5 text-primary" />} />
           <StatCard title="Verified users" value={data.summary.verifiedUsers} description={`${data.summary.verificationRate}% of users have completed email verification.`} icon={<MailCheck className="h-5 w-5 text-emerald-500" />} />
           <StatCard title="Pending invites" value={data.summary.pendingInvites} description="Outstanding care-team invitations awaiting action." icon={<UserPlus className="h-5 w-5 text-violet-500" />} />
-          <StatCard title="Admin accounts" value={data.summary.adminUsers} description="Accounts with full administrative visibility." icon={<UserCog className="h-5 w-5 text-rose-500" />} />
-          <StatCard title="Risk items" value={data.summary.riskItems} description="Open alerts, failed jobs, and pending invites needing review." icon={<AlertTriangle className="h-5 w-5 text-amber-500" />} />
+          <StatCard title="Deactivated users" value={data.summary.deactivatedUsers} description="Recently visible accounts blocked from sign-in and mobile/API use." icon={<Ban className="h-5 w-5 text-rose-500" />} />
+          <StatCard title="Risk items" value={data.summary.riskItems} description="Open alerts, failed jobs, pending invites, and deactivated accounts needing review." icon={<AlertTriangle className="h-5 w-5 text-amber-500" />} />
         </div>
 
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
@@ -168,7 +195,7 @@ export default async function AdminPage() {
           <Card>
             <CardHeader>
               <CardTitle>User roster snapshot</CardTitle>
-              <CardDescription>Recent accounts with role, verification, footprint, and safe admin controls.</CardDescription>
+              <CardDescription>Recent accounts with role, verification, lifecycle status, footprint, and admin controls.</CardDescription>
             </CardHeader>
             <CardContent>
               <div className="overflow-x-auto">
@@ -177,35 +204,44 @@ export default async function AdminPage() {
                     <TR>
                       <TH>User</TH>
                       <TH>Role</TH>
-                      <TH>Verification</TH>
+                      <TH>Status</TH>
                       <TH>Footprint</TH>
                       <TH>Created</TH>
                       <TH>Actions</TH>
                     </TR>
                   </THead>
                   <TBody>
-                    {data.userRoster.map((item: UserRosterItem) => (
-                      <TR key={item.id}>
-                        <TD>
-                          <div className="space-y-1">
-                            <div className="font-medium">{item.name || "Unnamed user"}</div>
-                            <div className="text-xs text-muted-foreground">{item.email}</div>
-                          </div>
-                        </TD>
-                        <TD><StatusPill tone={roleTone(item.role)}>{item.role}</StatusPill></TD>
-                        <TD><StatusPill tone={item.emailVerified ? "success" : "warning"}>{item.emailVerified ? "Verified" : "Pending"}</StatusPill></TD>
-                        <TD>
-                          <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
-                            <Badge>{item._count.reminders} reminders</Badge>
-                            <Badge>{item._count.alertEvents} alerts</Badge>
-                            <Badge>{item._count.documents} docs</Badge>
-                            <Badge>{item._count.mobileSessionTokens} sessions</Badge>
-                          </div>
-                        </TD>
-                        <TD>{formatDateTime(item.createdAt)}</TD>
-                        <TD><UserActions item={item} emailEnabled={emailEnabled} /></TD>
-                      </TR>
-                    ))}
+                    {data.userRoster.map((item: UserRosterItem) => {
+                      const isDeactivated = Boolean(item.deactivatedAt);
+                      return (
+                        <TR key={item.id}>
+                          <TD>
+                            <div className="space-y-1">
+                              <div className="font-medium">{item.name || "Unnamed user"}</div>
+                              <div className="text-xs text-muted-foreground">{item.email}</div>
+                              {item.deactivatedReason ? <div className="text-xs text-destructive">{item.deactivatedReason}</div> : null}
+                            </div>
+                          </TD>
+                          <TD><StatusPill tone={roleTone(item.role)}>{item.role}</StatusPill></TD>
+                          <TD>
+                            <div className="flex flex-col gap-2">
+                              <StatusPill tone={item.emailVerified ? "success" : "warning"}>{item.emailVerified ? "Verified" : "Pending email"}</StatusPill>
+                              <StatusPill tone={isDeactivated ? "danger" : "success"}>{isDeactivated ? "Deactivated" : "Active"}</StatusPill>
+                            </div>
+                          </TD>
+                          <TD>
+                            <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                              <Badge>{item._count.reminders} reminders</Badge>
+                              <Badge>{item._count.alertEvents} alerts</Badge>
+                              <Badge>{item._count.documents} docs</Badge>
+                              <Badge>{item._count.mobileSessionTokens} sessions</Badge>
+                            </div>
+                          </TD>
+                          <TD>{formatDateTime(item.createdAt)}</TD>
+                          <TD><UserActions item={item} emailEnabled={emailEnabled} currentUserId={user.id} /></TD>
+                        </TR>
+                      );
+                    })}
                   </TBody>
                 </Table>
               </div>
@@ -236,6 +272,18 @@ export default async function AdminPage() {
 
             <Card>
               <CardHeader>
+                <CardTitle>Lifecycle controls</CardTitle>
+                <CardDescription>Admin account suspension now uses the schema-backed deactivation fields.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-muted-foreground">
+                <p className="rounded-2xl border border-border/60 bg-background/60 p-4">Deactivated users are blocked by the existing auth/session guards and cannot continue protected app workflows.</p>
+                <p className="rounded-2xl border border-border/60 bg-background/60 p-4">Deactivation revokes mobile/API sessions and writes an admin audit log entry for traceability.</p>
+                <p className="rounded-2xl border border-border/60 bg-background/60 p-4">Admins cannot deactivate their own account from this panel.</p>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
                 <CardTitle>Recent users</CardTitle>
                 <CardDescription>Newest accounts created in the workspace.</CardDescription>
               </CardHeader>
@@ -246,7 +294,10 @@ export default async function AdminPage() {
                       <p className="font-medium">{item.name || "Unnamed user"}</p>
                       <p className="text-xs text-muted-foreground">{item.email} • {formatDateTime(item.createdAt)}</p>
                     </div>
-                    <StatusPill tone={roleTone(item.role)}>{item.role}</StatusPill>
+                    <div className="flex flex-wrap justify-end gap-2">
+                      <StatusPill tone={roleTone(item.role)}>{item.role}</StatusPill>
+                      <StatusPill tone={item.deactivatedAt ? "danger" : "success"}>{item.deactivatedAt ? "Deactivated" : "Active"}</StatusPill>
+                    </div>
                   </div>
                 ))}
                 {data.recentUsers.length === 0 ? <EmptyState title="No recent users" description="Account creation events will appear here." /> : null}
@@ -293,7 +344,7 @@ export default async function AdminPage() {
         <Card>
           <CardHeader>
             <CardTitle>Merged audit feed</CardTitle>
-            <CardDescription>Care access, alert, and reminder audit entries merged into a single admin timeline.</CardDescription>
+            <CardDescription>Care access, alert, reminder, and admin lifecycle audit entries merged into a single admin timeline.</CardDescription>
           </CardHeader>
           <CardContent className="grid gap-3 md:grid-cols-2">
             {data.auditFeed.map((item) => <AuditCard key={item.id} item={item} />)}

--- a/docs/PATCH_22_ADMIN_ACCOUNT_LIFECYCLE.md
+++ b/docs/PATCH_22_ADMIN_ACCOUNT_LIFECYCLE.md
@@ -1,0 +1,59 @@
+# Patch 22 — Admin Account Lifecycle Controls
+
+## Summary
+
+This patch upgrades the Admin Command Center with schema-backed account lifecycle controls using the existing `User.deactivatedAt` and `User.deactivatedReason` fields.
+
+## Added
+
+- Admin deactivate user action
+- Admin reactivate user action
+- Deactivation reason capture
+- Deactivated account status in the user roster
+- Deactivated user count in the admin summary
+- Lifecycle controls panel in `/admin`
+- Mobile/API session revocation during account deactivation
+- Audit log entries for deactivate/reactivate/session revoke actions
+- Mobile login/session checks that reject deactivated users
+
+## Safety notes
+
+- Admins cannot deactivate their own account from the Admin Command Center.
+- Deactivation does not delete user data.
+- Deactivation revokes mobile/API tokens, while existing protected app access is already blocked by the existing `requireUser()` guard.
+- Reactivation clears `deactivatedAt` and `deactivatedReason`.
+
+## Files changed
+
+- `app/admin/page.tsx`
+- `app/admin/actions.ts`
+- `lib/admin-dashboard.ts`
+- `lib/mobile-auth.ts`
+
+## Database impact
+
+No Prisma migration is required because the latest schema already includes:
+
+```prisma
+User.deactivatedAt
+User.deactivatedReason
+```
+
+## Test checklist
+
+Run:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:run
+```
+
+Manual checks:
+
+- Visit `/admin` as an admin
+- Deactivate a non-admin/non-current test user
+- Confirm the user row shows `Deactivated`
+- Confirm sessions can be revoked
+- Reactivate the same user
+- Confirm the row returns to `Active`

--- a/lib/admin-dashboard.ts
+++ b/lib/admin-dashboard.ts
@@ -61,6 +61,8 @@ export async function getAdminWorkspaceData() {
         email: true,
         role: true,
         emailVerified: true,
+        deactivatedAt: true,
+        deactivatedReason: true,
         createdAt: true,
       },
     }),
@@ -74,6 +76,8 @@ export async function getAdminWorkspaceData() {
         role: true,
         createdAt: true,
         emailVerified: true,
+        deactivatedAt: true,
+        deactivatedReason: true,
         _count: {
           select: {
             reminders: true,
@@ -191,7 +195,8 @@ export async function getAdminWorkspaceData() {
     .slice(0, 16);
 
   const verificationRate = totalUsers > 0 ? Math.round((verifiedUsers / totalUsers) * 100) : 0;
-  const riskItems = openAlerts + failedJobs + pendingInvites;
+  const deactivatedUsers = userRoster.filter((item) => Boolean(item.deactivatedAt)).length;
+  const riskItems = openAlerts + failedJobs + pendingInvites + deactivatedUsers;
 
   return {
     summary: {
@@ -204,6 +209,7 @@ export async function getAdminWorkspaceData() {
       openAlerts,
       failedJobs,
       activeMobileSessions,
+      deactivatedUsers,
       riskItems,
     },
     recentUsers,

--- a/lib/mobile-auth.ts
+++ b/lib/mobile-auth.ts
@@ -67,10 +67,11 @@ export async function authenticateMobileCredentials(params: {
       email: true,
       name: true,
       passwordHash: true,
+      deactivatedAt: true,
     },
   });
 
-  if (!user?.passwordHash) {
+  if (!user?.passwordHash || user.deactivatedAt) {
     return null;
   }
 
@@ -102,6 +103,7 @@ export async function requireMobileUser(request: Request) {
           id: true,
           email: true,
           name: true,
+          deactivatedAt: true,
         },
       },
     },
@@ -116,6 +118,10 @@ export async function requireMobileUser(request: Request) {
   }
 
   if (session.expiresAt <= new Date()) {
+    return null;
+  }
+
+  if (session.user.deactivatedAt) {
     return null;
   }
 


### PR DESCRIPTION
This PR adds Patch 22: Admin Account Lifecycle Controls.

Changes:
- Adds schema-backed deactivate/reactivate controls to the Admin Command Center
- Adds deactivation reason capture and account status visibility
- Adds deactivated user summary visibility
- Revokes mobile/API sessions when an account is deactivated
- Adds admin audit log entries for deactivate, reactivate, resend verification, and session revoke actions
- Updates mobile authentication/session checks to reject deactivated users
- Prevents admins from deactivating their own account
- Reuses existing deactivatedAt and deactivatedReason schema fields, so no Prisma migration is required