### PR TITLE
Add cloud document storage provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,9 +38,31 @@ RESEND_API_KEY=""
 RESEND_FROM_EMAIL="VitaVault <no-reply@example.com>"
 
 # Document storage
-# local is the current default. Future-ready modes: s3, r2, supabase, azure, gcs.
-DOCUMENT_STORAGE_MODE="local"
+# DOCUMENT_STORAGE_PROVIDER controls where document binaries are stored.
+# Supported values: local, s3, r2.
+DOCUMENT_STORAGE_PROVIDER="local"
+
+# DOCUMENT_STORAGE_MODE controls local visibility only.
+# Supported values: private, public. Use private for health documents.
+DOCUMENT_STORAGE_MODE="private"
 PRIVATE_UPLOAD_DIR="private-uploads"
+
+# S3 / Cloudflare R2-compatible document storage
+# Required when DOCUMENT_STORAGE_PROVIDER is s3 or r2.
+S3_ENDPOINT=""
+S3_REGION="us-east-1"
+S3_BUCKET=""
+S3_ACCESS_KEY_ID=""
+S3_SECRET_ACCESS_KEY=""
+S3_FORCE_PATH_STYLE="true"
+DOCUMENT_STORAGE_PREFIX="documents"
+
+# Optional Cloudflare R2 aliases. These can be used instead of S3_* names.
+R2_ENDPOINT=""
+R2_REGION="auto"
+R2_BUCKET=""
+R2_ACCESS_KEY_ID=""
+R2_SECRET_ACCESS_KEY=""
 
 # Deployment / health checks
 # Optional. Used by scripts/check-health-endpoint.cjs when you want to check a deployed URL.

--- a/app/api/documents/[id]/download/route.ts
+++ b/app/api/documents/[id]/download/route.ts
@@ -42,12 +42,14 @@ export async function GET(
     return NextResponse.json({ error: "Document not found." }, { status: 404 });
   }
 
