### PR TITLE
Expand test coverage for deployment exports and notifications

### DIFF
--- a/docs/PATCH_33_TEST_COVERAGE_V2.md
+++ b/docs/PATCH_33_TEST_COVERAGE_V2.md
@@ -1,0 +1,51 @@
+# Patch 33 — Test Coverage Expansion v2
+
+## Summary
+
+This patch expands automated coverage for newer VitaVault business logic without changing runtime behavior or database schema.
+
+## Added tests
+
+- `tests/deployment-readiness.test.ts`
+- `tests/export-center.test.ts`
+- `tests/notification-center.test.ts`
+
+## Coverage added
+
+### Deployment readiness
+
+- Required environment variables block deployment readiness when missing.
+- Placeholder values are not treated as production-ready.
+- Fully configured required and recommended values calculate a 100% readiness score.
+
+### Export Center v2
+
+- Export readiness scoring.
+- CSV coverage summaries.
+- Report packet generation.
+- Document link and medication adherence calculations.
+- Pre-export action items for profile gaps, document gaps, alerts, labs, and symptoms.
+- Healthy fallback action when no review items exist.
+
+### Notification Center
+
+- Multi-source notification aggregation.
+- Priority sorting.
+- Source filtering.
+- Priority filtering.
+- Counts by source.
+- Recommended next-action messaging.
+
+## Risk
+
+Low. This patch only adds tests and documentation.
+
+## Validation
+
+Run:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:run
+```

--- a/tests/deployment-readiness.test.ts
+++ b/tests/deployment-readiness.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getDeploymentChecks, getDeploymentReadinessSummary } from "@/lib/deployment-readiness";
+
+const trackedKeys = [
+  "DATABASE_URL",
+  "AUTH_SECRET",
+  "NEXTAUTH_URL",
+  "APP_URL",
+  "REDIS_URL",
+  "INTERNAL_API_SECRET",
+  "RESEND_API_KEY",
+  "RESEND_FROM_EMAIL",
+  "OPENAI_API_KEY",
+  "DOCUMENT_STORAGE_MODE",
+  "PRIVATE_UPLOAD_DIR",
+  "HEALTHCHECK_URL",
+];
+
+const originalEnv = { ...process.env };
+
+function clearTrackedEnv() {
+  for (const key of trackedKeys) {
+    delete process.env[key];
+  }
+}
+
+describe("deployment readiness", () => {
+  beforeEach(() => {
+    clearTrackedEnv();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("marks required environment variables as blocking when missing", () => {
+    const summary = getDeploymentReadinessSummary();
+
+    expect(summary.requiredTotal).toBeGreaterThanOrEqual(4);
+    expect(summary.requiredConfigured).toBe(0);
+    expect(summary.blockingIssues.map((item) => item.key)).toEqual(
+      expect.arrayContaining(["DATABASE_URL", "AUTH_SECRET", "NEXTAUTH_URL", "APP_URL"]),
+    );
+    expect(summary.score).toBe(0);
+  });
+
+  it("does not treat placeholder values as production-ready", () => {
+    process.env.DATABASE_URL = "postgresql://user:password@localhost:5432/db_name";
+    process.env.AUTH_SECRET = "change-this-secret";
+    process.env.NEXTAUTH_URL = "https://example.com";
+    process.env.APP_URL = "https://example.com";
+
+    const checks = getDeploymentChecks();
+    const required = checks.filter((item) => item.category === "required");
+
+    expect(required.every((item) => item.configured === false)).toBe(true);
+    expect(required.every((item) => item.tone === "danger")).toBe(true);
+  });
+
+  it("calculates readiness when required and recommended services are configured", () => {
+    process.env.DATABASE_URL = "postgresql://demo:demo@localhost:5432/vitavault";
+    process.env.AUTH_SECRET = "super-long-random-secret-for-tests";
+    process.env.NEXTAUTH_URL = "http://localhost:3000";
+    process.env.APP_URL = "http://localhost:3000";
+    process.env.REDIS_URL = "redis://127.0.0.1:6379";
+    process.env.INTERNAL_API_SECRET = "internal-secret";
+    process.env.RESEND_API_KEY = "re_test_key";
+    process.env.RESEND_FROM_EMAIL = "VitaVault <noreply@example.test>";
+    process.env.OPENAI_API_KEY = "sk-test";
+    process.env.DOCUMENT_STORAGE_MODE = "private";
+    process.env.PRIVATE_UPLOAD_DIR = "./private-uploads";
+
+    const summary = getDeploymentReadinessSummary();
+
+    expect(summary.blockingIssues).toHaveLength(0);
+    expect(summary.requiredConfigured).toBe(summary.requiredTotal);
+    expect(summary.recommendedConfigured).toBe(summary.recommendedTotal);
+    expect(summary.score).toBe(100);
+  });
+});

--- a/tests/export-center.test.ts
+++ b/tests/export-center.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireUserMock = vi.fn();
+const healthProfileFindUniqueMock = vi.fn();
+const countMock = vi.fn();
+
+vi.mock("@/lib/session", () => ({
+  requireUser: requireUserMock,
+}));
+
+vi.mock("@/lib/export-definitions", () => ({
+  exportDefinitions: [
+    { type: "medications", label: "Medications" },
+    { type: "labs", label: "Labs" },
+    { type: "vitals", label: "Vitals" },
+  ],
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    healthProfile: { findUnique: healthProfileFindUniqueMock },
+    medication: { count: countMock },
+    medicationLog: { count: countMock },
+    appointment: { count: countMock },
+    labResult: { count: countMock },
+    vitalRecord: { count: countMock },
+    symptomEntry: { count: countMock },
+    vaccinationRecord: { count: countMock },
+    medicalDocument: { count: countMock },
+    reminder: { count: countMock },
+    alertEvent: { count: countMock },
+    doctor: { count: countMock },
+  },
+}));
+
+describe("export center data", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    requireUserMock.mockReset();
+    healthProfileFindUniqueMock.mockReset();
+    countMock.mockReset();
+
+    requireUserMock.mockResolvedValue({ id: "user_1", role: "PATIENT" });
+  });
+
+  it("builds readiness, packet, and pre-export action signals", async () => {
+    healthProfileFindUniqueMock.mockResolvedValue({
+      fullName: "Demo Patient",
+      dateOfBirth: new Date("1998-01-01T00:00:00.000Z"),
+      emergencyContactName: "Demo Contact",
+      emergencyContactPhone: "+639000000000",
+    });
+
+    countMock
+      .mockResolvedValueOnce(2) // medications
+      .mockResolvedValueOnce(10) // medication logs 30d
+      .mockResolvedValueOnce(2) // missed/skipped medication logs 30d
+      .mockResolvedValueOnce(3) // appointments
+      .mockResolvedValueOnce(1) // upcoming appointments
+      .mockResolvedValueOnce(4) // labs
+      .mockResolvedValueOnce(2) // abnormal labs
+      .mockResolvedValueOnce(5) // vitals
+      .mockResolvedValueOnce(3) // symptoms
+      .mockResolvedValueOnce(1) // severe open symptoms
+      .mockResolvedValueOnce(2) // vaccinations
+      .mockResolvedValueOnce(4) // documents
+      .mockResolvedValueOnce(2) // linked documents
+      .mockResolvedValueOnce(6) // reminders
+      .mockResolvedValueOnce(1) // active reminders
+      .mockResolvedValueOnce(3) // open alerts
+      .mockResolvedValueOnce(1) // high-risk alerts
+      .mockResolvedValueOnce(2); // doctors
+
+    const { getExportCenterData } = await import("@/lib/export-center");
+    const data = await getExportCenterData();
+
+    expect(data.summary.readinessScore).toBe(100);
+    expect(data.summary.csvExportTypes).toBe(3);
+    expect(data.summary.reportPackets).toBe(4);
+    expect(data.summary.documentLinkRate).toBe(50);
+    expect(data.summary.medicationAdherenceRate).toBe(80);
+    expect(data.csvCoverage.map((item) => item.label)).toEqual(["Core records", "Monitoring data", "Coordination"]);
+    expect(data.packets.map((item) => item.title)).toEqual(
+      expect.arrayContaining(["Patient summary packet", "Doctor visit packet", "Emergency health card", "Care plan review workspace"]),
+    );
+    expect(data.actionItems.map((item) => item.title)).toEqual(
+      expect.arrayContaining(["Improve document link coverage", "Review high-risk open alerts", "Add lab review context", "Review severe unresolved symptoms"]),
+    );
+  });
+
+  it("falls back to a healthy export action when no review items exist", async () => {
+    healthProfileFindUniqueMock.mockResolvedValue({
+      fullName: "Demo Patient",
+      dateOfBirth: new Date("1998-01-01T00:00:00.000Z"),
+      emergencyContactName: "Demo Contact",
+      emergencyContactPhone: "+639000000000",
+    });
+
+    countMock
+      .mockResolvedValueOnce(1) // medications
+      .mockResolvedValueOnce(4) // medication logs 30d
+      .mockResolvedValueOnce(0) // missed/skipped medication logs 30d
+      .mockResolvedValueOnce(1) // appointments
+      .mockResolvedValueOnce(1) // upcoming appointments
+      .mockResolvedValueOnce(1) // labs
+      .mockResolvedValueOnce(0) // abnormal labs
+      .mockResolvedValueOnce(1) // vitals
+      .mockResolvedValueOnce(0) // symptoms
+      .mockResolvedValueOnce(0) // severe open symptoms
+      .mockResolvedValueOnce(1) // vaccinations
+      .mockResolvedValueOnce(2) // documents
+      .mockResolvedValueOnce(2) // linked documents
+      .mockResolvedValueOnce(1) // reminders
+      .mockResolvedValueOnce(0) // active reminders
+      .mockResolvedValueOnce(0) // open alerts
+      .mockResolvedValueOnce(0) // high-risk alerts
+      .mockResolvedValueOnce(1); // doctors
+
+    const { getExportCenterData } = await import("@/lib/export-center");
+    const data = await getExportCenterData();
+
+    expect(data.summary.documentLinkRate).toBe(100);
+    expect(data.summary.medicationAdherenceRate).toBe(100);
+    expect(data.actionItems).toHaveLength(1);
+    expect(data.actionItems[0]?.title).toBe("Export readiness looks healthy");
+  });
+});

--- a/tests/notification-center.test.ts
+++ b/tests/notification-center.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AlertSeverity,
+  AlertStatus,
+  AppointmentStatus,
+  CareAccessStatus,
+  DeviceConnectionStatus,
+  LabFlag,
+  ReminderState,
+} from "@prisma/client";
+
+const alertFindManyMock = vi.fn();
+const reminderFindManyMock = vi.fn();
+const appointmentFindManyMock = vi.fn();
+const labFindManyMock = vi.fn();
+const documentFindManyMock = vi.fn();
+const careInviteFindManyMock = vi.fn();
+const deviceConnectionFindManyMock = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    alertEvent: { findMany: alertFindManyMock },
+    reminder: { findMany: reminderFindManyMock },
+    appointment: { findMany: appointmentFindManyMock },
+    labResult: { findMany: labFindManyMock },
+    medicalDocument: { findMany: documentFindManyMock },
+    careInvite: { findMany: careInviteFindManyMock },
+    deviceConnection: { findMany: deviceConnectionFindManyMock },
+  },
+}));
+
+describe("notification center data", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    alertFindManyMock.mockReset();
+    reminderFindManyMock.mockReset();
+    appointmentFindManyMock.mockReset();
+    labFindManyMock.mockReset();
+    documentFindManyMock.mockReset();
+    careInviteFindManyMock.mockReset();
+    deviceConnectionFindManyMock.mockReset();
+  });
+
+  it("merges, prioritizes, and filters notification sources", async () => {
+    const now = new Date();
+    const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
+    const twoHoursAgo = new Date(now.getTime() - 2 * 60 * 60 * 1000);
+    const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+
+    alertFindManyMock.mockResolvedValue([
+      {
+        id: "alert_1",
+        title: "Critical blood pressure alert",
+        message: "Blood pressure is outside the safe range.",
+        severity: AlertSeverity.CRITICAL,
+        status: AlertStatus.OPEN,
+        category: "VITAL",
+        createdAt: oneHourAgo,
+      },
+    ]);
+    reminderFindManyMock.mockResolvedValue([
+      {
+        id: "reminder_1",
+        title: "Take medication",
+        description: "Morning dose",
+        state: ReminderState.OVERDUE,
+        type: "MEDICATION",
+        dueAt: twoHoursAgo,
+        createdAt: twoHoursAgo,
+      },
+    ]);
+    appointmentFindManyMock.mockResolvedValue([
+      {
+        id: "appointment_1",
+        purpose: "Follow-up visit",
+        doctorName: "Dr. Santos",
+        clinic: "Main Clinic",
+        scheduledAt: tomorrow,
+        createdAt: oneHourAgo,
+      },
+    ]);
+    labFindManyMock.mockResolvedValue([
+      {
+        id: "lab_1",
+        testName: "A1C",
+        resultSummary: "Above range",
+        flag: LabFlag.HIGH,
+        dateTaken: twoHoursAgo,
+        createdAt: twoHoursAgo,
+      },
+    ]);
+    documentFindManyMock.mockResolvedValue([
+      {
+        id: "document_1",
+        title: "Lab PDF",
+        type: "LAB_RESULT",
+        fileName: "lab.pdf",
+        linkedRecordType: null,
+        notes: null,
+        createdAt: twoHoursAgo,
+      },
+    ]);
+    careInviteFindManyMock.mockResolvedValue([
+      {
+        id: "invite_1",
+        email: "care@example.com",
+        accessRole: "CAREGIVER",
+        status: CareAccessStatus.PENDING,
+        expiresAt: tomorrow,
+        createdAt: oneHourAgo,
+      },
+    ]);
+    deviceConnectionFindManyMock.mockResolvedValue([
+      {
+        id: "device_1",
+        source: "SMART_BP_MONITOR",
+        platform: "demo",
+        deviceLabel: "Smart BP Monitor",
+        status: DeviceConnectionStatus.ERROR,
+        lastSyncedAt: twoHoursAgo,
+        lastError: "Sync failed",
+        createdAt: twoHoursAgo,
+        updatedAt: oneHourAgo,
+      },
+    ]);
+
+    const { getNotificationCenterData } = await import("@/lib/notification-center");
+    const allData = await getNotificationCenterData("user_1");
+    const alertOnly = await getNotificationCenterData("user_1", { source: "ALERT" });
+    const highOnly = await getNotificationCenterData("user_1", { priority: "high" });
+
+    expect(allData.counts.total).toBe(7);
+    expect(allData.counts.critical).toBe(1);
+    expect(allData.counts.high).toBeGreaterThanOrEqual(3);
+    expect(allData.items[0]?.priority).toBe("critical");
+    expect(alertOnly.items).toHaveLength(1);
+    expect(alertOnly.items[0]?.source).toBe("ALERT");
+    expect(highOnly.items.every((item) => item.priority === "high")).toBe(true);
+    expect(allData.counts.bySource.find((item) => item.source === "DEVICE")?.count).toBe(1);
+    expect(allData.nextActions).toContain("Review high-priority alerts, abnormal labs, or device errors first.");
+  });
+});


### PR DESCRIPTION
This PR adds Patch 33: Test Coverage Expansion v2.

Changes:
- Adds deployment readiness tests for missing, placeholder, and fully configured environment states
- Adds Export Center v2 tests for readiness scoring, CSV coverage, report packets, action items, document link rate, and medication adherence rate
- Adds Notification Center tests for source aggregation, priority sorting, source filtering, priority filtering, source counts, and next-action messaging
- Expands regression coverage for newer VitaVault workflow modules
- Requires no Prisma migration