### PR TITLE
Add role-based navigation visibility

### DIFF
--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -14,12 +14,13 @@ import {
   X,
 } from "lucide-react";
 import { AnimatePresence, motion } from "framer-motion";
-import { signOut } from "next-auth/react";
+import type { AppRole } from "@prisma/client";
+import { signOut, useSession } from "next-auth/react";
 import { useTheme } from "next-themes";
 import { cn } from "@/lib/utils";
 import {
-  allAppRoutes,
-  navigationSections,
+  getAllAppRoutesForRole,
+  getNavigationSectionsForRole,
   type AppRouteItem,
 } from "@/lib/app-routes";
 
@@ -104,11 +105,24 @@ function NavItem({
 
 export function AppShell({ children }: AppShellProps) {
   const pathname = usePathname();
+  const { data: session } = useSession();
   const { theme, setTheme } = useTheme();
 
   const [mobileOpen, setMobileOpen] = useState(false);
   const [desktopCollapsed, setDesktopCollapsed] = useState(false);
   const [hasMounted, setHasMounted] = useState(false);
+
+  const currentRole = (session?.user?.role ?? "PATIENT") as AppRole;
+
+  const visibleNavigationSections = useMemo(
+    () => getNavigationSectionsForRole(currentRole),
+    [currentRole]
+  );
+
+  const visibleAppRoutes = useMemo(
+    () => getAllAppRoutesForRole(currentRole),
+    [currentRole]
+  );
 
   useEffect(() => {
     setHasMounted(true);
@@ -129,18 +143,18 @@ export function AppShell({ children }: AppShellProps) {
   }, [desktopCollapsed, hasMounted]);
 
   const activeRoute = useMemo(() => {
-    return allAppRoutes.find(
+    return visibleAppRoutes.find(
       (item) => pathname === item.href || pathname.startsWith(`${item.href}/`)
     );
-  }, [pathname]);
+  }, [pathname, visibleAppRoutes]);
 
   const activeSection = useMemo(() => {
-    return navigationSections.find((section) =>
+    return visibleNavigationSections.find((section) =>
       section.items.some(
         (item) => pathname === item.href || pathname.startsWith(`${item.href}/`)
       )
     );
-  }, [pathname]);
+  }, [pathname, visibleNavigationSections]);
 
   const activeTitle = activeRoute?.title ?? "VitaVault";
 
@@ -186,6 +200,9 @@ export function AppShell({ children }: AppShellProps) {
                     <p className="truncate text-xs text-muted-foreground">
                       Health command center
                     </p>
+                    <p className="mt-0.5 text-[11px] font-medium uppercase tracking-wide text-primary/80">
+                      {currentRole.replace("_", " ")} workspace
+                    </p>
                   </motion.div>
                 ) : null}
               </AnimatePresence>
@@ -202,7 +219,7 @@ export function AppShell({ children }: AppShellProps) {
                 transition={{ duration: 0.18 }}
                 className="mt-3 text-xs leading-relaxed text-muted-foreground"
               >
-                Records, monitoring, care-team workflows, reports, and operations in one organized workspace.
+                Records, monitoring, care-team workflows, and reports in a role-aware workspace.
               </motion.p>
             ) : null}
           </AnimatePresence>
