### PR TITLE
Add document storage abstraction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,9 @@ APP_URL="http://localhost:3000"
 EMAIL_VERIFICATION_REQUIRED="false"
 RESEND_API_KEY=""
 RESEND_FROM_EMAIL="VitaVault <no-reply@example.com>"
+
+# Document storage
+# private = files stored under PRIVATE_UPLOAD_DIR and served only through authenticated download route.
+# public = files stored under public/uploads for legacy/local public-mode demos.
+DOCUMENT_STORAGE_MODE="private"
+PRIVATE_UPLOAD_DIR="private-uploads"

--- a/app/api/documents/[id]/download/route.ts
+++ b/app/api/documents/[id]/download/route.ts
@@ -1,9 +1,8 @@
-import { readFile } from "fs/promises";
 import path from "path";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-import { resolveStoredDocumentPath } from "@/lib/document-storage";
+import { readDocumentObject, resolveDocumentObject } from "@/lib/storage";
 
 export const runtime = "nodejs";
 
@@ -43,21 +42,22 @@ export async function GET(
     return NextResponse.json({ error: "Document not found." }, { status: 404 });
   }
 
-  const resolved = resolveStoredDocumentPath(document.filePath);
-
-  if (!resolved) {
+  if (!resolveDocumentObject(document.filePath)) {
     return NextResponse.json({ error: "Document storage path is invalid." }, { status: 400 });
   }
 
   try {
-    const bytes = await readFile(resolved.absolutePath);
-    const response = new NextResponse(bytes);
+    const { bytes } = await readDocumentObject(document.filePath);
+    const arrayBuffer = new ArrayBuffer(bytes.byteLength);
+    new Uint8Array(arrayBuffer).set(bytes);
+    const response = new NextResponse(arrayBuffer);
     response.headers.set("Content-Type", document.mimeType || "application/octet-stream");
     response.headers.set(
       "Content-Disposition",
       contentDisposition(document.fileName || `${document.title}.bin`, document.mimeType || "application/octet-stream")
     );
     response.headers.set("Cache-Control", "private, no-store, max-age=0");
+    response.headers.set("X-Document-Storage", "local");
     return response;
   } catch {
     return NextResponse.json({ error: "Document file is unavailable." }, { status: 404 });

--- a/docs/PATCH_26B_STORAGE_TYPECHECK_FIX.md
+++ b/docs/PATCH_26B_STORAGE_TYPECHECK_FIX.md
@@ -1,0 +1,20 @@
+# Patch 26B — Storage Typecheck Fix
+
+This hotfix cleans up Patch 26 validation issues.
+
+## Changes
+
+- Updates the protected document download route to pass an `ArrayBuffer` body into `NextResponse` instead of a Node `Buffer`, fixing TypeScript compatibility with `BodyInit`.
+- Removes unused Prisma enum imports from `lib/device-sync-simulator.ts`.
+- Keeps the document storage abstraction behavior intact.
+- Requires no Prisma migration.
+
+## Validation
+
+Run:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:run
+```

--- a/docs/PATCH_26C_STORAGE_RESPONSE_BODY_FIX.md
+++ b/docs/PATCH_26C_STORAGE_RESPONSE_BODY_FIX.md
@@ -1,0 +1,20 @@
+# Patch 26C — Storage Response Body Fix
+
+Fixes the remaining document download typecheck issue from Patch 26.
+
+## Changes
+
+- Converts Node `Buffer` data into a real `ArrayBuffer` before passing it to `NextResponse`.
+- Avoids the `ArrayBuffer | SharedArrayBuffer` type ambiguity caused by `Buffer.buffer`.
+- Keeps the document storage abstraction behavior unchanged.
+- Requires no Prisma migration.
+
+## Validation
+
+Run:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:run
+```

--- a/docs/PATCH_26_DOCUMENT_STORAGE_ABSTRACTION.md
+++ b/docs/PATCH_26_DOCUMENT_STORAGE_ABSTRACTION.md
@@ -1,0 +1,63 @@
+# Patch 26 — Production Document Storage Abstraction
+
+## Summary
+
+Patch 26 moves VitaVault's document upload/download/delete flow behind a storage provider abstraction.
+
+The current implementation keeps the existing local filesystem behavior as the default so local development and current tests remain compatible, while creating a clean path for future production providers such as S3, Cloudflare R2, Supabase Storage, Azure Blob Storage, or Google Cloud Storage.
+
+## Files changed
+
+- `lib/storage/storage-types.ts`
+- `lib/storage/local-storage.ts`
+- `lib/storage/index.ts`
+- `lib/upload.ts`
+- `app/api/documents/[id]/download/route.ts`
+- `lib/ops-health.ts`
+- `docs/PATCH_26_DOCUMENT_STORAGE_ABSTRACTION.md`
+
+## What changed
+
+- Added a document storage provider interface.
+- Added a local filesystem provider that preserves the existing private/public storage behavior.
+- Centralized document save, read, resolve, and delete helpers.
+- Updated upload helpers to use the provider abstraction.
+- Updated secure document download route to read through the provider abstraction.
+- Added document storage readiness visibility to the Operations Command Center.
+- Kept existing medical document schema unchanged.
+
+## Why this matters
+
+Before this patch, document storage logic was split between upload helpers, path helpers, and the download route. That works locally, but it makes production storage harder to add safely.
+
+After this patch, future storage providers can be added behind the same interface without rewriting the Documents page, upload action, or download route.
+
+## Current provider
+
+The active provider is:
+
+```txt
+local
+```
+
+Local storage is still best for local development and demos. Production deployments should eventually move to a durable object store.
+
+## Future provider path
+
+A future S3/R2/Supabase provider should implement:
+
+```ts
+DocumentStorageProvider
+```
+
+Required provider methods:
+
+- `save(input)`
+- `delete(filePath)`
+- `resolve(filePath)`
+- `read(filePath)`
+- `health()`
+
+## Migration impact
+
+No Prisma migration required.

--- a/lib/device-sync-simulator.ts
+++ b/lib/device-sync-simulator.ts
@@ -2,10 +2,7 @@ import {
   DeviceConnectionStatus,
   DevicePlatform,
   DeviceReadingType,
-  JobKind,
-  JobRunStatus,
   ReadingSource,
-  SyncJobStatus,
 } from "@prisma/client";
 import { db } from "@/lib/db";
 

--- a/lib/ops-health.ts
+++ b/lib/ops-health.ts
@@ -11,6 +11,7 @@ import {
 } from "@prisma/client";
 import { db } from "@/lib/db";
 import { APP_ROLES } from "@/lib/domain/enums";
+import { getDocumentStorageHealth } from "@/lib/storage";
 
 type SupportedRole = string | null | undefined;
 
@@ -245,6 +246,8 @@ export async function getOpsHealthData(userId: string, role: SupportedRole): Pro
     }),
   ]);
 
