### PR TITLE
Add device sync simulator

### DIFF
--- a/app/device-sync-simulator/actions.ts
+++ b/app/device-sync-simulator/actions.ts
@@ -1,0 +1,208 @@
+"use server";
+
+import {
+  DeviceConnectionStatus,
+  DeviceReadingType,
+  JobKind,
+  JobRunStatus,
+  ReadingSource,
+  SyncJobStatus,
+} from "@prisma/client";
+import { revalidatePath } from "next/cache";
+import { db } from "@/lib/db";
+import { requireUser } from "@/lib/session";
+import {
+  buildSimulatorReadings,
+  getSimulatorProvider,
+  parseSimulatorSource,
+  type SimulatorReadingInput,
+} from "@/lib/device-sync-simulator";
+
+function dedupeKey(userId: string, source: ReadingSource, reading: SimulatorReadingInput) {
+  return [
+    "simulator",
+    userId,
+    source,
+    reading.readingType,
+    reading.capturedAt.toISOString(),
+    reading.valueInt ?? "",
+    reading.valueFloat ?? "",
+    reading.systolic ?? "",
+    reading.diastolic ?? "",
+  ].join(":");
+}
+
+function vitalDataForReading(userId: string, source: ReadingSource, reading: SimulatorReadingInput, key: string) {
+  if (reading.readingType === DeviceReadingType.STEPS) return null;
+
+  return {
+    userId,
+    recordedAt: reading.capturedAt,
+    externalReadingId: key,
+    readingSource: source,
+    notes: "Mirrored from VitaVault device sync simulator.",
+    systolic: reading.readingType === DeviceReadingType.BLOOD_PRESSURE ? reading.systolic ?? null : null,
+    diastolic: reading.readingType === DeviceReadingType.BLOOD_PRESSURE ? reading.diastolic ?? null : null,
+    heartRate: reading.readingType === DeviceReadingType.HEART_RATE ? reading.valueInt ?? null : null,
+    bloodSugar: reading.readingType === DeviceReadingType.BLOOD_GLUCOSE ? reading.valueFloat ?? null : null,
+    oxygenSaturation: reading.readingType === DeviceReadingType.OXYGEN_SATURATION ? reading.valueInt ?? null : null,
+    temperatureC: reading.readingType === DeviceReadingType.TEMPERATURE ? reading.valueFloat ?? null : null,
+    weightKg: reading.readingType === DeviceReadingType.WEIGHT ? reading.valueFloat ?? null : null,
+  };
+}
+
+export async function runDeviceSyncSimulationAction(formData: FormData) {
+  const user = await requireUser();
+  const source = parseSimulatorSource(formData.get("source"));
+  const provider = getSimulatorProvider(source);
+  const readings = buildSimulatorReadings(source);
+  const startedAt = new Date();
+
+  const connection = await db.deviceConnection.upsert({
+    where: {
+      userId_source_clientDeviceId: {
+        userId: user.id,
+        source,
+        clientDeviceId: "vitavault-simulator-" + source.toLowerCase(),
+      },
+    },
+    create: {
+      userId: user.id,
+      source,
+      platform: provider.platform,
+      clientDeviceId: "vitavault-simulator-" + source.toLowerCase(),
+      deviceLabel: provider.title,
+      appVersion: "simulator-1.0",
+      scopesJson: JSON.stringify(provider.readings),
+      lastSyncedAt: startedAt,
+    },
+    update: {
+      platform: provider.platform,
+      deviceLabel: provider.title,
+      status: DeviceConnectionStatus.ACTIVE,
+      lastSyncedAt: startedAt,
+      lastError: null,
+      scopesJson: JSON.stringify(provider.readings),
+    },
+    select: { id: true },
+  });
+
+  const syncJob = await db.syncJob.create({
+    data: {
+      userId: user.id,
+      connectionId: connection.id,
+      source,
+      platform: provider.platform,
+      status: SyncJobStatus.RUNNING,
+      requestedCount: readings.length,
+      acceptedCount: 0,
+      mirroredCount: 0,
+      startedAt,
+      metadataJson: JSON.stringify({ simulator: true, provider: provider.title }),
+    },
+    select: { id: true },
+  });
+
+  const jobRun = await db.jobRun.create({
+    data: {
+      queueName: "device-sync-simulator",
+      jobName: provider.title,
+      jobKind: JobKind.DEVICE_SYNC_PROCESSING,
+      status: JobRunStatus.ACTIVE,
+      userId: user.id,
+      connectionId: connection.id,
+      syncJobId: syncJob.id,
+      inputJson: JSON.stringify({ source, requestedCount: readings.length }),
+      startedAt,
+      maxAttempts: 1,
+    },
+    select: { id: true },
+  });
+
+  let acceptedCount = 0;
+  let mirroredCount = 0;
+
+  for (const reading of readings) {
+    const key = dedupeKey(user.id, source, reading);
+
+    await db.deviceReading.upsert({
+      where: { dedupeKey: key },
+      create: {
+        userId: user.id,
+        connectionId: connection.id,
+        source,
+        platform: provider.platform,
+        readingType: reading.readingType,
+        capturedAt: reading.capturedAt,
+        dedupeKey: key,
+        unit: reading.unit,
+        valueInt: reading.valueInt,
+        valueFloat: reading.valueFloat,
+        systolic: reading.systolic,
+        diastolic: reading.diastolic,
+        metadataJson: JSON.stringify({ simulator: true, provider: provider.title }),
+        rawPayloadJson: JSON.stringify(reading),
+      },
+      update: {
+        connectionId: connection.id,
+        capturedAt: reading.capturedAt,
+        unit: reading.unit,
+        valueInt: reading.valueInt,
+        valueFloat: reading.valueFloat,
+        systolic: reading.systolic,
+        diastolic: reading.diastolic,
+        metadataJson: JSON.stringify({ simulator: true, provider: provider.title }),
+        rawPayloadJson: JSON.stringify(reading),
+      },
+    });
+
+    acceptedCount += 1;
+
+    const vitalData = vitalDataForReading(user.id, source, reading, key);
+    if (vitalData) {
+      await db.vitalRecord.upsert({
+        where: { externalReadingId: key },
+        create: vitalData,
+        update: vitalData,
+      });
+      mirroredCount += 1;
+    }
+  }
+
+  const finishedAt = new Date();
+
+  await db.syncJob.update({
+    where: { id: syncJob.id },
+    data: {
+      status: SyncJobStatus.SUCCEEDED,
+      acceptedCount,
+      mirroredCount,
+      finishedAt,
+      metadataJson: JSON.stringify({ simulator: true, provider: provider.title, acceptedCount, mirroredCount }),
+    },
+  });
+
+  await db.jobRun.update({
+    where: { id: jobRun.id },
+    data: {
+      status: JobRunStatus.COMPLETED,
+      attemptsMade: 1,
+      finishedAt,
+      resultJson: JSON.stringify({ acceptedCount, mirroredCount, syncJobId: syncJob.id }),
+    },
+  });
+
+  await db.jobRunLog.create({
+    data: {
+      jobRunId: jobRun.id,
+      level: "info",
+      message: "Device sync simulator completed successfully.",
+      contextJson: JSON.stringify({ source, acceptedCount, mirroredCount }),
+    },
+  });
+
+  revalidatePath("/device-sync-simulator");
+  revalidatePath("/device-connection");
+  revalidatePath("/vitals-monitor");
+  revalidatePath("/trends");
+}

