### PR TITLE
Upgrade export center

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { AppRole } from "@prisma/client";
-import { AlertTriangle, Ban, CheckCircle2, Cpu, MailCheck, RotateCcw, Shield, UserCog, UserPlus, Users } from "lucide-react";
+import { AlertTriangle, Ban, CheckCircle2, Cpu, MailCheck, RotateCcw, Shield, UserPlus, Users } from "lucide-react";
 
 import { AppShell } from "@/components/app-shell";
 import { EmptyState, PageHeader, StatusPill } from "@/components/common";

--- a/app/ai-insights/page.tsx
+++ b/app/ai-insights/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { AlertTriangle, BrainCircuit, CheckCircle2, ClipboardList, Database, FileText, HelpCircle, History, ShieldCheck, Sparkles } from "lucide-react";
+import { AlertTriangle, BrainCircuit, ClipboardList, Database, FileText, HelpCircle, History, ShieldCheck, Sparkles } from "lucide-react";
 import { AppShell } from "@/components/app-shell";
 import { EmptyState, PageHeader, StatusPill } from "@/components/common";
 import { Badge, Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";

--- a/app/exports/page.tsx
+++ b/app/exports/page.tsx
@@ -1,26 +1,93 @@
 import Link from "next/link";
-import { Download, FileSpreadsheet, ShieldCheck } from "lucide-react";
+import { ArrowRight, ClipboardCheck, Download, FileSpreadsheet, FileText, ShieldCheck, Sparkles } from "lucide-react";
 import { AppShell } from "@/components/app-shell";
-import { PageHeader } from "@/components/common";
+import { PageHeader, StatusPill } from "@/components/common";
 import { Badge, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
 import { ModuleHero, DataCard } from "@/components/module-sections";
 import { PageTransition, StaggerGroup, StaggerItem } from "@/components/page-transition";
 import { exportDefinitions } from "@/lib/export-definitions";
+import { getExportCenterData, type ExportActionItem, type ExportPacket } from "@/lib/export-center";
 
 const groups = ["Core", "Monitoring", "Coordination"] as const;
 
-export default function ExportsPage() {
+type Tone = "neutral" | "info" | "success" | "warning" | "danger";
+
+function readinessTone(readiness: ExportPacket["readiness"]): Tone {
+  if (readiness === "Ready") return "success";
+  if (readiness === "Review first") return "warning";
+  return "danger";
+}
+
+function priorityTone(priority: ExportActionItem["priority"]): Tone {
+  if (priority === "high") return "danger";
+  if (priority === "medium") return "warning";
+  return "success";
+}
+
+function ProgressBar({ value }: { value: number }) {
+  const safeValue = Math.max(0, Math.min(100, value));
+  return (
+    <div className="h-2 overflow-hidden rounded-full bg-muted">
+      <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${safeValue}%` }} />
+    </div>
+  );
+}
+
+function PacketCard({ packet }: { packet: ExportPacket }) {
+  return (
+    <DataCard className="flex h-full flex-col justify-between">
+      <div className="space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+            {packet.format === "Print / PDF" ? <FileText className="h-4 w-4" /> : <ClipboardCheck className="h-4 w-4" />}
+          </div>
+          <StatusPill tone={readinessTone(packet.readiness)}>{packet.readiness}</StatusPill>
+        </div>
+        <div>
+          <p className="font-semibold">{packet.title}</p>
+          <p className="mt-1 text-sm text-muted-foreground">{packet.description}</p>
+        </div>
+        <p className="rounded-2xl border border-border/60 bg-background/50 p-3 text-xs text-muted-foreground">{packet.reason}</p>
+      </div>
+      <div className="mt-4 flex items-center justify-between gap-3">
+        <Badge>{packet.format}</Badge>
+        <Link href={packet.href} className="inline-flex items-center justify-center rounded-2xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm hover:opacity-95">
+          Open
+          <ArrowRight className="ml-2 h-4 w-4" />
+        </Link>
+      </div>
+    </DataCard>
+  );
+}
+
+function ActionItemCard({ item }: { item: ExportActionItem }) {
+  return (
+    <Link href={item.href} className="block rounded-2xl border border-border/60 bg-background/50 p-4 transition hover:border-border hover:bg-muted/40">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="font-medium">{item.title}</p>
+          <p className="mt-1 text-sm text-muted-foreground">{item.description}</p>
+        </div>
+        <StatusPill tone={priorityTone(item.priority)}>{item.priority}</StatusPill>
+      </div>
+    </Link>
+  );
+}
+
+export default async function ExportsPage() {
+  const data = await getExportCenterData();
+
   return (
     <AppShell>
       <div className="mx-auto max-w-7xl space-y-6 p-6">
         <PageTransition>
           <PageHeader
-            title="Exports"
-            description="Download structured CSV exports of your records for offline review, spreadsheet analysis, handoff, or internal reporting."
+            title="Export Center"
+            description="Prepare CSV datasets, print-ready patient packets, and workflow handoff views from one reporting workspace."
             action={
               <div className="flex flex-wrap gap-2">
-                <Badge className="bg-background/70">{exportDefinitions.length} export types</Badge>
-                <Badge className="bg-background/70">CSV only</Badge>
+                <Badge className="bg-background/70">{data.summary.csvExportTypes} CSV exports</Badge>
+                <Badge className="bg-background/70">{data.summary.reportPackets} report packets</Badge>
               </div>
             }
           />
@@ -28,27 +95,70 @@ export default function ExportsPage() {
 
         <PageTransition delay={0.04}>
           <ModuleHero
-            eyebrow="Data portability"
-            title="Operational exports across the patient workspace"
-            description="Export coverage now extends beyond the original core modules so patient handoffs, admin review, and spreadsheet-based workflows are easier to support."
+            eyebrow="Reporting and handoff"
+            title="A stronger export workspace for patient records, clinical review, and operational reporting"
+            description="CSV exports stay available for spreadsheet work, while report packet shortcuts make doctor visits, emergency handoffs, and care-plan reviews easier to prepare."
             stats={[
-              { label: "Available exports", value: exportDefinitions.length },
-              { label: "Format", value: "CSV" },
-              { label: "Coverage", value: "Core + coordination" },
-              { label: "Use case", value: "Offline reporting" },
+              { label: "Readiness", value: `${data.summary.readinessScore}%`, hint: "Profile, records, documents, and provider context" },
+              { label: "Records covered", value: data.summary.totalRecords, hint: "Across exportable record families" },
+              { label: "Open alerts", value: data.summary.openAlerts, hint: `${data.summary.highRiskAlerts} high-priority` },
+              { label: "Document links", value: `${data.summary.documentLinkRate}%`, hint: "Documents connected to records" },
             ]}
           />
         </PageTransition>
 
+        <div className="grid gap-6 xl:grid-cols-[1fr_0.85fr]">
+          <Card>
+            <CardHeader>
+              <CardTitle>Export readiness</CardTitle>
+              <CardDescription className="mt-1">How ready this workspace is for clean handoff, reporting, and review packets.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-center justify-between gap-4">
+                <div>
+                  <p className="text-3xl font-semibold">{data.summary.readinessScore}%</p>
+                  <p className="text-sm text-muted-foreground">Overall export readiness</p>
+                </div>
+                <StatusPill tone={data.summary.readinessScore >= 75 ? "success" : data.summary.readinessScore >= 50 ? "warning" : "danger"}>
+                  {data.summary.readinessScore >= 75 ? "Ready" : "Needs review"}
+                </StatusPill>
+              </div>
+              <ProgressBar value={data.summary.readinessScore} />
+              <div className="grid gap-3 md:grid-cols-3">
+                {data.csvCoverage.map((item) => (
+                  <div key={item.label} className="rounded-2xl border border-border/60 bg-background/50 p-4">
+                    <p className="text-xs font-medium text-muted-foreground">{item.label}</p>
+                    <p className="mt-1 text-2xl font-semibold">{item.value}</p>
+                    <p className="mt-1 text-xs text-muted-foreground">{item.description}</p>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Recommended before exporting</CardTitle>
+              <CardDescription className="mt-1">Fix the highest-impact gaps before sharing reports.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {data.actionItems.map((item) => <ActionItemCard key={item.title} item={item} />)}
+            </CardContent>
+          </Card>
+        </div>
+
         <StaggerGroup delay={0.08}>
-          <div className="grid gap-6 xl:grid-cols-[1.25fr_0.75fr]">
+          <div className="grid gap-6 xl:grid-cols-[1.15fr_0.85fr]">
             <StaggerItem>
               <Card>
                 <CardHeader>
-                  <CardTitle>Export options</CardTitle>
-                  <CardDescription className="mt-1">
-                    Download structured datasets from the main health, monitoring, and coordination modules.
-                  </CardDescription>
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <CardTitle>CSV export library</CardTitle>
+                      <CardDescription className="mt-1">Download structured datasets from the main health, monitoring, and coordination modules.</CardDescription>
+                    </div>
+                    <FileSpreadsheet className="h-5 w-5 text-primary" />
+                  </div>
                 </CardHeader>
                 <CardContent className="space-y-6">
                   {groups.map((group) => {
@@ -62,24 +172,18 @@ export default function ExportsPage() {
                         <div className="grid gap-4 md:grid-cols-2">
                           {items.map((item) => (
                             <DataCard key={item.href}>
-                              <div className="flex items-start justify-between gap-3">
-                                <div className="flex items-start gap-3">
-                                  <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
-                                    <FileSpreadsheet className="h-4 w-4" />
-                                  </div>
-                                  <div>
-                                    <p className="text-sm font-semibold">{item.title}</p>
-                                    <p className="mt-1 text-sm text-muted-foreground">{item.description}</p>
-                                  </div>
+                              <div className="flex items-start gap-3">
+                                <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                                  <FileSpreadsheet className="h-4 w-4" />
+                                </div>
+                                <div>
+                                  <p className="text-sm font-semibold">{item.title}</p>
+                                  <p className="mt-1 text-sm text-muted-foreground">{item.description}</p>
                                 </div>
                               </div>
-
                               <div className="mt-4 flex items-center justify-between gap-3">
                                 <Badge className="bg-background/70">{item.format}</Badge>
-                                <Link
-                                  href={item.href}
-                                  className="inline-flex items-center justify-center rounded-2xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm hover:opacity-95"
-                                >
+                                <Link href={item.href} className="inline-flex items-center justify-center rounded-2xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm hover:opacity-95">
                                   <Download className="mr-2 h-4 w-4" />
                                   Download
                                 </Link>
@@ -98,35 +202,16 @@ export default function ExportsPage() {
               <div className="space-y-6">
                 <Card>
                   <CardHeader>
-                    <CardTitle>Export guidance</CardTitle>
-                    <CardDescription className="mt-1">
-                      Keep exports useful, readable, and operational.
-                    </CardDescription>
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <CardTitle>Report packets and handoff views</CardTitle>
+                        <CardDescription className="mt-1">Open print-friendly packets or review workspaces before sharing records.</CardDescription>
+                      </div>
+                      <Sparkles className="h-5 w-5 text-primary" />
+                    </div>
                   </CardHeader>
-                  <CardContent className="space-y-4">
-                    <DataCard>
-                      <p className="text-sm font-medium">Best use cases</p>
-                      <ul className="mt-2 space-y-2 text-sm text-muted-foreground">
-                        <li>Spreadsheet review</li>
-                        <li>Clinical handoff support</li>
-                        <li>Operational reporting</li>
-                        <li>Record backup and audit prep</li>
-                      </ul>
-                    </DataCard>
-
-                    <DataCard>
-                      <p className="text-sm font-medium">Current format</p>
-                      <p className="mt-2 text-sm text-muted-foreground">
-                        CSV keeps the export simple, widely compatible, and easy to open in Excel, Google Sheets, or internal reporting tools.
-                      </p>
-                    </DataCard>
-
-                    <DataCard>
-                      <p className="text-sm font-medium">Also available</p>
-                      <p className="mt-2 text-sm text-muted-foreground">
-                        For print-ready handoffs, the patient summary page provides a separate PDF-friendly browser print workflow.
-                      </p>
-                    </DataCard>
+                  <CardContent className="grid gap-4">
+                    {data.packets.map((packet) => <PacketCard key={packet.href} packet={packet} />)}
                   </CardContent>
                 </Card>
 
@@ -135,7 +220,7 @@ export default function ExportsPage() {
                     <div className="flex items-start gap-3">
                       <ShieldCheck className="mt-0.5 h-4 w-4 text-primary" />
                       <p className="text-sm text-muted-foreground">
-                        These exports are scoped to the signed-in user’s records and intended for controlled operational use only.
+                        Exports are scoped to the signed-in user. Print packets should be reviewed before sharing with providers, caregivers, or external recipients.
                       </p>
                     </div>
                   </CardContent>

--- a/docs/PATCH_24B_EXPORT_CENTER_TYPECHECK_FIX.md
+++ b/docs/PATCH_24B_EXPORT_CENTER_TYPECHECK_FIX.md
@@ -1,0 +1,21 @@
+# Patch 24B — Export Center Lint / Typecheck Fix
+
+This hotfix stabilizes Patch 24 after local checks reported a parser error in `lib/export-center.ts` and two unused imports.
+
+## Fixes
+
+- Fixed template literals in `lib/export-center.ts` that were closed with double quotes instead of backticks.
+- Removed unused `UserCog` import from `app/admin/page.tsx`.
+- Removed unused `CheckCircle2` import from `app/ai-insights/page.tsx`.
+
+## Validation
+
+Run:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:run
+```
+
+No Prisma migration is required.

--- a/docs/PATCH_24C_EXPORT_CENTER_FINAL_TYPECHECK_FIX.md
+++ b/docs/PATCH_24C_EXPORT_CENTER_FINAL_TYPECHECK_FIX.md
@@ -1,0 +1,20 @@
+# Patch 24C — Export Center Final Typecheck Fix
+
+This hotfix corrects the Patch 24 Export Center typecheck issue that remained after the previous ZIP did not include the corrected `lib/export-center.ts` file.
+
+## Changes
+
+- Restores the corrected `lib/export-center.ts` with properly closed template literals.
+- Removes the unused `CheckCircle2` import from `app/ai-insights/page.tsx`.
+- Keeps Export Center v2 and AI Insights v2 behavior intact.
+- Requires no Prisma migration.
+
+## Validation
+
+Run:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:run
+```

--- a/docs/PATCH_24D_EXPORT_CENTER_FINAL_REPLACEMENT.md
+++ b/docs/PATCH_24D_EXPORT_CENTER_FINAL_REPLACEMENT.md
@@ -1,0 +1,20 @@
+# Patch 24D — Export Center Final Replacement
+
+This hotfix replaces `lib/export-center.ts` with a syntax-clean version after the previous export center fix did not fully overwrite the local file.
+
+## Fixes
+
+- Corrects all broken template literals in `lib/export-center.ts`.
+- Keeps Export Center v2 behavior intact.
+- Includes the AI Insights page without the unused `CheckCircle2` import.
+- Requires no Prisma migration.
+
+## Verification
+
+Run:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:run
+```

--- a/docs/PATCH_24_EXPORT_CENTER_V2.md
+++ b/docs/PATCH_24_EXPORT_CENTER_V2.md
@@ -1,0 +1,28 @@
+# Patch 24 — Export Center v2
+
+## Summary
+
+This patch upgrades the existing `/exports` page into a stronger reporting and handoff workspace.
+
+## Added
+
+- Export readiness score
+- CSV coverage cards
+- Recommended pre-export action queue
+- Report packet shortcuts
+- Patient summary packet shortcut
+- Doctor visit packet shortcut
+- Emergency card packet shortcut
+- Care plan review workspace shortcut
+- Document link coverage signal
+- Medication adherence signal
+- Open/high-risk alert signal
+
+## Files changed
+
+- `app/exports/page.tsx`
+- `lib/export-center.ts`
+
+## Notes
+
+This patch does not add a Prisma migration. It reuses existing VitaVault health, alert, reminder, document, appointment, medication, and care-workflow data.

--- a/lib/export-center.ts
+++ b/lib/export-center.ts
@@ -1,0 +1,202 @@
+import { AlertSeverity, AlertStatus, LabFlag, MedicationLogStatus, ReminderState } from "@prisma/client";
+import { db } from "@/lib/db";
+import { requireUser } from "@/lib/session";
+import { exportDefinitions } from "@/lib/export-definitions";
+
+export type ExportPacket = {
+  title: string;
+  description: string;
+  href: string;
+  format: "Print / PDF" | "Workspace";
+  readiness: "Ready" | "Review first" | "Setup needed";
+  reason: string;
+};
+
+export type ExportActionItem = {
+  title: string;
+  description: string;
+  href: string;
+  priority: "high" | "medium" | "low";
+};
+
+function pct(value: number, total: number) {
+  if (total <= 0) return 0;
+  return Math.round((value / total) * 100);
+}
+
+function scoreFromChecks(checks: boolean[]) {
+  if (!checks.length) return 0;
+  return pct(checks.filter(Boolean).length, checks.length);
+}
+
+export async function getExportCenterData() {
+  const user = await requireUser();
+  const now = new Date();
+  const thirtyDaysAgo = new Date(now);
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+  const [
+    profile,
+    medications,
+    medicationLogs30d,
+    missedMedicationLogs30d,
+    appointments,
+    upcomingAppointments,
+    labs,
+    abnormalLabs,
+    vitals,
+    symptoms,
+    severeOpenSymptoms,
+    vaccinations,
+    documents,
+    linkedDocuments,
+    reminders,
+    activeReminders,
+    openAlerts,
+    highRiskAlerts,
+    doctors,
+  ] = await Promise.all([
+    db.healthProfile.findUnique({ where: { userId: user.id } }),
+    db.medication.count({ where: { userId: user.id } }),
+    db.medicationLog.count({ where: { userId: user.id, loggedAt: { gte: thirtyDaysAgo } } }),
+    db.medicationLog.count({ where: { userId: user.id, loggedAt: { gte: thirtyDaysAgo }, status: { in: [MedicationLogStatus.MISSED, MedicationLogStatus.SKIPPED] } } }),
+    db.appointment.count({ where: { userId: user.id } }),
+    db.appointment.count({ where: { userId: user.id, scheduledAt: { gte: now } } }),
+    db.labResult.count({ where: { userId: user.id } }),
+    db.labResult.count({ where: { userId: user.id, flag: { in: [LabFlag.BORDERLINE, LabFlag.HIGH, LabFlag.LOW] } } }),
+    db.vitalRecord.count({ where: { userId: user.id } }),
+    db.symptomEntry.count({ where: { userId: user.id } }),
+    db.symptomEntry.count({ where: { userId: user.id, severity: "SEVERE", resolved: false } }),
+    db.vaccinationRecord.count({ where: { userId: user.id } }),
+    db.medicalDocument.count({ where: { userId: user.id } }),
+    db.medicalDocument.count({ where: { userId: user.id, linkedRecordType: { not: null }, linkedRecordId: { not: null } } }),
+    db.reminder.count({ where: { userId: user.id } }),
+    db.reminder.count({ where: { userId: user.id, state: { in: [ReminderState.DUE, ReminderState.OVERDUE, ReminderState.MISSED] } } }),
+    db.alertEvent.count({ where: { userId: user.id, status: AlertStatus.OPEN } }),
+    db.alertEvent.count({ where: { userId: user.id, status: AlertStatus.OPEN, severity: { in: [AlertSeverity.HIGH, AlertSeverity.CRITICAL] } } }),
+    db.doctor.count({ where: { userId: user.id } }),
+  ]);
+
+  const profileReady = Boolean(profile?.fullName && profile?.dateOfBirth && profile?.emergencyContactName && profile?.emergencyContactPhone);
+  const medicationReady = medications > 0;
+  const clinicalReady = labs > 0 || vitals > 0 || symptoms > 0;
+  const documentReady = documents > 0;
+  const providerReady = doctors > 0 || appointments > 0;
+  const readinessScore = scoreFromChecks([profileReady, medicationReady, clinicalReady, documentReady, providerReady]);
+  const documentLinkRate = pct(linkedDocuments, documents);
+  const medicationAdherenceRate = medicationLogs30d > 0 ? Math.max(0, 100 - pct(missedMedicationLogs30d, medicationLogs30d)) : 0;
+
+  const csvCoverage = [
+    { label: "Core records", value: appointments + medications + labs + vaccinations, description: "Appointments, medications, lab results, and vaccination records." },
+    { label: "Monitoring data", value: vitals + symptoms, description: "Vitals and symptom history for trends and review." },
+    { label: "Coordination", value: reminders + documents + openAlerts, description: "Reminders, documents, and alert snapshots." },
+  ];
+
+  const packets: ExportPacket[] = [
+    {
+      title: "Patient summary packet",
+      description: "A broad handoff report for patient profile, recent records, reminders, and risk context.",
+      href: "/summary/print?mode=compact",
+      format: "Print / PDF",
+      readiness: profileReady ? "Ready" : "Review first",
+      reason: profileReady ? "Profile and emergency basics are available." : "Add profile and emergency contact details before sharing.",
+    },
+    {
+      title: "Doctor visit packet",
+      description: "A provider-focused report for upcoming visits and clinical handoff preparation.",
+      href: "/summary/print?mode=doctor",
+      format: "Print / PDF",
+      readiness: upcomingAppointments > 0 || providerReady ? "Ready" : "Setup needed",
+      reason: upcomingAppointments > 0 ? "Upcoming appointment context is available." : "Add an appointment or provider to make this stronger.",
+    },
+    {
+      title: "Emergency health card",
+      description: "A compact printable card for emergency contact, allergies, conditions, medications, and latest vitals.",
+      href: "/emergency-card/print",
+      format: "Print / PDF",
+      readiness: profile?.emergencyContactName && profile?.emergencyContactPhone ? "Ready" : "Review first",
+      reason: profile?.emergencyContactName && profile?.emergencyContactPhone ? "Emergency contact details are present." : "Emergency contact details are missing.",
+    },
+    {
+      title: "Care plan review workspace",
+      description: "A workflow view for current care gaps, action items, upcoming care, and provider context.",
+      href: "/care-plan",
+      format: "Workspace",
+      readiness: readinessScore >= 60 ? "Ready" : "Review first",
+      reason: `${readinessScore}% export readiness across profile, records, documents, and provider context.`,
+    },
+  ];
+
+  const actionItems: ExportActionItem[] = [];
+
+  if (!profileReady) {
+    actionItems.push({
+      title: "Complete profile and emergency details",
+      description: "Patient summary and emergency reports are more useful when identity, date of birth, and emergency contact fields are complete.",
+      href: "/onboarding",
+      priority: "high",
+    });
+  }
+
+  if (documents > 0 && documentLinkRate < 60) {
+    actionItems.push({
+      title: "Improve document link coverage",
+      description: `${documentLinkRate}% of documents are linked to a record. Link lab files, prescriptions, and discharge documents before exporting.`,
+      href: "/documents?link=UNLINKED",
+      priority: "medium",
+    });
+  }
+
+  if (highRiskAlerts > 0) {
+    actionItems.push({
+      title: "Review high-risk open alerts",
+      description: `${highRiskAlerts} high-priority alert${highRiskAlerts === 1 ? "" : "s"} should be reviewed before sending a handoff packet.`,
+      href: "/alerts",
+      priority: "high",
+    });
+  }
+
+  if (abnormalLabs > 0) {
+    actionItems.push({
+      title: "Add lab review context",
+      description: `${abnormalLabs} lab result${abnormalLabs === 1 ? "" : "s"} are abnormal or borderline. Review them before a doctor packet.`,
+      href: "/lab-review",
+      priority: "medium",
+    });
+  }
+
+  if (severeOpenSymptoms > 0) {
+    actionItems.push({
+      title: "Review severe unresolved symptoms",
+      description: `${severeOpenSymptoms} severe symptom${severeOpenSymptoms === 1 ? "" : "s"} remain unresolved and should be included in visit prep.`,
+      href: "/symptom-review",
+      priority: "high",
+    });
+  }
+
+  if (actionItems.length === 0) {
+    actionItems.push({
+      title: "Export readiness looks healthy",
+      description: "Core profile, records, and reporting context look ready for handoff and review workflows.",
+      href: "/summary",
+      priority: "low",
+    });
+  }
+
+  return {
+    summary: {
+      readinessScore,
+      csvExportTypes: exportDefinitions.length,
+      reportPackets: packets.length,
+      totalRecords: medications + appointments + labs + vitals + symptoms + vaccinations + documents + reminders + openAlerts,
+      documentLinkRate,
+      medicationAdherenceRate,
+      activeReminders,
+      openAlerts,
+      highRiskAlerts,
+    },
+    csvCoverage,
+    packets,
+    actionItems,
+  };
+}


### PR DESCRIPTION
This PR adds Patch 24: Export Center v2.

Changes:
- Upgrades /exports into a stronger reporting and handoff workspace
- Adds export readiness scoring
- Adds CSV coverage cards across core, monitoring, and coordination records
- Adds recommended pre-export action items
- Adds report packet shortcuts for patient summary, doctor visit packet, emergency card, and care plan review
- Adds document link coverage, medication adherence, and alert-risk signals
- Keeps existing CSV export downloads intact
- Requires no Prisma migration