@@ -210,7 +227,7 @@ export function AppShell({ children }: AppShellProps) {
       </div>
 
       <div className={cn("mt-6 flex-1 overflow-y-auto pb-6", collapsed ? "px-2" : "px-3")}>
-        {navigationSections.map((section) => (
+        {visibleNavigationSections.map((section) => (
           <div key={section.label} className="mb-5">
             <AnimatePresence initial={false}>
               {!collapsed ? (
@@ -311,7 +328,7 @@ export function AppShell({ children }: AppShellProps) {
                 {activeSection?.label ?? "Protected workspace"}
               </p>
               <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                {activeSection?.description ?? "Authenticated and protected by server-side checks."}
+                {activeSection?.description ?? "Authenticated, role-aware, and protected by server-side checks."}
               </p>
             </motion.div>
           ) : null}
@@ -360,7 +377,7 @@ export function AppShell({ children }: AppShellProps) {
               </div>
 
               <div className="text-xs text-muted-foreground">
-                Organized healthcare workspace • Navigation grouped by workflow
+                Organized healthcare workspace • Role-aware navigation
               </div>
             </div>
           </div>
@@ -438,7 +455,7 @@ export function AppShell({ children }: AppShellProps) {
                 <div className="flex items-center justify-between px-4 py-4">
                   <div>
                     <p className="text-sm font-semibold">Navigation</p>
-                    <p className="text-xs text-muted-foreground">Grouped by product workflow</p>
+                    <p className="text-xs text-muted-foreground">Grouped by role and workflow</p>
                   </div>
                   <button
                     type="button"

--- a/docs/PATCH_31_ROLE_BASED_NAVIGATION.md
+++ b/docs/PATCH_31_ROLE_BASED_NAVIGATION.md
@@ -1,0 +1,59 @@
+# Patch 31 — Role-Based Navigation Visibility
+
+## Summary
+
+This patch makes VitaVault's sidebar navigation role-aware so normal users do not see administrator-only operational links.
+
+## Problem fixed
+
+The sidebar previously displayed the full **Admin & Ops** group to every authenticated account. Even when server-side page protection existed, exposing admin links to patient/caregiver/doctor/lab users created confusion and made the UI feel less polished.
+
+## Changes
+
+- Adds role visibility metadata to app route sections/items.
+- Adds navigation helper functions for filtering routes by role.
+- Hides the **Admin & Ops** section from non-admin accounts.
+- Moves personal account security into a separate **Account** section visible to all authenticated users.
+- Keeps admin-only links visible to admin accounts:
+  - Audit Log
+  - Admin
+  - Jobs
+  - Operations
+  - API Docs
+- Updates the app shell to derive the current user role from the NextAuth session.
+- Updates sidebar/topbar copy to describe the workspace as role-aware.
+
+## Expected behavior
+
+### Patient / Caregiver / Doctor / Lab Staff
+
+Visible:
+- Overview
+- Records
+- Monitoring
+- Sharing & Reports
+- Account → Security
+
+Hidden:
+- Admin
+- Jobs
+- Operations
+- Audit Log
+- API Docs
+
+### Admin
+
+Visible:
+- All normal product sections
+- Account
+- Admin & Ops
+
+## Files changed
+
+- `components/app-shell.tsx`
+- `lib/app-routes.ts`
+- `docs/PATCH_31_ROLE_BASED_NAVIGATION.md`
+
+## Migration
+
+No Prisma migration required.

--- a/lib/app-routes.ts
+++ b/lib/app-routes.ts
@@ -1,3 +1,4 @@
+import type { AppRole } from "@prisma/client";
 import type { LucideIcon } from "lucide-react";
 import {
   Activity,
@@ -31,12 +32,14 @@ export type AppRouteItem = {
   href: string;
   description: string;
   icon: LucideIcon;
+  allowedRoles?: readonly AppRole[];
 };
 
 export type AppRouteSection = {
   label: string;
   description: string;
   items: AppRouteItem[];
+  allowedRoles?: readonly AppRole[];
 };
 
 export const overviewRoutes: AppRouteItem[] = [
@@ -231,13 +234,16 @@ export const sharingReportRoutes: AppRouteItem[] = [
   },
 ];
 
-export const adminOpsRoutes: AppRouteItem[] = [
+export const accountRoutes: AppRouteItem[] = [
   {
     title: "Security",
     href: "/security",
     description: "Password rotation and mobile session visibility",
     icon: ShieldCheck,
   },
+];
+
+export const adminOpsRoutes: AppRouteItem[] = [
   {
     title: "Audit Log",
     href: "/audit-log",
@@ -292,9 +298,15 @@ export const navigationSections: AppRouteSection[] = [
     items: sharingReportRoutes,
   },
   {
+    label: "Account",
+    description: "Account security and personal session controls",
+    items: accountRoutes,
+  },
+  {
     label: "Admin & Ops",
-    description: "Security, audit, admin, jobs, ops, and API visibility",
+    description: "System audit, users, jobs, operations, and API visibility",
     items: adminOpsRoutes,
+    allowedRoles: ["ADMIN" as AppRole],
   },
 ];
 
@@ -305,6 +317,29 @@ export const primaryRoutes: AppRouteItem[] = [
   ...sharingReportRoutes,
 ];
 
-export const utilityRoutes: AppRouteItem[] = [...adminOpsRoutes];
+export const utilityRoutes: AppRouteItem[] = [...accountRoutes, ...adminOpsRoutes];
 
 export const allAppRoutes: AppRouteItem[] = navigationSections.flatMap((section) => section.items);
+
+export function canAccessRouteItem(item: AppRouteItem, role: AppRole) {
+  return !item.allowedRoles || item.allowedRoles.includes(role);
+}
+
+export function canAccessRouteSection(section: AppRouteSection, role: AppRole) {
+  return !section.allowedRoles || section.allowedRoles.includes(role);
+}
+
+export function getNavigationSectionsForRole(role: AppRole) {
+  return navigationSections
+    .filter((section) => canAccessRouteSection(section, role))
+    .map((section) => ({
+      ...section,
+      items: section.items.filter((item) => canAccessRouteItem(item, role)),
+    }))
+    .filter((section) => section.items.length > 0);
+}
+
+export function getAllAppRoutesForRole(role: AppRole) {
+  return getNavigationSectionsForRole(role).flatMap((section) => section.items);
+}
+


### PR DESCRIPTION
This PR adds Patch 31: Role-Based Navigation Visibility.

Changes:
- Makes VitaVault's sidebar navigation role-aware
- Hides the Admin & Ops section from non-admin users
- Keeps Audit Log, Admin, Jobs, Operations, and API Docs visible only to ADMIN accounts
- Adds an Account section for user-facing Security access
- Updates the app shell to filter navigation using the current NextAuth session role
- Updates sidebar and topbar copy to describe the workspace as role-aware
- Requires no Prisma migration