--- a/app/device-sync-simulator/page.tsx
+++ b/app/device-sync-simulator/page.tsx
@@ -1,0 +1,252 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { Activity, DatabaseZap, HeartPulse, Play, RefreshCcw, Smartphone, Watch } from "lucide-react";
+import { AppShell } from "@/components/app-shell";
+import { EmptyState, PageHeader, StatusPill } from "@/components/common";
+import { Badge, Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Select } from "@/components/ui";
+import { requireUser } from "@/lib/session";
+import {
+  getDeviceSyncSimulatorData,
+  readingDisplayValue,
+  readingLabel,
+  simulatorProviders,
+  vitalDisplayValue,
+} from "@/lib/device-sync-simulator";
+import { runDeviceSyncSimulationAction } from "./actions";
+
+function formatDateTime(value: Date | null | undefined) {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat("en-PH", { dateStyle: "medium", timeStyle: "short" }).format(value);
+}
+
+function statusTone(status: string) {
+  if (["SUCCEEDED", "COMPLETED", "ACTIVE"].includes(status)) return "success" as const;
+  if (["RUNNING", "QUEUED", "PARTIAL"].includes(status)) return "info" as const;
+  if (["ERROR", "FAILED", "REVOKED"].includes(status)) return "danger" as const;
+  if (["DISCONNECTED", "RETRYING"].includes(status)) return "warning" as const;
+  return "neutral" as const;
+}
+
+function sourceLabel(value: string) {
+  return value
+    .toLowerCase()
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function StatCard({ title, value, description, icon }: { title: string; value: number | string; description: string; icon: ReactNode }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardDescription>{title}</CardDescription>
+            <CardTitle className="mt-2 text-3xl">{value}</CardTitle>
+          </div>
+          <div className="rounded-2xl border border-border/60 bg-background/70 p-2">{icon}</div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default async function DeviceSyncSimulatorPage() {
+  const user = await requireUser();
+  const data = await getDeviceSyncSimulatorData(user.id);
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-7xl space-y-6 p-6">
+        <PageHeader
+          title="Device Sync Simulator"
+          description="Run a safe sample sync that creates source-aware device readings, mirrored vitals, sync jobs, and job-run logs for demos without requiring a real wearable integration."
+          action={
+            <div className="flex flex-wrap gap-2">
+              <Link href="/device-connection" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium hover:bg-muted/50">
+                Device roadmap
+              </Link>
+              <Link href="/vitals-monitor" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium hover:bg-muted/50">
+                Vitals monitor
+              </Link>
+            </div>
+          }
+        />
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+          <StatCard title="Connections" value={data.summary.totalConnections} description="Simulator and device connections created for this workspace." icon={<Smartphone className="h-5 w-5 text-primary" />} />
+          <StatCard title="Active" value={data.summary.activeConnections} description="Connections currently marked active and ready for ingestion." icon={<Watch className="h-5 w-5 text-emerald-500" />} />
+          <StatCard title="Readings" value={data.summary.recentReadings} description="Recent source-aware readings available for review." icon={<Activity className="h-5 w-5 text-sky-500" />} />
+          <StatCard title="Accepted" value={data.summary.acceptedCount} description="Readings accepted by recent simulator sync jobs." icon={<DatabaseZap className="h-5 w-5 text-violet-500" />} />
+          <StatCard title="Mirrored" value={data.summary.mirroredCount} description="Accepted readings mirrored into the vitals table." icon={<HeartPulse className="h-5 w-5 text-rose-500" />} />
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-[0.9fr_1.1fr]">
+          <Card>
+            <CardHeader>
+              <CardTitle>Run demo sync</CardTitle>
+              <CardDescription>
+                Pick a provider and create realistic sample readings. The simulator is idempotent per timestamped sample batch and stays inside your account.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <form action={runDeviceSyncSimulationAction} className="space-y-4 rounded-[28px] border border-border/60 bg-background/50 p-4">
+                <div className="space-y-2">
+                  <label htmlFor="source" className="text-sm font-medium">Demo provider</label>
+                  <Select id="source" name="source" defaultValue={simulatorProviders[0].source}>
+                    {simulatorProviders.map((provider) => (
+                      <option key={provider.source} value={provider.source}>{provider.title}</option>
+                    ))}
+                  </Select>
+                </div>
+                <Button type="submit" className="w-full">
+                  <Play className="h-4 w-4" />
+                  Run simulator sync
+                </Button>
+              </form>
+
+              <div className="space-y-3">
+                {simulatorProviders.map((provider) => (
+                  <div key={provider.source} className="rounded-2xl border border-border/60 bg-background/50 p-4">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div>
+                        <p className="font-medium">{provider.title}</p>
+                        <p className="mt-1 text-sm text-muted-foreground">{provider.description}</p>
+                      </div>
+                      <StatusPill tone={provider.tone}>{sourceLabel(provider.source)}</StatusPill>
+                    </div>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {provider.readings.map((reading) => <Badge key={reading}>{reading}</Badge>)}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Connection state</CardTitle>
+              <CardDescription>Latest source connections and their ingestion footprints.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {data.connections.map((connection) => (
+                <div key={connection.id} className="rounded-2xl border border-border/60 bg-background/50 p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="font-medium">{connection.deviceLabel || sourceLabel(connection.source)}</p>
+                      <p className="text-xs text-muted-foreground">{sourceLabel(connection.source)} • {connection.platform}</p>
+                    </div>
+                    <StatusPill tone={statusTone(connection.status)}>{connection.status}</StatusPill>
+                  </div>
+                  <div className="mt-3 grid gap-2 text-xs text-muted-foreground md:grid-cols-2">
+                    <p>Last sync: {formatDateTime(connection.lastSyncedAt)}</p>
+                    <p>Created: {formatDateTime(connection.createdAt)}</p>
+                    <p>{connection._count.readings} readings</p>
+                    <p>{connection._count.syncJobs} sync jobs</p>
+                  </div>
+                  {connection.lastError ? <p className="mt-3 rounded-xl bg-destructive/10 p-3 text-sm text-destructive">{connection.lastError}</p> : null}
+                </div>
+              ))}
+              {data.connections.length === 0 ? <EmptyState title="No simulated connections yet" description="Run a demo sync to create a sample provider connection." /> : null}
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-3">
+          <Card>
+            <CardHeader>
+              <CardTitle>Recent readings</CardTitle>
+              <CardDescription>Raw source-aware device readings accepted by the simulator.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {data.recentReadings.map((reading) => (
+                <div key={reading.id} className="rounded-2xl border border-border/60 bg-background/50 p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="font-medium">{readingLabel(reading.readingType)}</p>
+                    <Badge>{sourceLabel(reading.source)}</Badge>
+                  </div>
+                  <p className="mt-2 text-2xl font-semibold">{readingDisplayValue(reading)}</p>
+                  <p className="mt-1 text-xs text-muted-foreground">Captured {formatDateTime(reading.capturedAt)}</p>
+                </div>
+              ))}
+              {data.recentReadings.length === 0 ? <EmptyState title="No readings yet" description="Accepted readings will appear after a simulator sync." /> : null}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Sync job history</CardTitle>
+              <CardDescription>Persisted sync jobs created by the simulator workflow.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {data.recentSyncJobs.map((job) => (
+                <div key={job.id} className="rounded-2xl border border-border/60 bg-background/50 p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="font-medium">{sourceLabel(job.source)}</p>
+                    <StatusPill tone={statusTone(job.status)}>{job.status}</StatusPill>
+                  </div>
+                  <div className="mt-3 grid gap-2 text-xs text-muted-foreground">
+                    <p>Requested: {job.requestedCount}</p>
+                    <p>Accepted: {job.acceptedCount}</p>
+                    <p>Mirrored: {job.mirroredCount}</p>
+                    <p>Finished: {formatDateTime(job.finishedAt)}</p>
+                  </div>
+                  {job.errorMessage ? <p className="mt-3 text-sm text-destructive">{job.errorMessage}</p> : null}
+                </div>
+              ))}
+              {data.recentSyncJobs.length === 0 ? <EmptyState title="No sync jobs yet" description="Simulator sync jobs will appear here after a run." /> : null}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Mirrored vitals</CardTitle>
+              <CardDescription>Device readings that were copied into the main vitals record system.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {data.mirroredVitals.map((vital) => (
+                <div key={vital.id} className="rounded-2xl border border-border/60 bg-background/50 p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="font-medium">{vitalDisplayValue(vital)}</p>
+                    <Badge>{sourceLabel(vital.readingSource)}</Badge>
+                  </div>
+                  <p className="mt-2 text-xs text-muted-foreground">Recorded {formatDateTime(vital.recordedAt)}</p>
+                  {vital.notes ? <p className="mt-2 text-sm text-muted-foreground">{vital.notes}</p> : null}
+                </div>
+              ))}
+              {data.mirroredVitals.length === 0 ? <EmptyState title="No mirrored vitals yet" description="Non-step simulator readings will appear here after they are mirrored into vitals." /> : null}
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Why this matters for demos</CardTitle>
+            <CardDescription>Patch 25 turns the device/mobile foundation into something reviewers can see working without external vendor credentials.</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-3 md:grid-cols-3">
+            <div className="rounded-2xl border border-border/60 bg-background/50 p-4">
+              <RefreshCcw className="h-5 w-5 text-primary" />
+              <p className="mt-3 font-medium">Shows ingestion flow</p>
+              <p className="mt-1 text-sm text-muted-foreground">A single action creates connection, readings, sync job, job run, and mirrored vitals.</p>
+            </div>
+            <div className="rounded-2xl border border-border/60 bg-background/50 p-4">
+              <DatabaseZap className="h-5 w-5 text-primary" />
+              <p className="mt-3 font-medium">Proves data modeling</p>
+              <p className="mt-1 text-sm text-muted-foreground">The simulator uses the existing device, sync, job, and vital models instead of fake UI-only cards.</p>
+            </div>
+            <div className="rounded-2xl border border-border/60 bg-background/50 p-4">
+              <HeartPulse className="h-5 w-5 text-primary" />
+              <p className="mt-3 font-medium">Feeds monitoring pages</p>
+              <p className="mt-1 text-sm text-muted-foreground">Mirrored vitals become visible in monitoring and trend workflows after sync.</p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </AppShell>
+  );
+}

--- a/docs/PATCH_25_DEVICE_SYNC_SIMULATOR.md
+++ b/docs/PATCH_25_DEVICE_SYNC_SIMULATOR.md
@@ -1,0 +1,58 @@
+# Patch 25 — Device Sync Simulator
+
+## Summary
+
+Adds a protected `/device-sync-simulator` workspace that lets reviewers run a safe simulated device sync without requiring Apple Health, Android Health Connect, Fitbit, or device vendor credentials.
+
+The simulator uses existing VitaVault data models instead of mock-only UI cards:
+
+- `DeviceConnection`
+- `DeviceReading`
+- `SyncJob`
+- `JobRun`
+- `JobRunLog`
+- `VitalRecord`
+
+## What changed
+
+- Added `/device-sync-simulator`
+- Added simulator server action for sample sync runs
+- Added sample providers:
+  - Apple Health
+  - Android Health Connect
+  - Smart BP Monitor
+  - Pulse Oximeter
+  - Smart Scale
+- Added connection state cards
+- Added recent accepted readings
+- Added sync job history
+- Added mirrored vitals panel
+- Added sidebar navigation entry under Monitoring
+- Added shared simulator helper/data layer
+
+## Why it matters
+
+VitaVault already had mobile/device ingestion foundations. This patch makes that foundation visible and demo-friendly by allowing a reviewer to trigger a realistic sync flow from the UI.
+
+## Safety notes
+
+- No Prisma migration is required.
+- All records are scoped to the signed-in user.
+- The simulator creates sample data only inside the user's workspace.
+- The simulator is not a medical-device integration and does not claim diagnostic behavior.
+
+## Manual test routes
+
+- `/device-sync-simulator`
+- `/device-connection`
+- `/vitals-monitor`
+- `/trends`
+- `/jobs`
+
+## Recommended checks
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:run
+```

--- a/lib/app-routes.ts
+++ b/lib/app-routes.ts
@@ -190,6 +190,12 @@ export const monitoringRoutes: AppRouteItem[] = [
     description: "Integration roadmap for phone and health devices",
     icon: Smartphone,
   },
+  {
+    title: "Device Sync Simulator",
+    href: "/device-sync-simulator",
+    description: "Run sample device syncs into readings, jobs, and mirrored vitals",
+    icon: Workflow,
+  },
 ];
 
 export const sharingReportRoutes: AppRouteItem[] = [

--- a/lib/device-sync-simulator.ts
+++ b/lib/device-sync-simulator.ts
@@ -1,0 +1,268 @@
+import {
+  DeviceConnectionStatus,
+  DevicePlatform,
+  DeviceReadingType,
+  JobKind,
+  JobRunStatus,
+  ReadingSource,
+  SyncJobStatus,
+} from "@prisma/client";
+import { db } from "@/lib/db";
+
+export type SimulatorProvider = {
+  source: ReadingSource;
+  platform: DevicePlatform;
+  title: string;
+  description: string;
+  readings: string[];
+  tone: "neutral" | "info" | "success" | "warning" | "danger";
+};
+
+export type SimulatorReadingInput = {
+  readingType: DeviceReadingType;
+  capturedAt: Date;
+  unit?: string;
+  valueInt?: number;
+  valueFloat?: number;
+  systolic?: number;
+  diastolic?: number;
+};
+
+export const simulatorProviders: SimulatorProvider[] = [
+  {
+    source: ReadingSource.APPLE_HEALTH,
+    platform: DevicePlatform.IOS,
+    title: "Apple Health demo sync",
+    description: "Simulates a HealthKit-style mobile sync with activity, heart rate, oxygen, and weight readings.",
+    readings: ["heart rate", "oxygen", "weight", "steps"],
+    tone: "info",
+  },
+  {
+    source: ReadingSource.ANDROID_HEALTH_CONNECT,
+    platform: DevicePlatform.ANDROID,
+    title: "Android Health Connect demo sync",
+    description: "Simulates an Android wellness import with daily activity and recent vital readings.",
+    readings: ["steps", "heart rate", "blood glucose", "weight"],
+    tone: "success",
+  },
+  {
+    source: ReadingSource.SMART_BP_MONITOR,
+    platform: DevicePlatform.OTHER,
+    title: "Smart BP monitor demo sync",
+    description: "Simulates a home blood-pressure monitor pushing recent BP and pulse readings.",
+    readings: ["blood pressure", "heart rate"],
+    tone: "warning",
+  },
+  {
+    source: ReadingSource.PULSE_OXIMETER,
+    platform: DevicePlatform.OTHER,
+    title: "Pulse oximeter demo sync",
+    description: "Simulates a respiratory monitoring device syncing oxygen saturation and pulse readings.",
+    readings: ["oxygen", "heart rate", "temperature"],
+    tone: "danger",
+  },
+  {
+    source: ReadingSource.SMART_SCALE,
+    platform: DevicePlatform.OTHER,
+    title: "Smart scale demo sync",
+    description: "Simulates a connected scale importing weight trend data for monitoring dashboards.",
+    readings: ["weight"],
+    tone: "neutral",
+  },
+];
+
+export function parseSimulatorSource(value: FormDataEntryValue | null): ReadingSource {
+  const raw = String(value || "");
+  const match = simulatorProviders.find((provider) => provider.source === raw);
+  return match?.source || ReadingSource.APPLE_HEALTH;
+}
+
+export function getSimulatorProvider(source: ReadingSource) {
+  return simulatorProviders.find((provider) => provider.source === source) || simulatorProviders[0];
+}
+
+function minutesAgo(minutes: number) {
+  return new Date(Date.now() - minutes * 60 * 1000);
+}
+
+export function buildSimulatorReadings(source: ReadingSource): SimulatorReadingInput[] {
+  if (source === ReadingSource.SMART_BP_MONITOR) {
+    return [
+      { readingType: DeviceReadingType.BLOOD_PRESSURE, capturedAt: minutesAgo(18), systolic: 128, diastolic: 82, unit: "mmHg" },
+      { readingType: DeviceReadingType.BLOOD_PRESSURE, capturedAt: minutesAgo(70), systolic: 136, diastolic: 88, unit: "mmHg" },
+      { readingType: DeviceReadingType.HEART_RATE, capturedAt: minutesAgo(18), valueInt: 76, unit: "bpm" },
+    ];
+  }
+
+  if (source === ReadingSource.PULSE_OXIMETER) {
+    return [
+      { readingType: DeviceReadingType.OXYGEN_SATURATION, capturedAt: minutesAgo(11), valueInt: 97, unit: "%" },
+      { readingType: DeviceReadingType.HEART_RATE, capturedAt: minutesAgo(11), valueInt: 82, unit: "bpm" },
+      { readingType: DeviceReadingType.TEMPERATURE, capturedAt: minutesAgo(35), valueFloat: 36.8, unit: "C" },
+    ];
+  }
+
+  if (source === ReadingSource.SMART_SCALE) {
+    return [
+      { readingType: DeviceReadingType.WEIGHT, capturedAt: minutesAgo(25), valueFloat: 71.4, unit: "kg" },
+      { readingType: DeviceReadingType.WEIGHT, capturedAt: minutesAgo(60 * 24), valueFloat: 71.9, unit: "kg" },
+      { readingType: DeviceReadingType.WEIGHT, capturedAt: minutesAgo(60 * 48), valueFloat: 72.1, unit: "kg" },
+    ];
+  }
+
+  if (source === ReadingSource.ANDROID_HEALTH_CONNECT) {
+    return [
+      { readingType: DeviceReadingType.STEPS, capturedAt: minutesAgo(8), valueInt: 6240, unit: "steps" },
+      { readingType: DeviceReadingType.HEART_RATE, capturedAt: minutesAgo(20), valueInt: 74, unit: "bpm" },
+      { readingType: DeviceReadingType.BLOOD_GLUCOSE, capturedAt: minutesAgo(95), valueFloat: 104, unit: "mg/dL" },
+      { readingType: DeviceReadingType.WEIGHT, capturedAt: minutesAgo(60 * 20), valueFloat: 70.8, unit: "kg" },
+    ];
+  }
+
+  return [
+    { readingType: DeviceReadingType.STEPS, capturedAt: minutesAgo(6), valueInt: 8120, unit: "steps" },
+    { readingType: DeviceReadingType.HEART_RATE, capturedAt: minutesAgo(14), valueInt: 72, unit: "bpm" },
+    { readingType: DeviceReadingType.OXYGEN_SATURATION, capturedAt: minutesAgo(22), valueInt: 98, unit: "%" },
+    { readingType: DeviceReadingType.WEIGHT, capturedAt: minutesAgo(60 * 26), valueFloat: 70.5, unit: "kg" },
+  ];
+}
+
+export function readingDisplayValue(reading: {
+  readingType: DeviceReadingType;
+  unit: string | null;
+  valueInt: number | null;
+  valueFloat: number | null;
+  systolic: number | null;
+  diastolic: number | null;
+}) {
+  if (reading.readingType === DeviceReadingType.BLOOD_PRESSURE && reading.systolic && reading.diastolic) {
+    return String(reading.systolic) + "/" + String(reading.diastolic) + " " + (reading.unit || "mmHg");
+  }
+
+  const value = reading.valueInt ?? reading.valueFloat;
+  if (value === null || value === undefined) return "—";
+  return String(value) + (reading.unit ? " " + reading.unit : "");
+}
+
+export function readingLabel(type: DeviceReadingType) {
+  return type
+    .toLowerCase()
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export async function getDeviceSyncSimulatorData(userId: string) {
+  const [connections, recentReadings, recentSyncJobs, mirroredVitals] = await Promise.all([
+    db.deviceConnection.findMany({
+      where: { userId },
+      orderBy: [{ updatedAt: "desc" }, { createdAt: "desc" }],
+      take: 8,
+      select: {
+        id: true,
+        source: true,
+        platform: true,
+        deviceLabel: true,
+        status: true,
+        lastSyncedAt: true,
+        lastError: true,
+        createdAt: true,
+        _count: { select: { readings: true, syncJobs: true, jobRuns: true } },
+      },
+    }),
+    db.deviceReading.findMany({
+      where: { userId },
+      orderBy: { capturedAt: "desc" },
+      take: 12,
+      select: {
+        id: true,
+        source: true,
+        platform: true,
+        readingType: true,
+        capturedAt: true,
+        unit: true,
+        valueInt: true,
+        valueFloat: true,
+        systolic: true,
+        diastolic: true,
+      },
+    }),
+    db.syncJob.findMany({
+      where: { userId },
+      orderBy: { createdAt: "desc" },
+      take: 8,
+      select: {
+        id: true,
+        source: true,
+        platform: true,
+        status: true,
+        requestedCount: true,
+        acceptedCount: true,
+        mirroredCount: true,
+        errorMessage: true,
+        createdAt: true,
+        finishedAt: true,
+      },
+    }),
+    db.vitalRecord.findMany({
+      where: { userId, readingSource: { not: ReadingSource.MANUAL } },
+      orderBy: { recordedAt: "desc" },
+      take: 8,
+      select: {
+        id: true,
+        recordedAt: true,
+        readingSource: true,
+        systolic: true,
+        diastolic: true,
+        heartRate: true,
+        bloodSugar: true,
+        oxygenSaturation: true,
+        temperatureC: true,
+        weightKg: true,
+        notes: true,
+      },
+    }),
+  ]);
+
+  const activeConnections = connections.filter((connection) => connection.status === DeviceConnectionStatus.ACTIVE).length;
+  const erroredConnections = connections.filter((connection) => connection.status === DeviceConnectionStatus.ERROR).length;
+  const mirroredCount = recentSyncJobs.reduce((total, job) => total + job.mirroredCount, 0);
+  const acceptedCount = recentSyncJobs.reduce((total, job) => total + job.acceptedCount, 0);
+
+  return {
+    providers: simulatorProviders,
+    connections,
+    recentReadings,
+    recentSyncJobs,
+    mirroredVitals,
+    summary: {
+      totalConnections: connections.length,
+      activeConnections,
+      erroredConnections,
+      recentReadings: recentReadings.length,
+      acceptedCount,
+      mirroredCount,
+    },
+  };
+}
+
+export function vitalDisplayValue(vital: {
+  systolic: number | null;
+  diastolic: number | null;
+  heartRate: number | null;
+  bloodSugar: number | null;
+  oxygenSaturation: number | null;
+  temperatureC: number | null;
+  weightKg: number | null;
+}) {
+  const parts = [
+    vital.systolic && vital.diastolic ? String(vital.systolic) + "/" + String(vital.diastolic) + " BP" : null,
+    vital.heartRate ? String(vital.heartRate) + " bpm" : null,
+    vital.bloodSugar ? String(vital.bloodSugar) + " glucose" : null,
+    vital.oxygenSaturation ? String(vital.oxygenSaturation) + "% SpO2" : null,
+    vital.temperatureC ? String(vital.temperatureC) + " C" : null,
+    vital.weightKg ? String(vital.weightKg) + " kg" : null,
+  ].filter(Boolean);
+
+  return parts.join(" • ") || "Mirrored vital reading";
+}


### PR DESCRIPTION
This PR adds Patch 25: Device Sync Simulator.

Changes:
- Adds a protected /device-sync-simulator page
- Adds a safe simulator for Apple Health, Android Health Connect, Smart BP Monitor, Pulse Oximeter, and Smart Scale demo syncs
- Creates scoped DeviceConnection, DeviceReading, SyncJob, JobRun, JobRunLog, and mirrored VitalRecord records
- Adds recent readings, sync job history, mirrored vitals, and connection state panels
- Adds Device Sync Simulator to the Monitoring sidebar group
- Makes the mobile/device foundation demo-friendly without requiring real external vendor credentials
- Reuses existing schema models, so no Prisma migration is required