### PR TITLE
Add workflow helper test coverage

### DIFF
--- a/docs/PATCH_27_TESTS_EXPANSION.md
+++ b/docs/PATCH_27_TESTS_EXPANSION.md
@@ -1,0 +1,34 @@
+# Patch 27 — Tests Expansion
+
+## Summary
+
+Patch 27 expands VitaVault's Vitest coverage around newer product helpers added during the monitoring, review, and device-sync upgrades.
+
+## Added
+
+- `tests/device-sync-simulator.test.ts`
+  - validates simulator source parsing
+  - validates provider-specific reading generation
+  - validates device reading labels and display values
+- `tests/health-workflow-helpers.test.ts`
+  - validates lab review tone helpers
+  - validates vitals monitor tone helpers
+  - validates symptom review tone helpers
+
+## Why this matters
+
+VitaVault now has many workflow hubs beyond basic CRUD. These tests add lightweight regression coverage around shared helper functions that feed several newer product pages.
+
+## Migration
+
+No Prisma migration required.
+
+## Validation
+
+Run:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:run
+```

--- a/tests/device-sync-simulator.test.ts
+++ b/tests/device-sync-simulator.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import { DeviceReadingType, ReadingSource } from "@prisma/client";
+
+vi.mock("@/lib/db", () => ({
+  db: {},
+}));
+
+describe("device sync simulator helpers", () => {
+  it("falls back to Apple Health for invalid simulator sources", async () => {
+    const { parseSimulatorSource, getSimulatorProvider } = await import("@/lib/device-sync-simulator");
+
+    expect(parseSimulatorSource(null)).toBe(ReadingSource.APPLE_HEALTH);
+    expect(parseSimulatorSource("not-a-provider")).toBe(ReadingSource.APPLE_HEALTH);
+    expect(parseSimulatorSource(ReadingSource.SMART_SCALE)).toBe(ReadingSource.SMART_SCALE);
+
+    expect(getSimulatorProvider(ReadingSource.SMART_BP_MONITOR).title).toContain("BP");
+  });
+
+  it("builds provider-specific simulator readings", async () => {
+    const { buildSimulatorReadings } = await import("@/lib/device-sync-simulator");
+
+    const bpReadings = buildSimulatorReadings(ReadingSource.SMART_BP_MONITOR);
+    const scaleReadings = buildSimulatorReadings(ReadingSource.SMART_SCALE);
+
+    expect(bpReadings.some((reading) => reading.readingType === DeviceReadingType.BLOOD_PRESSURE)).toBe(true);
+    expect(bpReadings.some((reading) => reading.readingType === DeviceReadingType.HEART_RATE)).toBe(true);
+    expect(scaleReadings.every((reading) => reading.readingType === DeviceReadingType.WEIGHT)).toBe(true);
+  });
+
+  it("formats reading labels and display values", async () => {
+    const { readingDisplayValue, readingLabel } = await import("@/lib/device-sync-simulator");
+
+    expect(readingLabel(DeviceReadingType.OXYGEN_SATURATION)).toBe("Oxygen Saturation");
+    expect(
+      readingDisplayValue({
+        readingType: DeviceReadingType.BLOOD_PRESSURE,
+        unit: "mmHg",
+        valueInt: null,
+        valueFloat: null,
+        systolic: 128,
+        diastolic: 82,
+      })
+    ).toBe("128/82 mmHg");
+    expect(
+      readingDisplayValue({
+        readingType: DeviceReadingType.STEPS,
+        unit: "steps",
+        valueInt: 8120,
+        valueFloat: null,
+        systolic: null,
+        diastolic: null,
+      })
+    ).toBe("8120 steps");
+    expect(
+      readingDisplayValue({
+        readingType: DeviceReadingType.WEIGHT,
+        unit: "kg",
+        valueInt: null,
+        valueFloat: null,
+        systolic: null,
+        diastolic: null,
+      })
+    ).toBe("—");
+  });
+});

--- a/tests/health-workflow-helpers.test.ts
+++ b/tests/health-workflow-helpers.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { LabFlag, SymptomSeverity } from "@prisma/client";
+
+vi.mock("@/lib/db", () => ({
+  db: {},
+}));
+
+describe("health workflow helper tones", () => {
+  it("maps lab flags to review tones", async () => {
+    const { getLabFlagTone, getLabPriorityTone } = await import("@/lib/lab-review");
+
+    expect(getLabFlagTone(LabFlag.NORMAL)).toBe("success");
+    expect(getLabFlagTone(LabFlag.BORDERLINE)).toBe("warning");
+    expect(getLabFlagTone(LabFlag.HIGH)).toBe("danger");
+    expect(getLabFlagTone(LabFlag.LOW)).toBe("danger");
+
+    expect(getLabPriorityTone("critical")).toBe("danger");
+    expect(getLabPriorityTone("high")).toBe("warning");
+    expect(getLabPriorityTone("medium")).toBe("info");
+    expect(getLabPriorityTone("low")).toBe("neutral");
+  });
+
+  it("maps vital statuses and priorities to monitor tones", async () => {
+    const { getVitalStatusTone, getVitalPriorityTone } = await import("@/lib/vitals-monitor");
+
+    expect(getVitalStatusTone("danger")).toBe("danger");
+    expect(getVitalStatusTone("watch")).toBe("warning");
+    expect(getVitalStatusTone("normal")).toBe("success");
+    expect(getVitalStatusTone("missing")).toBe("neutral");
+
+    expect(getVitalPriorityTone("critical")).toBe("danger");
+    expect(getVitalPriorityTone("high")).toBe("warning");
+    expect(getVitalPriorityTone("medium")).toBe("info");
+    expect(getVitalPriorityTone("low")).toBe("neutral");
+  });
+
+  it("maps symptom severity and priority to review tones", async () => {
+    const { getSymptomSeverityTone, getSymptomPriorityTone } = await import("@/lib/symptom-review");
+
+    expect(getSymptomSeverityTone(SymptomSeverity.SEVERE)).toBe("danger");
+    expect(getSymptomSeverityTone(SymptomSeverity.MODERATE)).toBe("warning");
+    expect(getSymptomSeverityTone(SymptomSeverity.MILD)).toBe("info");
+
+    expect(getSymptomPriorityTone("critical")).toBe("danger");
+    expect(getSymptomPriorityTone("high")).toBe("warning");
+    expect(getSymptomPriorityTone("medium")).toBe("info");
+    expect(getSymptomPriorityTone("low")).toBe("neutral");
+  });
+});


### PR DESCRIPTION
This PR adds Patch 27: Tests Expansion.

Changes:
- Adds tests for Device Sync Simulator helper behavior
- Validates simulator source parsing and fallback behavior
- Validates generated provider-specific simulator readings
- Validates reading labels and display values
- Adds helper coverage for Lab Review, Vitals Monitor, and Symptom Review tone mapping
- Expands regression coverage for newer workflow hubs without changing app behavior
- Requires no Prisma migration