+  const documentStorage = getDocumentStorageHealth();
+
   const envReadiness: OpsEnvItem[] = [
     {
       label: "Database",
@@ -298,6 +301,13 @@ export async function getOpsHealthData(userId: string, role: SupportedRole): Pro
       available: Boolean(process.env.OPENAI_API_KEY),
       tone: envTone(Boolean(process.env.OPENAI_API_KEY), true),
       detail: process.env.OPENAI_API_KEY ? "AI insight generation is enabled." : "Optional. AI features stay disabled without it.",
+    },
+    {
+      label: "Document storage",
+      key: "DOCUMENT_STORAGE_MODE",
+      available: documentStorage.ready,
+      tone: documentStorage.productionReady ? "success" : "warning",
+      detail: documentStorage.detail,
     },
   ];
 

--- a/lib/storage/index.ts
+++ b/lib/storage/index.ts
@@ -1,0 +1,47 @@
+import { localDocumentStorageProvider } from "@/lib/storage/local-storage";
+import type { DocumentStorageHealth, DocumentStorageProvider } from "@/lib/storage/storage-types";
+
+export const DOCUMENT_STORAGE_PROVIDER = "local" as const;
+
+export function getDocumentStorageProvider(): DocumentStorageProvider {
+  return localDocumentStorageProvider;
+}
+
+export function getDocumentStorageHealth(): DocumentStorageHealth {
+  return getDocumentStorageProvider().health();
+}
+
+export async function saveDocumentObject(file: File) {
+  const provider = getDocumentStorageProvider();
+  const bytes = Buffer.from(await file.arrayBuffer());
+
+  return provider.save({
+    originalName: file.name,
+    mimeType: file.type,
+    sizeBytes: file.size,
+    bytes,
+  });
+}
+
+export async function deleteDocumentObject(filePath: string | null | undefined) {
+  await getDocumentStorageProvider().delete(filePath);
+}
+
+export async function readDocumentObject(filePath: string) {
+  return getDocumentStorageProvider().read(filePath);
+}
+
+export function resolveDocumentObject(filePath: string | null | undefined) {
+  return getDocumentStorageProvider().resolve(filePath);
+}
+
+export type {
+  DocumentStorageHealth,
+  DocumentStorageProvider,
+  DocumentStorageProviderId,
+  DocumentStorageVisibility,
+  ReadDocumentObjectResult,
+  ResolvedDocumentObject,
+  SavedDocumentObject,
+  SaveDocumentObjectInput,
+} from "@/lib/storage/storage-types";

