### PR TITLE
Add deployment hardening checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ NEXTAUTH_URL="http://localhost:3000"
 # Vercel example:
 # NEXTAUTH_URL="https://your-project.vercel.app"
 
+# App URL used by emails, API docs, and deployment checks.
+APP_URL="http://localhost:3000"
+
 # Redis / BullMQ
 # Required for jobs, reminders, alerts, and worker-connected features.
 REDIS_URL="redis://127.0.0.1:6379"
@@ -24,16 +27,21 @@ JOB_DASHBOARD_LIMIT="20"
 # Optional, but AI insight features will be disabled without these.
 OPENAI_API_KEY=""
 OPENAI_MODEL="gpt-5-mini"
-INTERNAL_API_SECRET=
+
+# Internal API protection
+# Use a long random secret for internal job dispatch/API workflows in production.
+INTERNAL_API_SECRET=""
 
 # Account email workflows
-APP_URL="http://localhost:3000"
 EMAIL_VERIFICATION_REQUIRED="false"
 RESEND_API_KEY=""
 RESEND_FROM_EMAIL="VitaVault <no-reply@example.com>"
 
 # Document storage
-# private = files stored under PRIVATE_UPLOAD_DIR and served only through authenticated download route.
-# public = files stored under public/uploads for legacy/local public-mode demos.
-DOCUMENT_STORAGE_MODE="private"
+# local is the current default. Future-ready modes: s3, r2, supabase, azure, gcs.
+DOCUMENT_STORAGE_MODE="local"
 PRIVATE_UPLOAD_DIR="private-uploads"
+
+# Deployment / health checks
+# Optional. Used by scripts/check-health-endpoint.cjs when you want to check a deployed URL.
+HEALTHCHECK_URL="http://localhost:3000/api/health"

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { getDeploymentReadinessSummary } from "@/lib/deployment-readiness";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type HealthCheckResult = {
+  name: string;
+  status: "ok" | "warning" | "error";
+  detail: string;
+};
+
+async function checkDatabase(): Promise<HealthCheckResult> {
+  try {
+    await db.$queryRaw`SELECT 1`;
+    return { name: "database", status: "ok", detail: "Prisma database ping succeeded." };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown database error";
+    return { name: "database", status: "error", detail: message };
+  }
+}
+
+function checkRedis(): HealthCheckResult {
+  if (process.env.REDIS_URL?.trim()) {
+    return { name: "redis", status: "ok", detail: "REDIS_URL is configured for queue-backed workflows." };
+  }
+  return { name: "redis", status: "warning", detail: "REDIS_URL is not configured. Worker-backed jobs will be degraded." };
+}
+
+function checkEmail(): HealthCheckResult {
+  if (process.env.RESEND_API_KEY?.trim() && process.env.RESEND_FROM_EMAIL?.trim()) {
+    return { name: "email", status: "ok", detail: "Email delivery variables are configured." };
+  }
+  return { name: "email", status: "warning", detail: "Email delivery is not fully configured." };
+}
+
+function checkAi(): HealthCheckResult {
+  if (process.env.OPENAI_API_KEY?.trim()) {
+    return { name: "ai", status: "ok", detail: "AI insight generation key is configured." };
+  }
+  return { name: "ai", status: "warning", detail: "OPENAI_API_KEY is missing. AI features should use fallback/demo behavior." };
+}
+
+export async function GET() {
+  const readiness = getDeploymentReadinessSummary();
+  const checks = [await checkDatabase(), checkRedis(), checkEmail(), checkAi()];
+  const hasError = checks.some((check) => check.status === "error") || readiness.blockingIssues.length > 0;
+  const hasWarning = checks.some((check) => check.status === "warning") || readiness.warningIssues.length > 0;
+
+  const body = {
+    status: hasError ? "error" : hasWarning ? "warning" : "ok",
+    service: "VitaVault",
+    timestamp: new Date().toISOString(),
+    readiness: {
+      score: readiness.score,
+      requiredConfigured: readiness.requiredConfigured,
+      requiredTotal: readiness.requiredTotal,
+      recommendedConfigured: readiness.recommendedConfigured,
+      recommendedTotal: readiness.recommendedTotal,
+      blockingKeys: readiness.blockingIssues.map((issue) => issue.key),
+      warningKeys: readiness.warningIssues.map((issue) => issue.key),
+    },
+    checks,
+  };
+
+  return NextResponse.json(body, { status: hasError ? 503 : 200 });
+}

