### PR TITLE
Add AI source citations

### DIFF
--- a/app/ai-insights/page.tsx
+++ b/app/ai-insights/page.tsx
@@ -1,9 +1,9 @@
 import Link from "next/link";
-import { AlertTriangle, BrainCircuit, ClipboardList, Database, FileText, HelpCircle, History, ShieldCheck, Sparkles } from "lucide-react";
+import { AlertTriangle, BrainCircuit, ClipboardList, Database, FileText, HelpCircle, History, ListChecks, Quote, SearchCheck, ShieldCheck, Sparkles } from "lucide-react";
 import { AppShell } from "@/components/app-shell";
 import { EmptyState, PageHeader, StatusPill } from "@/components/common";
 import { Badge, Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
-import { getAiInsightsWorkspaceData, type AiEvidenceCard, type AiRiskSignal } from "@/lib/ai-insights-workspace";
+import { getAiInsightsWorkspaceData, type AiConfidenceMetric, type AiEvidenceCard, type AiRiskSignal, type AiSourceCitationCard } from "@/lib/ai-insights-workspace";
 import { requireUser } from "@/lib/session";
 import { generateOwnAiInsightAction } from "./actions";
 
@@ -60,6 +60,35 @@ function EvidenceCard({ item }: { item: AiEvidenceCard }) {
   );
 }
 