--- a/lib/storage/local-storage.ts
+++ b/lib/storage/local-storage.ts
@@ -1,0 +1,99 @@
+import * as fs from "fs/promises";
+import path from "path";
+import {
+  buildStoredDocumentPath,
+  DOCUMENT_STORAGE_MODE,
+  getPrivateUploadsDir,
+  getPublicUploadsDir,
+  resolveStoredDocumentPath,
+} from "@/lib/document-storage";
+import type {
+  DocumentStorageHealth,
+  DocumentStorageProvider,
+  ResolvedDocumentObject,
+  SaveDocumentObjectInput,
+  SavedDocumentObject,
+} from "@/lib/storage/storage-types";
+
+function sanitizeOriginalName(value: string) {
+  return path.basename(value || "document.bin").replace(/[^a-zA-Z0-9._-]/g, "-") || "document.bin";
+}
+
+function uniqueStoredName(originalName: string) {
+  return `${Date.now()}-${sanitizeOriginalName(originalName)}`;
+}
+
+function uploadDir(storage: "private" | "public") {
+  return storage === "public" ? getPublicUploadsDir() : getPrivateUploadsDir();
+}
+
+function toResolved(filePath: string | null | undefined): ResolvedDocumentObject | null {
+  if (!filePath) return null;
+  const resolved = resolveStoredDocumentPath(filePath);
+  if (!resolved) return null;
+
+  return {
+    provider: "local",
+    storage: resolved.storage,
+    key: resolved.relativePath,
+    filePath: resolved.relativePath,
+    absolutePath: resolved.absolutePath,
+  };
+}
+
+export const localDocumentStorageProvider: DocumentStorageProvider = {
+  id: "local",
+  label: "Local filesystem storage",
+
+  async save(input: SaveDocumentObjectInput): Promise<SavedDocumentObject> {
+    const stored = buildStoredDocumentPath(uniqueStoredName(input.originalName));
+    await fs.mkdir(uploadDir(stored.storage), { recursive: true });
+    await fs.writeFile(stored.absolutePath, input.bytes);
+
+    return {
+      provider: "local",
+      storage: stored.storage,
+      key: stored.filePath,
+      filePath: stored.filePath,
+      fileName: stored.fileName,
+      mimeType: input.mimeType,
+      sizeBytes: input.sizeBytes,
+    };
+  },
+
+  async delete(filePath: string | null | undefined) {
+    const resolved = toResolved(filePath);
+    if (!resolved?.absolutePath) return;
+    await fs.rm(resolved.absolutePath, { force: true });
+  },
+
+  resolve(filePath: string | null | undefined) {
+    return toResolved(filePath);
+  },
+
+  async read(filePath: string) {
+    const resolved = toResolved(filePath);
+    if (!resolved?.absolutePath) {
+      throw new Error("Document storage path is invalid.");
+    }
+
+    return {
+      bytes: await fs.readFile(resolved.absolutePath),
+      resolved,
+    };
+  },
+
+  health(): DocumentStorageHealth {
+    const mode = DOCUMENT_STORAGE_MODE;
+    const dir = mode === "public" ? getPublicUploadsDir() : getPrivateUploadsDir();
+
+    return {
+      provider: "local",
+      label: "Local filesystem storage",
+      mode,
+      ready: true,
+      productionReady: false,
+      detail: `Using ${mode} local storage at ${dir}. This is fine for local demos; production should move to S3, Cloudflare R2, Supabase Storage, or another durable object store.`,
+    };
+  },
+};