--- a/docs/DEPLOYMENT_CHECKLIST.md
+++ b/docs/DEPLOYMENT_CHECKLIST.md
@@ -1,0 +1,77 @@
+# VitaVault Deployment Checklist
+
+This checklist is for preparing VitaVault for a production-style deployment on Vercel or a similar Node.js host.
+
+## Required environment variables
+
+| Variable | Purpose |
+|---|---|
+| `DATABASE_URL` | PostgreSQL connection used by Prisma and all record modules. |
+| `AUTH_SECRET` | Auth.js secret used for session signing and encryption. |
+| `NEXTAUTH_URL` | Canonical public URL for auth callbacks and redirects. |
+| `APP_URL` | Base app URL used by emails, links, and workflows. |
+
+## Recommended environment variables
+
+| Variable | Purpose |
+|---|---|
+| `REDIS_URL` | BullMQ workers, alerts, reminders, and job dispatch workflows. |
+| `INTERNAL_API_SECRET` | Protection for internal job/dispatch routes. |
+| `RESEND_API_KEY` | Outbound email delivery for invites and verification. |
+| `RESEND_FROM_EMAIL` | Verified sender identity for outbound email workflows. |
+| `OPENAI_API_KEY` | AI insight generation. |
+| `DOCUMENT_STORAGE_MODE` | Document storage provider mode. Current default: `local`. |
+| `PRIVATE_UPLOAD_DIR` | Private local document upload directory. |
+
+## Local checks
+
+Run these before creating a PR or deploying:
+
+```bash
+npm run env:check
+npm run deploy:check
+```
+
+`npm run deploy:check` runs Prisma validation, TypeScript, ESLint, and Vitest.
+
+## Runtime health check
+
+After starting the app, open:
+
+```txt
+/api/health
+```
+
+Or run:
+
+```bash
+npm run health:local
+```
+
+The health endpoint checks deployment readiness, database connectivity, Redis config presence, email config presence, and AI config presence without exposing secrets.
+
+## Vercel notes
+
+1. Add all required environment variables in Vercel project settings.
+2. Use a hosted PostgreSQL database, not local Docker, for deployed builds.
+3. Keep `AUTH_TRUST_HOST=true` for Vercel-hosted Auth.js flows.
+4. Use a hosted Redis provider for worker-backed flows.
+5. Deploy the worker separately if queue processing is required outside the web runtime.
+6. Configure email sender/domain verification before enabling email verification in production.
+7. Use production object storage before accepting real medical documents.
+
+## Worker deployment notes
+
+The web app can deploy without a running worker, but queue-backed features will not process automatically unless a worker is running.
+
+Recommended worker command:
+
+```bash
+npm run worker
+```
+
+For production, run this on a background-worker-capable host such as Railway, Render, Fly.io, a VPS, or another long-running Node process platform.
+
+## Document storage notes
+
+The local provider is useful for development and demos. Production deployments should eventually use durable object storage such as S3, Cloudflare R2, Supabase Storage, Azure Blob Storage, or Google Cloud Storage.