+function CitationCard({ item }: { item: AiSourceCitationCard }) {
+  return (
+    <Link href={item.href} className="block rounded-3xl border border-border/60 bg-background/60 p-4 transition hover:border-primary/40 hover:bg-muted/40">
+      <div className="flex flex-wrap items-center gap-2">
+        <StatusPill tone={item.tone}>{item.label}</StatusPill>
+        <Badge>{item.recordType}</Badge>
+      </div>
+      <p className="mt-3 font-semibold">{item.title}</p>
+      <p className="mt-2 text-sm leading-6 text-muted-foreground">{item.detail}</p>
+      <p className="mt-3 text-xs text-muted-foreground">Captured: {formatDateTime(item.capturedAt)}</p>
+    </Link>
+  );
+}
+
+function ConfidenceCard({ item }: { item: AiConfidenceMetric }) {
+  return (
+    <div className="rounded-3xl border border-border/60 bg-background/60 p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-sm text-muted-foreground">{item.label}</p>
+          <p className="mt-2 text-2xl font-semibold">{item.value}</p>
+        </div>
+        <StatusPill tone={item.tone}>{item.tone}</StatusPill>
+      </div>
+      <p className="mt-3 text-sm text-muted-foreground">{item.detail}</p>
+    </div>
+  );
+}
+
 function StatusMessage({ error, success }: { error?: string; success?: string }) {
   if (success === "1") {
     return <div className="rounded-3xl border border-emerald-200/70 bg-emerald-50/70 p-4 text-sm text-emerald-800 dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-200">AI insight generated successfully.</div>;
@@ -92,7 +121,7 @@ export default async function AiInsightsPage({ searchParams }: { searchParams?: 
       <div className="mx-auto max-w-7xl space-y-6 p-6">
         <PageHeader
           title="AI Insights"
-          description="Turn structured health records into source-aware summaries, care questions, risk signals, and visit-prep follow-ups. Informational only, not diagnostic."
+          description="Turn structured health records into source-aware summaries, visible evidence cards, confidence signals, care questions, and follow-up notes. Informational only, not diagnostic."
           action={
             <div className="flex flex-wrap gap-3">
               <form action={generateOwnAiInsightAction}>
@@ -117,15 +146,15 @@ export default async function AiInsightsPage({ searchParams }: { searchParams?: 
             </CardHeader>
             <CardContent className="space-y-3">
               <ProgressBar value={data.readinessScore} />
-              <p className="text-sm text-muted-foreground">Based on profile, records, workflows, and previous insight coverage.</p>
+              <p className="text-sm text-muted-foreground">Based on profile, records, workflows, previous insights, and visible evidence coverage.</p>
             </CardContent>
           </Card>
           <Card>
             <CardHeader className="pb-3">
-              <CardDescription>Records available</CardDescription>
-              <CardTitle className="mt-2 text-3xl">{data.sourceSummary.totalRecords}</CardTitle>
+              <CardDescription>Evidence cards</CardDescription>
+              <CardTitle className="mt-2 text-3xl">{data.sourceCitationCards.length}</CardTitle>
             </CardHeader>
-            <CardContent><p className="text-sm text-muted-foreground">Structured records available for source-aware summarization.</p></CardContent>
+            <CardContent><p className="text-sm text-muted-foreground">Recent source records that can be shown beside AI outputs.</p></CardContent>
           </Card>
           <Card>
             <CardHeader className="pb-3">
@@ -151,7 +180,7 @@ export default async function AiInsightsPage({ searchParams }: { searchParams?: 
               <div className="flex items-start justify-between gap-4">
                 <div>
                   <CardTitle className="flex items-center gap-2"><BrainCircuit className="h-5 w-5" /> Latest source-linked insight</CardTitle>
-                  <CardDescription>Generated for {data.patientLabel}. Includes summary, flags, questions, and follow-up actions.</CardDescription>
+                  <CardDescription>Generated for {data.patientLabel}. Includes summary, flags, questions, follow-up actions, and traceable evidence.</CardDescription>
                 </div>
                 {latest ? <StatusPill tone={riskTone(latest.adherenceRisk)}>{latest.adherenceRisk.toUpperCase()} risk</StatusPill> : null}
               </div>
@@ -163,6 +192,7 @@ export default async function AiInsightsPage({ searchParams }: { searchParams?: 
                     <div className="flex flex-wrap items-center gap-2">
                       <Badge>{formatDateTime(latest.createdAt)}</Badge>
                       <Badge>{latest.trendFlags.length} trend flags</Badge>
+                      <Badge>{data.sourceCitationCards.length} evidence cards</Badge>
                     </div>
                     <p className="mt-4 text-lg font-semibold">{latest.title}</p>
                     <p className="mt-2 text-sm leading-6 text-muted-foreground">{latest.summary}</p>
@@ -200,33 +230,44 @@ export default async function AiInsightsPage({ searchParams }: { searchParams?: 
           <div className="space-y-6">
             <Card>
               <CardHeader>
-                <CardTitle className="flex items-center gap-2"><ClipboardList className="h-5 w-5" /> Recommended next actions</CardTitle>
-                <CardDescription>Follow-ups from the latest insight plus due workflow items.</CardDescription>
+                <CardTitle className="flex items-center gap-2"><SearchCheck className="h-5 w-5" /> Confidence signals</CardTitle>
+                <CardDescription>Quick quality checks before relying on a summary.</CardDescription>
               </CardHeader>
               <CardContent className="space-y-3">
-                {data.followUpItems.length ? data.followUpItems.map((item) => (
-                  <Link key={item.id} href={item.href} className="block rounded-2xl border border-border/60 bg-background/60 p-4 transition hover:border-primary/40 hover:bg-muted/40">
-                    <div className="flex flex-wrap items-center gap-2"><Badge>{item.source}</Badge><span className="font-medium">{item.title}</span></div>
-                    <p className="mt-2 text-sm text-muted-foreground">{item.detail}</p>
-                  </Link>
-                )) : <EmptyState title="No follow-up queue" description="AI follow-ups and due reminders will appear here." />}
+                {data.confidenceMetrics.map((item) => <ConfidenceCard key={item.label} item={item} />)}
               </CardContent>
             </Card>
 
             <Card>
               <CardHeader>
-                <CardTitle className="flex items-center gap-2"><ShieldCheck className="h-5 w-5" /> Prompt transparency</CardTitle>
-                <CardDescription>What the assistant can and cannot use.</CardDescription>
+                <CardTitle className="flex items-center gap-2"><ListChecks className="h-5 w-5" /> Data gaps</CardTitle>
+                <CardDescription>Missing context that may reduce insight quality.</CardDescription>
               </CardHeader>
-              <CardContent className="space-y-3 text-sm text-muted-foreground">
-                <div className="flex flex-wrap gap-2">
-                  {data.sourceSummary.promptModules.length ? data.sourceSummary.promptModules.map((module) => <Badge key={module}>{module}</Badge>) : <Badge>No record modules yet</Badge>}
-                </div>
-                {data.transparencyNotes.map((note) => <p key={note} className="rounded-2xl border border-border/60 bg-background/60 p-3">{note}</p>)}
+              <CardContent className="space-y-3">
+                {data.sourceGaps.length ? data.sourceGaps.map((gap) => (
+                  <Link key={gap.id} href={gap.href} className="block rounded-2xl border border-border/60 bg-background/60 p-4 transition hover:border-primary/40 hover:bg-muted/40">
+                    <div className="flex flex-wrap items-center gap-2"><StatusPill tone={gap.tone}>{gap.priority}</StatusPill><span className="font-medium">{gap.title}</span></div>
+                    <p className="mt-2 text-sm text-muted-foreground">{gap.detail}</p>
+                  </Link>
+                )) : <EmptyState title="No major data gaps" description="The current record set has enough context for stronger source-aware summaries." />}
               </CardContent>
             </Card>
           </div>
         </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2"><Quote className="h-5 w-5" /> Visible source citations</CardTitle>
+            <CardDescription>Recent records that can explain where an AI summary is drawing context from.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {data.sourceCitationCards.length ? (
+              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                {data.sourceCitationCards.map((item) => <CitationCard key={item.id} item={item} />)}
+              </div>
+            ) : <EmptyState title="No citation cards yet" description="Add medications, labs, vitals, symptoms, documents, appointments, or alerts to build an evidence map." />}
+          </CardContent>
+        </Card>
 
         <div className="grid gap-6 xl:grid-cols-[0.95fr_1.05fr]">
           <Card>
@@ -251,6 +292,36 @@ export default async function AiInsightsPage({ searchParams }: { searchParams?: 
                   <p className="mt-2 text-sm text-muted-foreground">{signal.detail}</p>
                 </Link>
               )) : <EmptyState title="No major risk signals" description="Open alerts, abnormal labs, severe symptoms, missed logs, and vital review signals will appear here." />}
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="grid gap-6 xl:grid-cols-[0.9fr_1.1fr]">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2"><ClipboardList className="h-5 w-5" /> Recommended next actions</CardTitle>
+              <CardDescription>Follow-ups from the latest insight plus due workflow items.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {data.followUpItems.length ? data.followUpItems.map((item) => (
+                <Link key={item.id} href={item.href} className="block rounded-2xl border border-border/60 bg-background/60 p-4 transition hover:border-primary/40 hover:bg-muted/40">
+                  <div className="flex flex-wrap items-center gap-2"><Badge>{item.source}</Badge><span className="font-medium">{item.title}</span></div>
+                  <p className="mt-2 text-sm text-muted-foreground">{item.detail}</p>
+                </Link>
+              )) : <EmptyState title="No follow-up queue" description="AI follow-ups and due reminders will appear here." />}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2"><ShieldCheck className="h-5 w-5" /> Prompt transparency</CardTitle>
+              <CardDescription>What the assistant can and cannot use.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm text-muted-foreground">
+              <div className="flex flex-wrap gap-2">
+                {data.sourceSummary.promptModules.length ? data.sourceSummary.promptModules.map((module) => <Badge key={module}>{module}</Badge>) : <Badge>No record modules yet</Badge>}
+              </div>
+              {data.transparencyNotes.map((note) => <p key={note} className="rounded-2xl border border-border/60 bg-background/60 p-3">{note}</p>)}
             </CardContent>
           </Card>
         </div>

--- a/docs/PATCH_29_AI_SOURCE_CITATIONS.md
+++ b/docs/PATCH_29_AI_SOURCE_CITATIONS.md
@@ -1,0 +1,23 @@
+# Patch 29 — AI Insights v3 Source Citations
+
+## Summary
+
+This patch upgrades the AI Insights workspace with visible evidence cards, confidence metrics, and data-gap guidance so AI outputs feel more traceable and review-ready.
+
+## Changes
+
+- Adds visible source citation cards for recent medications, labs, vitals, symptoms, documents, appointments, and alerts.
+- Adds AI confidence metrics for source coverage, citation pool size, open risk context, and data gaps.
+- Adds data-gap recommendations to improve future AI summaries.
+- Adds richer prompt transparency around what records can and cannot support generated summaries.
+- Fixes duplicate Labs evidence metadata in the AI workspace helper.
+- Preserves the existing AI generation action and fallback behavior.
+
+## Files changed
+
+- `app/ai-insights/page.tsx`
+- `lib/ai-insights-workspace.ts`
+
+## Notes
+
+This patch uses existing schema models only and does not require a Prisma migration.

--- a/lib/ai-insights-workspace.ts
+++ b/lib/ai-insights-workspace.ts
@@ -52,6 +52,32 @@ export type SharedAiPatient = {
   href: string;
 };
 
+export type AiSourceCitationCard = {
+  id: string;
+  label: string;
+  recordType: string;
+  title: string;
+  detail: string;
+  capturedAt: Date | null;
+  href: string;
+  tone: "neutral" | "info" | "success" | "warning" | "danger";
+};
+
+export type AiConfidenceMetric = {
+  label: string;
+  value: string;
+  detail: string;
+  tone: "neutral" | "info" | "success" | "warning" | "danger";
+};
+
+export type AiSourceGap = {
+  id: string;
+  title: string;
+  detail: string;
+  href: string;
+  priority: "low" | "medium" | "high";
+};
+
 function parseJsonArray<T>(value: string | null): T[] {
   if (!value) return [];
   try {
@@ -124,6 +150,26 @@ function parseInsight(item: {
     disclaimer: item.disclaimer,
     createdAt: item.createdAt,
   };
+}
+
+
+function formatVitalDetail(vital: { systolic: number | null; diastolic: number | null; heartRate: number | null; oxygenSaturation: number | null; bloodSugar: number | null; temperatureC: number | null; weightKg: number | null }) {
+  const parts = [
+    vital.systolic && vital.diastolic ? `${vital.systolic}/${vital.diastolic} BP` : null,
+    vital.heartRate ? `${vital.heartRate} bpm` : null,
+    vital.oxygenSaturation ? `${vital.oxygenSaturation}% SpO2` : null,
+    vital.bloodSugar ? `${vital.bloodSugar} glucose` : null,
+    vital.temperatureC ? `${vital.temperatureC}°C` : null,
+    vital.weightKg ? `${vital.weightKg} kg` : null,
+  ].filter(Boolean);
+
+  return parts.join(" • ") || "Vitals captured";
+}
+
+function priorityTone(priority: "low" | "medium" | "high") {
+  if (priority === "high") return "danger" as const;
+  if (priority === "medium") return "warning" as const;
+  return "info" as const;
 }
 
 export async function getAiInsightsWorkspaceData(userId: string) {
@@ -386,6 +432,160 @@ export async function getAiInsightsWorkspaceData(userId: string) {
     insightCount: insights.length,
   });
 
+  const sourceCitationCards: AiSourceCitationCard[] = [
+    ...activeMedications.slice(0, 3).map((item) => ({
+      id: `medication-${item.id}`,
+      label: "Medication",
+      recordType: "Medication",
+      title: item.name,
+      detail: [item.dosage, item.frequency, item.doctor?.name ? `Provider: ${item.doctor.name}` : null].filter(Boolean).join(" • "),
+      capturedAt: item.updatedAt ?? item.startDate,
+      href: `/medications?focus=${item.id}`,
+      tone: item.logs.some((log) => log.status === MedicationLogStatus.MISSED) ? "warning" as const : "success" as const,
+    })),
+    ...labs.slice(0, 4).map((item) => ({
+      id: `lab-${item.id}`,
+      label: "Lab",
+      recordType: "Lab result",
+      title: item.testName,
+      detail: `${item.flag} • ${item.resultSummary}`,
+      capturedAt: item.dateTaken,
+      href: `/lab-review?q=${encodeURIComponent(item.testName)}`,
+      tone: item.flag === LabFlag.NORMAL ? "success" as const : "warning" as const,
+    })),
+    ...vitals.slice(0, 4).map((item) => ({
+      id: `vital-${item.id}`,
+      label: "Vital",
+      recordType: "Vital reading",
+      title: "Recent vital reading",
+      detail: formatVitalDetail(item),
+      capturedAt: item.recordedAt,
+      href: "/vitals-monitor",
+      tone: elevatedVitals.some((vital) => vital.id === item.id) ? "warning" as const : "info" as const,
+    })),
+    ...symptoms.slice(0, 4).map((item) => ({
+      id: `symptom-${item.id}`,
+      label: "Symptom",
+      recordType: "Symptom entry",
+      title: item.title,
+      detail: `${item.severity}${item.resolved ? " • resolved" : " • unresolved"}${item.bodyArea ? ` • ${item.bodyArea}` : ""}`,
+      capturedAt: item.startedAt,
+      href: `/symptom-review?q=${encodeURIComponent(item.title)}`,
+      tone: item.severity === SymptomSeverity.SEVERE && !item.resolved ? "danger" as const : "info" as const,
+    })),
+    ...documents.slice(0, 3).map((item) => ({
+      id: `document-${item.id}`,
+      label: "Document",
+      recordType: "Medical document",
+      title: item.title,
+      detail: `${item.type} • ${item.linkedRecordType ? `Linked to ${item.linkedRecordType}` : "Not linked"}`,
+      capturedAt: item.createdAt,
+      href: "/documents",
+      tone: item.linkedRecordType ? "success" as const : "warning" as const,
+    })),
+    ...upcomingAppointments.slice(0, 2).map((item) => ({
+      id: `appointment-${item.id}`,
+      label: "Appointment",
+      recordType: "Appointment",
+      title: item.purpose,
+      detail: `${item.doctorName} • ${item.clinic}`,
+      capturedAt: item.scheduledAt,
+      href: "/visit-prep",
+      tone: "info" as const,
+    })),
+    ...alerts.slice(0, 3).map((item) => ({
+      id: `alert-${item.id}`,
+      label: "Alert",
+      recordType: "Alert event",
+      title: item.title,
+      detail: item.message,
+      capturedAt: item.createdAt,
+      href: `/alerts/${item.id}`,
+      tone: item.severity === AlertSeverity.CRITICAL || item.severity === AlertSeverity.HIGH ? "danger" as const : "warning" as const,
+    })),
+  ]
+    .sort((a, b) => (b.capturedAt?.getTime() ?? 0) - (a.capturedAt?.getTime() ?? 0))
+    .slice(0, 12);
+
+  const sourceGaps: AiSourceGap[] = [];
+
+  if (!user?.healthProfile) {
+    sourceGaps.push({
+      id: "profile-gap",
+      title: "Complete the health profile",
+      detail: "AI summaries are stronger when baseline details, allergies, emergency contact, and care context are available.",
+      href: "/onboarding",
+      priority: "high",
+    });
+  }
+
+  if (labs.length === 0) {
+    sourceGaps.push({
+      id: "lab-gap",
+      title: "Add recent lab results",
+      detail: "Lab data gives AI better evidence for trend flags and provider questions.",
+      href: "/labs",
+      priority: "medium",
+    });
+  }
+
+  if (vitals.length < 3) {
+    sourceGaps.push({
+      id: "vitals-gap",
+      title: "Capture more vital readings",
+      detail: "At least three recent readings help reduce noisy AI trend summaries.",
+      href: "/vitals",
+      priority: "medium",
+    });
+  }
+
+  if (documents.length > 0 && documents.every((item) => !item.linkedRecordType)) {
+    sourceGaps.push({
+      id: "document-link-gap",
+      title: "Link documents to records",
+      detail: "Linked documents give reports and AI summaries better traceability.",
+      href: "/documents?link=UNLINKED",
+      priority: "low",
+    });
+  }
+
+  if (activeMedications.length > 0 && activeMedications.every((item) => item.logs.length === 0)) {
+    sourceGaps.push({
+      id: "adherence-gap",
+      title: "Log medication adherence",
+      detail: "Dose logs help AI separate medication schedule context from actual adherence behavior.",
+      href: "/medication-safety",
+      priority: "medium",
+    });
+  }
+
+  const confidenceMetrics: AiConfidenceMetric[] = [
+    {
+      label: "Source coverage",
+      value: `${evidenceCards.filter((item) => item.status === "Ready").length}/${evidenceCards.length}`,
+      detail: "Modules with enough structured records for a stronger summary.",
+      tone: evidenceCards.filter((item) => item.status === "Ready").length >= 4 ? "success" : "warning",
+    },
+    {
+      label: "Citation pool",
+      value: String(sourceCitationCards.length),
+      detail: "Recent records available to show as visible evidence cards.",
+      tone: sourceCitationCards.length >= 6 ? "success" : "warning",
+    },
+    {
+      label: "Open risk context",
+      value: String(riskSignals.length),
+      detail: "Alert, lab, symptom, medication, and vital signals available for risk review.",
+      tone: riskSignals.some((item) => item.severity === "urgent") ? "danger" : riskSignals.length > 0 ? "warning" : "success",
+    },
+    {
+      label: "Data gaps",
+      value: String(sourceGaps.length),
+      detail: "Known missing context that may reduce insight quality.",
+      tone: sourceGaps.some((item) => item.priority === "high") ? "danger" : sourceGaps.length > 0 ? "warning" : "success",
+    },
+  ];
+
   const sourceSummary = {
     totalRecords: medications.length + appointments.length + labs.length + vitals.length + symptoms.length + documents.length,
     openAlerts: alerts.length,
@@ -403,6 +603,9 @@ export async function getAiInsightsWorkspaceData(userId: string) {
     riskSignals: riskSignals.slice(0, 6),
     followUpItems,
     sharedPatients,
+    sourceCitationCards,
+    confidenceMetrics,
+    sourceGaps: sourceGaps.map((item) => ({ ...item, tone: priorityTone(item.priority) })),
     sourceSummary,
     suggestedQuestions: latestInsight?.suggestedQuestions ?? [],
     transparencyNotes: [


### PR DESCRIPTION
This PR adds Patch 29: AI Source Citations v3.

Changes:
- Upgrades /ai-insights with visible source citation cards
- Adds evidence cards from medications, labs, vitals, symptoms, documents, appointments, and alerts
- Adds AI confidence metrics for source coverage, citation pool size, risk context, and data gaps
- Adds data-gap recommendations to improve future AI summaries
- Adds stronger prompt transparency around what records can support generated insights
- Fixes duplicate Labs evidence metadata in the AI workspace helper
- Preserves existing AI generation and fallback behavior
- Requires no Prisma migration