--- a/lib/storage/storage-types.ts
+++ b/lib/storage/storage-types.ts
@@ -1,0 +1,52 @@
+export type DocumentStorageProviderId = "local" | "s3" | "r2" | "supabase";
+
+export type DocumentStorageVisibility = "private" | "public";
+
+export type DocumentStorageHealth = {
+  provider: DocumentStorageProviderId;
+  label: string;
+  mode: DocumentStorageVisibility;
+  ready: boolean;
+  detail: string;
+  productionReady: boolean;
+};
+
+export type SaveDocumentObjectInput = {
+  originalName: string;
+  mimeType: string;
+  sizeBytes: number;
+  bytes: Buffer;
+};
+
+export type SavedDocumentObject = {
+  provider: DocumentStorageProviderId;
+  storage: DocumentStorageVisibility;
+  key: string;
+  filePath: string;
+  fileName: string;
+  mimeType: string;
+  sizeBytes: number;
+};
+
+export type ResolvedDocumentObject = {
+  provider: DocumentStorageProviderId;
+  storage: DocumentStorageVisibility;
+  key: string;
+  filePath: string;
+  absolutePath?: string;
+};
+
+export type ReadDocumentObjectResult = {
+  bytes: Buffer;
+  resolved: ResolvedDocumentObject;
+};
+
+export type DocumentStorageProvider = {
+  id: DocumentStorageProviderId;
+  label: string;
+  save(input: SaveDocumentObjectInput): Promise<SavedDocumentObject>;
+  delete(filePath: string | null | undefined): Promise<void>;
+  resolve(filePath: string | null | undefined): ResolvedDocumentObject | null;
+  read(filePath: string): Promise<ReadDocumentObjectResult>;
+  health(): DocumentStorageHealth;
+};

--- a/lib/upload.ts
+++ b/lib/upload.ts
@@ -1,32 +1,22 @@
-import { mkdir, rm, writeFile } from "fs/promises";
-import { buildStoredDocumentPath, getPublicUploadsDir, getPrivateUploadsDir, resolveStoredDocumentPath } from "@/lib/document-storage";
+import { deleteDocumentObject, saveDocumentObject } from "@/lib/storage";
 
 const allowed = ["application/pdf", "image/png", "image/jpeg", "image/webp"];
+const MAX_UPLOAD_BYTES = 5 * 1024 * 1024;
 
 export async function saveUpload(file: File) {
   if (!allowed.includes(file.type)) throw new Error("Unsupported file type.");
-  if (file.size > 5 * 1024 * 1024) throw new Error("File must be 5MB or smaller.");
+  if (file.size > MAX_UPLOAD_BYTES) throw new Error("File must be 5MB or smaller.");
 
-  const bytes = await file.arrayBuffer();
-  const safeName = `${Date.now()}-${file.name.replace(/[^a-zA-Z0-9._-]/g, "-")}`;
-  const stored = buildStoredDocumentPath(safeName);
-  const dir = stored.storage === "public" ? getPublicUploadsDir() : getPrivateUploadsDir();
-  await mkdir(dir, { recursive: true });
-  await writeFile(stored.absolutePath, Buffer.from(bytes));
+  const saved = await saveDocumentObject(file);
 
   return {
-    filePath: stored.filePath,
-    fileName: stored.fileName,
-    mimeType: file.type,
-    sizeBytes: file.size,
+    filePath: saved.filePath,
+    fileName: saved.fileName,
+    mimeType: saved.mimeType,
+    sizeBytes: saved.sizeBytes,
   };
 }
 
 export async function deleteUpload(filePath: string | null | undefined) {
-  if (!filePath) return;
-
-  const resolved = resolveStoredDocumentPath(filePath);
-  if (!resolved) return;
-
-  await rm(resolved.absolutePath, { force: true });
+  await deleteDocumentObject(filePath);
 }


### PR DESCRIPTION
This PR adds Patch 26: Document Storage Abstraction.

Changes:
- Adds a storage provider architecture under lib/storage
- Adds a local filesystem document storage provider as the current default
- Centralizes document save, read, resolve, delete, and health-check behavior
- Updates upload helpers to use the storage provider abstraction
- Updates the protected document download route to read through the storage provider abstraction
- Adds document storage readiness visibility to the Operations Command Center
- Updates .env.example with document storage configuration
- Creates a clean future path for S3, Cloudflare R2, Supabase Storage, Azure Blob Storage, or similar production object storage
- Requires no Prisma migration