--- a/docs/PATCH_30_DEPLOYMENT_HARDENING.md
+++ b/docs/PATCH_30_DEPLOYMENT_HARDENING.md
@@ -1,0 +1,43 @@
+# Patch 30 — Deployment Hardening
+
+## Summary
+
+This patch adds deployment-readiness checks, a health endpoint, environment validation scripts, and production deployment documentation.
+
+## Added
+
+- `/api/health` runtime health endpoint
+- `lib/deployment-readiness.ts`
+- `scripts/validate-env.cjs`
+- `scripts/check-health-endpoint.cjs`
+- `npm run env:check`
+- `npm run deploy:check`
+- `npm run health:local`
+- `docs/DEPLOYMENT_CHECKLIST.md`
+- updated `.env.example`
+
+## Why it matters
+
+VitaVault now has many production-style features: Auth.js, Prisma/PostgreSQL, Redis/BullMQ workers, email workflows, AI insights, document storage, mobile/device ingestion, admin/ops, and report generation. This patch gives reviewers and future deployers a single clear path to validate required configuration and runtime health.
+
+## Validation
+
+Run:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:run
+npm run deploy:check
+```
+
+When environment variables are configured locally, also run:
+
+```bash
+npm run env:check
+npm run health:local
+```
+
+## Migration
+
+No Prisma migration is required.

--- a/lib/deployment-readiness.ts
+++ b/lib/deployment-readiness.ts
@@ -1,0 +1,96 @@
+export type DeploymentTone = "success" | "warning" | "danger" | "neutral";
+
+export type DeploymentCheck = {
+  key: string;
+  label: string;
+  category: "required" | "recommended" | "optional";
+  configured: boolean;
+  tone: DeploymentTone;
+  detail: string;
+};
+
+function hasValue(value: string | undefined | null) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isPlaceholder(value: string | undefined | null) {
+  if (!hasValue(value)) return true;
+  const normalized = String(value).toLowerCase();
+  return normalized.includes("change-this") || normalized.includes("example.com") || normalized.includes("user:password") || normalized.includes("db_name");
+}
+
+function checkRequired(key: string, label: string, detail: string): DeploymentCheck {
+  const value = process.env[key];
+  const configured = hasValue(value) && !isPlaceholder(value);
+  return {
+    key,
+    label,
+    category: "required",
+    configured,
+    tone: configured ? "success" : "danger",
+    detail: configured ? detail : `${detail} This value is required before production deployment.`,
+  };
+}
+
+function checkRecommended(key: string, label: string, detail: string): DeploymentCheck {
+  const value = process.env[key];
+  const configured = hasValue(value) && !isPlaceholder(value);
+  return {
+    key,
+    label,
+    category: "recommended",
+    configured,
+    tone: configured ? "success" : "warning",
+    detail: configured ? detail : `${detail} The app can run without it, but the related feature will be degraded or disabled.`,
+  };
+}
+
+function checkOptional(key: string, label: string, detail: string): DeploymentCheck {
+  const value = process.env[key];
+  const configured = hasValue(value) && !isPlaceholder(value);
+  return {
+    key,
+    label,
+    category: "optional",
+    configured,
+    tone: configured ? "success" : "neutral",
+    detail,
+  };
+}
+
+export function getDeploymentChecks(): DeploymentCheck[] {
+  return [
+    checkRequired("DATABASE_URL", "Database URL", "PostgreSQL connection used by Prisma, records, auth, and reporting."),
+    checkRequired("AUTH_SECRET", "Auth secret", "Long random secret used by Auth.js session encryption and signing."),
+    checkRequired("NEXTAUTH_URL", "Public auth URL", "Canonical app URL used by Auth.js callbacks and redirects."),
+    checkRequired("APP_URL", "Application URL", "Base URL used by emails, links, and product-facing workflows."),
+    checkRecommended("REDIS_URL", "Redis URL", "Redis connection used by BullMQ workers, reminders, alerts, and queue-backed features."),
+    checkRecommended("INTERNAL_API_SECRET", "Internal API secret", "Secret used to protect internal job dispatch and worker-facing endpoints."),
+    checkRecommended("RESEND_API_KEY", "Resend API key", "Email delivery key used by verification, invites, and outbound notifications."),
+    checkRecommended("RESEND_FROM_EMAIL", "Email sender", "Verified sender identity for outbound email workflows."),
+    checkRecommended("OPENAI_API_KEY", "OpenAI API key", "Enables AI insight generation. Without it, AI pages should remain in fallback/demo mode."),
+    checkRecommended("DOCUMENT_STORAGE_MODE", "Document storage mode", "Selects the document storage provider. Local storage is fine for local development."),
+    checkRecommended("PRIVATE_UPLOAD_DIR", "Private upload directory", "Local private document upload path used by the default storage provider."),
+    checkOptional("HEALTHCHECK_URL", "Healthcheck URL", "Optional URL used by local scripts to check a running deployment."),
+  ];
+}
+
+export function getDeploymentReadinessSummary() {
+  const checks = getDeploymentChecks();
+  const required = checks.filter((check) => check.category === "required");
+  const recommended = checks.filter((check) => check.category === "recommended");
+  const requiredConfigured = required.filter((check) => check.configured).length;
+  const recommendedConfigured = recommended.filter((check) => check.configured).length;
+  const score = Math.round(((requiredConfigured * 2 + recommendedConfigured) / Math.max(1, required.length * 2 + recommended.length)) * 100);
+
+  return {
+    score,
+    requiredTotal: required.length,
+    requiredConfigured,
+    recommendedTotal: recommended.length,
+    recommendedConfigured,
+    blockingIssues: required.filter((check) => !check.configured),
+    warningIssues: recommended.filter((check) => !check.configured),
+    checks,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "seed:demo": "tsx prisma/demo-seed.ts"
+    "seed:demo": "tsx prisma/demo-seed.ts",
+    "env:check": "node scripts/validate-env.cjs",
+    "deploy:check": "npm run db:validate:ci && npm run typecheck && npm run lint && npm run test:run",
+    "health:local": "node scripts/check-health-endpoint.cjs"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.10.0",

--- a/scripts/check-health-endpoint.cjs
+++ b/scripts/check-health-endpoint.cjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+const url = process.env.HEALTHCHECK_URL || process.argv[2] || "http://localhost:3000/api/health";
+
+async function main() {
+  console.log(`Checking VitaVault health endpoint: ${url}`);
+  const response = await fetch(url, { headers: { Accept: "application/json" } });
+  const body = await response.json().catch(() => ({}));
+  console.log(JSON.stringify(body, null, 2));
+  if (!response.ok) {
+    throw new Error(`Health endpoint returned HTTP ${response.status}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/validate-env.cjs
+++ b/scripts/validate-env.cjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+
+const root = process.cwd();
+
+function parseEnvFile(filePath) {
+  if (!fs.existsSync(filePath)) return {};
+  const output = {};
+  const lines = fs.readFileSync(filePath, "utf8").split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#") || !trimmed.includes("=")) continue;
+    const index = trimmed.indexOf("=");
+    const key = trimmed.slice(0, index).trim();
+    let value = trimmed.slice(index + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    output[key] = value;
+  }
+  return output;
+}
+
+const env = {
+  ...parseEnvFile(path.join(root, ".env")),
+  ...parseEnvFile(path.join(root, ".env.local")),
+  ...process.env,
+};
+
+function hasValue(key) {
+  return typeof env[key] === "string" && env[key].trim().length > 0;
+}
+
+function isPlaceholder(key) {
+  if (!hasValue(key)) return true;
+  const value = env[key].toLowerCase();
+  return value.includes("change-this") || value.includes("example.com") || value.includes("user:password") || value.includes("db_name");
+}
+
+const required = [
+  ["DATABASE_URL", "PostgreSQL connection used by Prisma."],
+  ["AUTH_SECRET", "Auth.js secret used for session signing/encryption."],
+  ["NEXTAUTH_URL", "Public app URL used by auth callbacks."],
+  ["APP_URL", "Base URL used by emails and app links."],
+];
+
+const recommended = [
+  ["REDIS_URL", "Queue and worker workflows."],
+  ["INTERNAL_API_SECRET", "Internal job dispatch/API protection."],
+  ["RESEND_API_KEY", "Outbound email delivery."],
+  ["RESEND_FROM_EMAIL", "Verified email sender."],
+  ["OPENAI_API_KEY", "AI insight generation."],
+  ["DOCUMENT_STORAGE_MODE", "Document storage provider selection."],
+  ["PRIVATE_UPLOAD_DIR", "Local private upload directory."],
+];
+
+const missingRequired = required.filter(([key]) => isPlaceholder(key));
+const missingRecommended = recommended.filter(([key]) => isPlaceholder(key));
+
+console.log("\nVitaVault environment check\n");
+for (const [key, detail] of required) {
+  console.log(`${isPlaceholder(key) ? "✗" : "✓"} ${key} - ${detail}`);
+}
+for (const [key, detail] of recommended) {
+  console.log(`${isPlaceholder(key) ? "!" : "✓"} ${key} - ${detail}`);
+}
+
+if (missingRecommended.length) {
+  console.log("\nWarnings:");
+  for (const [key, detail] of missingRecommended) console.log(`- ${key}: ${detail}`);
+}
+
+if (missingRequired.length) {
+  console.error("\nBlocking issues:");
+  for (const [key, detail] of missingRequired) console.error(`- ${key}: ${detail}`);
+  process.exit(1);
+}
+
+console.log("\nEnvironment check passed for required deployment variables.\n");


### PR DESCRIPTION
This PR adds Patch 30: Deployment Hardening.

Changes:
- Adds a runtime /api/health endpoint
- Adds deployment readiness checks for required and recommended environment variables
- Adds database, Redis, email, and AI health signals
- Adds npm run env:check for environment validation
- Adds npm run deploy:check for Prisma validation, typecheck, lint, and tests
- Adds npm run health:local for checking the running health endpoint
- Updates .env.example with deployment and storage variables
- Adds docs/DEPLOYMENT_CHECKLIST.md for Vercel/local production readiness
- Requires no Prisma migration