-  if (!resolveDocumentObject(document.filePath)) {
+  const resolved = resolveDocumentObject(document.filePath);
+
+  if (!resolved) {
     return NextResponse.json({ error: "Document storage path is invalid." }, { status: 400 });
   }
 
   try {
-    const { bytes } = await readDocumentObject(document.filePath);
+    const { bytes, resolved: readResolved } = await readDocumentObject(document.filePath);
     const arrayBuffer = new ArrayBuffer(bytes.byteLength);
     new Uint8Array(arrayBuffer).set(bytes);
     const response = new NextResponse(arrayBuffer);
@@ -57,7 +59,7 @@ export async function GET(
       contentDisposition(document.fileName || `${document.title}.bin`, document.mimeType || "application/octet-stream")
     );
     response.headers.set("Cache-Control", "private, no-store, max-age=0");
-    response.headers.set("X-Document-Storage", "local");
+    response.headers.set("X-Document-Storage", readResolved.provider);
     return response;
   } catch {
     return NextResponse.json({ error: "Document file is unavailable." }, { status: 404 });

--- a/docs/DEPLOYMENT_CHECKLIST.md
+++ b/docs/DEPLOYMENT_CHECKLIST.md
@@ -20,8 +20,23 @@ This checklist is for preparing VitaVault for a production-style deployment on V
 | `RESEND_API_KEY` | Outbound email delivery for invites and verification. |
 | `RESEND_FROM_EMAIL` | Verified sender identity for outbound email workflows. |
 | `OPENAI_API_KEY` | AI insight generation. |
-| `DOCUMENT_STORAGE_MODE` | Document storage provider mode. Current default: `local`. |
+| `DOCUMENT_STORAGE_PROVIDER` | Document binary provider. Use `local`, `s3`, or `r2`. |
+| `DOCUMENT_STORAGE_MODE` | Local provider visibility mode: `private` or `public`. |
 | `PRIVATE_UPLOAD_DIR` | Private local document upload directory. |
+
+## Cloud document storage variables
+
+Use these when `DOCUMENT_STORAGE_PROVIDER=s3` or `DOCUMENT_STORAGE_PROVIDER=r2`.
+
+| Variable | Purpose |
+|---|---|
+| `S3_ENDPOINT` / `R2_ENDPOINT` | Object storage endpoint URL. |
+| `S3_REGION` / `R2_REGION` | Signing region. Use `auto` for Cloudflare R2. |
+| `S3_BUCKET` / `R2_BUCKET` | Bucket name for medical document binaries. |
+| `S3_ACCESS_KEY_ID` / `R2_ACCESS_KEY_ID` | Storage access key. |
+| `S3_SECRET_ACCESS_KEY` / `R2_SECRET_ACCESS_KEY` | Storage secret key. |
+| `S3_FORCE_PATH_STYLE` | Use path-style URLs. Usually `true` for S3-compatible providers. |
+| `DOCUMENT_STORAGE_PREFIX` | Folder/prefix for stored medical documents. |
 
 ## Local checks
 
@@ -48,7 +63,7 @@ Or run:
 npm run health:local
 ```
 
-The health endpoint checks deployment readiness, database connectivity, Redis config presence, email config presence, and AI config presence without exposing secrets.
+The health endpoint checks deployment readiness, database connectivity, Redis config presence, email config presence, AI config presence, and document storage configuration without exposing secrets.
 
 ## Vercel notes
 
@@ -58,7 +73,7 @@ The health endpoint checks deployment readiness, database connectivity, Redis co
 4. Use a hosted Redis provider for worker-backed flows.
 5. Deploy the worker separately if queue processing is required outside the web runtime.
 6. Configure email sender/domain verification before enabling email verification in production.
-7. Use production object storage before accepting real medical documents.
+7. Use `DOCUMENT_STORAGE_PROVIDER=s3` or `DOCUMENT_STORAGE_PROVIDER=r2` before accepting real medical documents in a hosted deployment.
 
 ## Worker deployment notes
 
@@ -74,4 +89,6 @@ For production, run this on a background-worker-capable host such as Railway, Re
 
 ## Document storage notes
 
-The local provider is useful for development and demos. Production deployments should eventually use durable object storage such as S3, Cloudflare R2, Supabase Storage, Azure Blob Storage, or Google Cloud Storage.
+The local provider is useful for development and demos. Production deployments should use durable object storage such as AWS S3, Cloudflare R2, Supabase Storage, Azure Blob Storage, or Google Cloud Storage.
+
+Patch 32 adds an S3-compatible provider, so Cloudflare R2 and most S3-compatible object stores can be used without adding another dependency.

--- a/docs/PATCH_32_CLOUD_STORAGE_PROVIDER.md
+++ b/docs/PATCH_32_CLOUD_STORAGE_PROVIDER.md
@@ -1,0 +1,44 @@
+# Patch 32 — Real Cloud Storage Provider
+
+## Summary
+
+This patch upgrades the document storage abstraction from Patch 26 by adding a real S3-compatible cloud storage provider.
+
+## Added
+
+- `lib/storage/s3-storage.ts`
+- S3-compatible signed upload, read, and delete operations
+- Cloudflare R2 support through the same provider
+- `DOCUMENT_STORAGE_PROVIDER` environment selection
+- S3/R2 environment variables in `.env.example`
+- Deployment checklist updates for cloud document storage
+- Download route storage-provider header now reflects the actual provider
+
+## Supported providers
+
+```txt
+local
+s3
+r2
+```
+
+## Required env for S3/R2
+
+```txt
+DOCUMENT_STORAGE_PROVIDER="s3"
+S3_ENDPOINT="https://s3.amazonaws.com"
+S3_REGION="us-east-1"
+S3_BUCKET="your-bucket"
+S3_ACCESS_KEY_ID="your-access-key"
+S3_SECRET_ACCESS_KEY="your-secret-key"
+S3_FORCE_PATH_STYLE="true"
+DOCUMENT_STORAGE_PREFIX="documents"
+```
+
+For Cloudflare R2, use either the `S3_*` variables with an R2 endpoint or the `R2_*` aliases.
+
+## Migration impact
+
+No Prisma migration is required.
+
+Existing local files stay local. New uploaded files use the provider configured by `DOCUMENT_STORAGE_PROVIDER`.

--- a/lib/storage/index.ts
+++ b/lib/storage/index.ts
@@ -1,9 +1,23 @@
 import { localDocumentStorageProvider } from "@/lib/storage/local-storage";
-import type { DocumentStorageHealth, DocumentStorageProvider } from "@/lib/storage/storage-types";
+import { createS3CompatibleDocumentStorageProvider } from "@/lib/storage/s3-storage";
+import type { DocumentStorageHealth, DocumentStorageProvider, DocumentStorageProviderId } from "@/lib/storage/storage-types";
 
-export const DOCUMENT_STORAGE_PROVIDER = "local" as const;
+export function getConfiguredDocumentStorageProviderId(): DocumentStorageProviderId {
+  const provider = String(process.env.DOCUMENT_STORAGE_PROVIDER || "local").toLowerCase();
+
+  if (provider === "s3") return "s3";
+  if (provider === "r2") return "r2";
+
+  return "local";
+}
 
 export function getDocumentStorageProvider(): DocumentStorageProvider {
+  const provider = getConfiguredDocumentStorageProviderId();
+
+  if (provider === "s3" || provider === "r2") {
+    return createS3CompatibleDocumentStorageProvider(provider);
+  }
+
   return localDocumentStorageProvider;
 }
 

--- a/lib/storage/s3-storage.ts
+++ b/lib/storage/s3-storage.ts
@@ -1,0 +1,321 @@
+import { createHash, createHmac } from "crypto";
+import path from "path";
+import type {
+  DocumentStorageHealth,
+  DocumentStorageProvider,
+  DocumentStorageProviderId,
+  ResolvedDocumentObject,
+  SaveDocumentObjectInput,
+  SavedDocumentObject,
+} from "@/lib/storage/storage-types";
+
+const EMPTY_BODY_HASH = createHash("sha256").update("").digest("hex");
+
+type S3CompatibleConfig = {
+  provider: Extract<DocumentStorageProviderId, "s3" | "r2">;
+  endpoint: string;
+  region: string;
+  bucket: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  forcePathStyle: boolean;
+  keyPrefix: string;
+  publicBaseUrl: string | null;
+};
+
+function awsEncode(value: string) {
+  return encodeURIComponent(value).replace(/[!'()*]/g, (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`);
+}
+
+function encodeObjectKey(key: string) {
+  return key.split("/").map(awsEncode).join("/");
+}
+
+function sanitizeOriginalName(value: string) {
+  return path.basename(value || "document.bin").replace(/[^a-zA-Z0-9._-]/g, "-") || "document.bin";
+}
+
+function cleanPrefix(value: string | undefined) {
+  return String(value || "documents")
+    .replace(/^\/+|\/+$/g, "")
+    .replace(/[^a-zA-Z0-9._/-]/g, "-") || "documents";
+}
+
+function normalizeObjectKey(value: string | null | undefined) {
+  const raw = String(value || "").replace(/\\/g, "/").trim();
+  if (!raw) return null;
+  if (raw.startsWith("s3://")) {
+    const withoutScheme = raw.slice("s3://".length);
+    const [, ...keyParts] = withoutScheme.split("/");
+    return keyParts.join("/") || null;
+  }
+  if (raw.startsWith("r2://")) {
+    const withoutScheme = raw.slice("r2://".length);
+    const [, ...keyParts] = withoutScheme.split("/");
+    return keyParts.join("/") || null;
+  }
+  return raw.replace(/^\/+/, "");
+}
+
+function getProviderConfig(provider: Extract<DocumentStorageProviderId, "s3" | "r2">): S3CompatibleConfig | null {
+  const endpoint = process.env.S3_ENDPOINT || process.env.R2_ENDPOINT || "";
+  const bucket = process.env.S3_BUCKET || process.env.R2_BUCKET || "";
+  const accessKeyId = process.env.S3_ACCESS_KEY_ID || process.env.R2_ACCESS_KEY_ID || "";
+  const secretAccessKey = process.env.S3_SECRET_ACCESS_KEY || process.env.R2_SECRET_ACCESS_KEY || "";
+  const region = process.env.S3_REGION || process.env.R2_REGION || (provider === "r2" ? "auto" : "us-east-1");
+
+  if (!endpoint || !bucket || !accessKeyId || !secretAccessKey) return null;
+
+  return {
+    provider,
+    endpoint,
+    region,
+    bucket,
+    accessKeyId,
+    secretAccessKey,
+    forcePathStyle: process.env.S3_FORCE_PATH_STYLE !== "false",
+    keyPrefix: cleanPrefix(process.env.DOCUMENT_STORAGE_PREFIX),
+    publicBaseUrl: process.env.S3_PUBLIC_BASE_URL || process.env.R2_PUBLIC_BASE_URL || null,
+  };
+}
+
+function requiredConfigDetail(provider: Extract<DocumentStorageProviderId, "s3" | "r2">) {
+  const missing = [
+    ["S3_ENDPOINT/R2_ENDPOINT", process.env.S3_ENDPOINT || process.env.R2_ENDPOINT],
+    ["S3_BUCKET/R2_BUCKET", process.env.S3_BUCKET || process.env.R2_BUCKET],
+    ["S3_ACCESS_KEY_ID/R2_ACCESS_KEY_ID", process.env.S3_ACCESS_KEY_ID || process.env.R2_ACCESS_KEY_ID],
+    ["S3_SECRET_ACCESS_KEY/R2_SECRET_ACCESS_KEY", process.env.S3_SECRET_ACCESS_KEY || process.env.R2_SECRET_ACCESS_KEY],
+  ]
+    .filter(([, value]) => !value)
+    .map(([key]) => key);
+
+  if (missing.length === 0) {
+    return `${provider.toUpperCase()} storage is configured for durable object storage.`;
+  }
+
+  return `Missing ${missing.join(", ")} for ${provider.toUpperCase()} document storage.`;
+}
+
+function hashHex(input: string | Buffer | Uint8Array) {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function hmac(key: Buffer | string, value: string) {
+  return createHmac("sha256", key).update(value).digest();
+}
+
+function hmacHex(key: Buffer | string, value: string) {
+  return createHmac("sha256", key).update(value).digest("hex");
+}
+
+function amzDateParts(date = new Date()) {
+  const iso = date.toISOString().replace(/[:-]|\.\d{3}/g, "");
+  return {
+    amzDate: iso,
+    dateStamp: iso.slice(0, 8),
+  };
+}
+
+function signingKey(secretAccessKey: string, dateStamp: string, region: string) {
+  const dateKey = hmac(`AWS4${secretAccessKey}`, dateStamp);
+  const regionKey = hmac(dateKey, region);
+  const serviceKey = hmac(regionKey, "s3");
+  return hmac(serviceKey, "aws4_request");
+}
+
+function buildObjectUrl(config: S3CompatibleConfig, key: string) {
+  const endpoint = new URL(config.endpoint);
+  const encodedKey = encodeObjectKey(key);
+  const basePath = endpoint.pathname.replace(/\/+$/g, "");
+
+  if (config.forcePathStyle) {
+    const canonicalUri = `${basePath}/${awsEncode(config.bucket)}/${encodedKey}`.replace(/\/+/g, "/");
+    return {
+      url: `${endpoint.protocol}//${endpoint.host}${canonicalUri}`,
+      host: endpoint.host,
+      canonicalUri,
+    };
+  }
+
+  const host = `${config.bucket}.${endpoint.host}`;
+  const canonicalUri = `${basePath}/${encodedKey}`.replace(/\/+/g, "/");
+  return {
+    url: `${endpoint.protocol}//${host}${canonicalUri}`,
+    host,
+    canonicalUri,
+  };
+}
+
+function toArrayBuffer(input: Buffer | Uint8Array | string) {
+  const source = typeof input === "string" ? Buffer.from(input) : Buffer.from(input);
+  const arrayBuffer = new ArrayBuffer(source.byteLength);
+  new Uint8Array(arrayBuffer).set(source);
+  return arrayBuffer;
+}
+
+function signedRequestInit(
+  config: S3CompatibleConfig,
+  method: "GET" | "PUT" | "DELETE",
+  key: string,
+  payload: Buffer | Uint8Array | string = "",
+  contentType?: string
+) {
+  const payloadHash = method === "GET" || method === "DELETE" ? EMPTY_BODY_HASH : hashHex(payload);
+  const { amzDate, dateStamp } = amzDateParts();
+  const scope = `${dateStamp}/${config.region}/s3/aws4_request`;
+  const objectUrl = buildObjectUrl(config, key);
+
+  const signedHeaders = "host;x-amz-content-sha256;x-amz-date";
+  const canonicalHeaders = [
+    `host:${objectUrl.host}`,
+    `x-amz-content-sha256:${payloadHash}`,
+    `x-amz-date:${amzDate}`,
+    "",
+  ].join("\n");
+
+  const canonicalRequest = [
+    method,
+    objectUrl.canonicalUri,
+    "",
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join("\n");
+
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    amzDate,
+    scope,
+    hashHex(canonicalRequest),
+  ].join("\n");
+
+  const signature = hmacHex(signingKey(config.secretAccessKey, dateStamp, config.region), stringToSign);
+  const authorization = `AWS4-HMAC-SHA256 Credential=${config.accessKeyId}/${scope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
+
+  const headers: Record<string, string> = {
+    Authorization: authorization,
+    "x-amz-content-sha256": payloadHash,
+    "x-amz-date": amzDate,
+  };
+
+  if (contentType) headers["Content-Type"] = contentType;
+
+  return {
+    url: objectUrl.url,
+    init: {
+      method,
+      headers,
+      body: method === "PUT" ? toArrayBuffer(payload) : undefined,
+    } satisfies RequestInit,
+  };
+}
+
+function ensureConfig(provider: Extract<DocumentStorageProviderId, "s3" | "r2">) {
+  const config = getProviderConfig(provider);
+  if (!config) {
+    throw new Error(requiredConfigDetail(provider));
+  }
+  return config;
+}
+
+function toResolved(provider: Extract<DocumentStorageProviderId, "s3" | "r2">, key: string | null | undefined): ResolvedDocumentObject | null {
+  const objectKey = normalizeObjectKey(key);
+  if (!objectKey) return null;
+
+  return {
+    provider,
+    storage: "private",
+    key: objectKey,
+    filePath: objectKey,
+  };
+}
+
+export function createS3CompatibleDocumentStorageProvider(
+  provider: Extract<DocumentStorageProviderId, "s3" | "r2">
+): DocumentStorageProvider {
+  return {
+    id: provider,
+    label: provider === "r2" ? "Cloudflare R2 object storage" : "S3-compatible object storage",
+
+    async save(input: SaveDocumentObjectInput): Promise<SavedDocumentObject> {
+      const config = ensureConfig(provider);
+      const fileName = `${Date.now()}-${sanitizeOriginalName(input.originalName)}`;
+      const key = `${config.keyPrefix}/${fileName}`;
+      const request = signedRequestInit(config, "PUT", key, input.bytes, input.mimeType || "application/octet-stream");
+      const response = await fetch(request.url, request.init);
+
+      if (!response.ok) {
+        throw new Error(`Document upload failed with ${response.status} ${response.statusText}.`);
+      }
+
+      return {
+        provider,
+        storage: "private",
+        key,
+        filePath: key,
+        fileName,
+        mimeType: input.mimeType,
+        sizeBytes: input.sizeBytes,
+      };
+    },
+
+    async delete(filePath: string | null | undefined) {
+      const resolved = toResolved(provider, filePath);
+      if (!resolved) return;
+      const config = ensureConfig(provider);
+      const request = signedRequestInit(config, "DELETE", resolved.key);
+      const response = await fetch(request.url, request.init);
+
+      if (!response.ok && response.status !== 404) {
+        throw new Error(`Document delete failed with ${response.status} ${response.statusText}.`);
+      }
+    },
+
+    resolve(filePath: string | null | undefined) {
+      return toResolved(provider, filePath);
+    },
+
+    async read(filePath: string) {
+      const resolved = toResolved(provider, filePath);
+      if (!resolved) {
+        throw new Error("Document storage path is invalid.");
+      }
+
+      const config = ensureConfig(provider);
+      const request = signedRequestInit(config, "GET", resolved.key);
+      const response = await fetch(request.url, request.init);
+
+      if (!response.ok) {
+        throw new Error(`Document read failed with ${response.status} ${response.statusText}.`);
+      }
+
+      return {
+        bytes: Buffer.from(await response.arrayBuffer()),
+        resolved,
+      };
+    },
+
+    health(): DocumentStorageHealth {
+      const config = getProviderConfig(provider);
+      if (!config) {
+        return {
+          provider,
+          label: provider === "r2" ? "Cloudflare R2 object storage" : "S3-compatible object storage",
+          mode: "private",
+          ready: false,
+          productionReady: false,
+          detail: requiredConfigDetail(provider),
+        };
+      }
+
+      return {
+        provider,
+        label: provider === "r2" ? "Cloudflare R2 object storage" : "S3-compatible object storage",
+        mode: "private",
+        ready: true,
+        productionReady: true,
+        detail: `${provider.toUpperCase()} object storage is configured for bucket ${config.bucket} with prefix ${config.keyPrefix}.`,
+      };
+    },
+  };
+}


### PR DESCRIPTION
This PR adds Patch 32: Real Cloud Storage Provider.

Changes:
- Adds an S3-compatible document storage provider
- Adds Cloudflare R2-compatible storage support
- Adds environment-based provider selection through DOCUMENT_STORAGE_PROVIDER
- Adds signed upload, read, and delete flows for object storage
- Updates the protected document download route to expose the actual storage provider
- Updates .env.example with S3/R2 configuration
- Updates the deployment checklist with cloud storage setup notes
- Keeps the local filesystem provider as the default for development
- Requires no Prisma migration