### PR TITLE
Upgrade patient timeline

### DIFF
--- a/app/timeline/page.tsx
+++ b/app/timeline/page.tsx
@@ -1,48 +1,222 @@
 import Link from "next/link";
-import { AppShell } from "@/components/app-shell";
-import { PageHeader, StatusPill } from "@/components/common";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
-import { requireUser } from "@/lib/session";
-import { getTimelineItems } from "@/lib/timeline";
+import { CalendarDays, Download, Filter, Search, ShieldAlert, Workflow } from "lucide-react";
 
-export default async function TimelinePage() {
+import { AppShell } from "@/components/app-shell";
+import { EmptyState, PageHeader, StatusPill } from "@/components/common";
+import { Badge, Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Input, Label, Select } from "@/components/ui";
+import { requireUser } from "@/lib/session";
+import { getTimelineWorkspaceData, type TimelineItem, type TimelineTone } from "@/lib/timeline";
+
+function formatDateTime(value: Date | null | undefined) {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat("en-PH", { dateStyle: "medium", timeStyle: "short" }).format(value);
+}
+
+function typeLabel(value: string) {
+  return value.replaceAll("_", " ").toLowerCase().replace(/(^|\s)\S/g, (letter) => letter.toUpperCase());
+}
+
+function timelineToneLabel(tone: TimelineTone) {
+  if (tone === "danger") return "Urgent";
+  if (tone === "warning") return "Watch";
+  if (tone === "success") return "Resolved";
+  if (tone === "info") return "Info";
+  return "Routine";
+}
+
+function StatCard({ title, value, description }: { title: string; value: string | number; description: string }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardDescription>{title}</CardDescription>
+        <CardTitle className="mt-2 text-3xl">{value}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function TimelineItemCard({ item }: { item: TimelineItem }) {
+  return (
+    <Link href={item.href} className="block rounded-3xl border border-border/60 bg-background/40 p-5 transition hover:border-border hover:bg-muted/30">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <StatusPill tone={item.tone}>{typeLabel(item.type)}</StatusPill>
+            <StatusPill tone={item.riskLevel === "urgent" ? "danger" : item.riskLevel === "watch" ? "warning" : "neutral"}>{item.riskLevel}</StatusPill>
+          </div>
+          <p className="text-sm font-semibold">{item.title}</p>
+          <p className="max-w-3xl text-sm text-muted-foreground">{item.description}</p>
+        </div>
+        <div className="text-right text-xs text-muted-foreground">
+          <p>{formatDateTime(item.occurredAt)}</p>
+          <p className="mt-1">{item.source}</p>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+export default async function TimelinePage({ searchParams }: { searchParams?: Promise<Record<string, string | string[] | undefined>> }) {
   const user = await requireUser();
-  const items = await getTimelineItems(user.id!);
+  const params = (await searchParams) ?? {};
+  const filters = {
+    type: typeof params.type === "string" ? params.type : "all",
+    tone: typeof params.tone === "string" ? params.tone : "all",
+    q: typeof params.q === "string" ? params.q : "",
+    from: typeof params.from === "string" ? params.from : "",
+    to: typeof params.to === "string" ? params.to : "",
+  };
+  const data = await getTimelineWorkspaceData(user.id!, filters);
+
+  const printParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(data.appliedFilters)) {
+    if (value && value !== "all") printParams.set(key, value);
+  }
+  const printHref = `/timeline/print${printParams.toString() ? `?${printParams.toString()}` : ""}`;
 
   return (
     <AppShell>
-      <div className="mx-auto max-w-6xl space-y-6 p-6">
+      <div className="mx-auto max-w-7xl space-y-6 p-6">
         <PageHeader
           title="Patient timeline"
-          description="A single chronological view of appointments, labs, vitals, symptoms, medications, reminders, and documents."
-          action={<Link href="/dashboard" className="inline-flex items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 py-2 text-sm font-medium hover:bg-muted/50">Back to dashboard</Link>}
+          description="A filterable longitudinal view of records, care events, risks, reminders, documents, and handoff context."
+          action={
+            <div className="flex flex-wrap gap-2">
+              <Link href={printHref} className="inline-flex h-10 items-center justify-center gap-2 rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium transition-all hover:border-border hover:bg-muted/60">
+                <Download className="h-4 w-4" /> Print timeline
+              </Link>
+              <Link href="/summary" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium transition-all hover:border-border hover:bg-muted/60">Patient summary</Link>
+            </div>
+          }
         />
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+          <StatCard title="Visible events" value={data.summary.visibleItems} description={`${data.summary.totalItems} total timeline records loaded.`} />
+          <StatCard title="Urgent" value={data.summary.urgentItems} description="Severe symptoms or critical alert events in the current view." />
+          <StatCard title="Watch" value={data.summary.watchItems} description="Warning-state labs, reminders, appointments, or moderate symptoms." />
+          <StatCard title="Documents" value={data.summary.documentItems} description="Medical files represented in the current timeline view." />
+          <StatCard title="Record types" value={data.summary.recordTypesCovered} description="Distinct clinical and workflow sources present in history." />
+        </div>
 
         <Card>
           <CardHeader>
-            <CardTitle>Recent history</CardTitle>
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <CardTitle className="flex items-center gap-2"><Filter className="h-5 w-5" /> Timeline filters</CardTitle>
+                <CardDescription>Filter by source, status tone, date range, or keyword before printing a handoff timeline.</CardDescription>
+              </div>
+              <Badge>{formatDateTime(data.summary.oldestItemAt)} → {formatDateTime(data.summary.newestItemAt)}</Badge>
+            </div>
           </CardHeader>
-          <CardContent className="space-y-4">
-            {items.length ? (
-              items.map((item) => (
-                <Link key={`${item.type}-${item.id}`} href={item.href} className="block rounded-3xl border border-border/60 bg-background/40 p-5 transition hover:bg-muted/30">
-                  <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div>
-                      <p className="text-sm font-semibold">{item.title}</p>
-                      <p className="mt-1 text-sm text-muted-foreground">{item.description}</p>
-                    </div>
-                    <div className="flex flex-wrap gap-2">
-                      <StatusPill tone={item.tone}>{item.type.replaceAll("_", " ")}</StatusPill>
-                    </div>
-                  </div>
-                  <div className="mt-3 text-xs text-muted-foreground">{new Date(item.occurredAt).toLocaleString()}</div>
-                </Link>
-              ))
-            ) : (
-              <div className="rounded-3xl border border-dashed border-border/60 bg-background/40 p-5 text-sm text-muted-foreground">No timeline items yet.</div>
-            )}
+          <CardContent>
+            <form className="grid gap-4 lg:grid-cols-[1.2fr_0.8fr_0.8fr_0.8fr_0.8fr_auto]" action="/timeline">
+              <div className="space-y-2">
+                <Label htmlFor="q">Search</Label>
+                <div className="relative">
+                  <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input id="q" name="q" defaultValue={data.appliedFilters.q} placeholder="Search title, notes, source..." className="pl-9" />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="type">Record type</Label>
+                <Select id="type" name="type" defaultValue={data.appliedFilters.type}>
+                  <option value="all">All types</option>
+                  {data.availableTypes.map((type) => <option key={type} value={type}>{typeLabel(type)}</option>)}
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="tone">Tone</Label>
+                <Select id="tone" name="tone" defaultValue={data.appliedFilters.tone}>
+                  <option value="all">All tones</option>
+                  {data.availableTones.map((tone) => <option key={tone} value={tone}>{timelineToneLabel(tone)}</option>)}
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="from">From</Label>
+                <Input id="from" name="from" type="date" defaultValue={data.appliedFilters.from} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="to">To</Label>
+                <Input id="to" name="to" type="date" defaultValue={data.appliedFilters.to} />
+              </div>
+              <div className="flex items-end gap-2">
+                <Button type="submit">Apply</Button>
+                <Link href="/timeline" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium transition hover:bg-muted/60">Reset</Link>
+              </div>
+            </form>
           </CardContent>
         </Card>
+
+        <div className="grid gap-6 xl:grid-cols-[0.72fr_1.28fr]">
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2"><ShieldAlert className="h-5 w-5" /> Timeline risk markers</CardTitle>
+                <CardDescription>Use these as quick handoff signals before a visit or export.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <div className="rounded-2xl border border-border/60 bg-background/50 p-4">
+                  <div className="flex items-center justify-between"><span className="text-sm font-medium">Urgent records</span><StatusPill tone={data.summary.urgentItems ? "danger" : "success"}>{data.summary.urgentItems}</StatusPill></div>
+                  <p className="mt-2 text-sm text-muted-foreground">Critical alert or severe unresolved symptom events in the current view.</p>
+                </div>
+                <div className="rounded-2xl border border-border/60 bg-background/50 p-4">
+                  <div className="flex items-center justify-between"><span className="text-sm font-medium">Watch records</span><StatusPill tone={data.summary.watchItems ? "warning" : "success"}>{data.summary.watchItems}</StatusPill></div>
+                  <p className="mt-2 text-sm text-muted-foreground">Warning-state items that should be reviewed before sharing the timeline.</p>
+                </div>
+                <div className="rounded-2xl border border-border/60 bg-background/50 p-4">
+                  <div className="flex items-center justify-between"><span className="text-sm font-medium">Coverage</span><StatusPill tone={data.summary.recordTypesCovered >= 5 ? "success" : "warning"}>{data.summary.recordTypesCovered} types</StatusPill></div>
+                  <p className="mt-2 text-sm text-muted-foreground">A stronger handoff includes labs, vitals, symptoms, medications, reminders, and documents.</p>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2"><CalendarDays className="h-5 w-5" /> Month index</CardTitle>
+                <CardDescription>Grouped by month for faster review.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                {data.groups.map((group) => (
+                  <a key={group.key} href={`#month-${group.key}`} className="flex items-center justify-between rounded-2xl border border-border/60 bg-background/50 px-4 py-3 text-sm transition hover:bg-muted/50">
+                    <span>{group.label}</span>
+                    <span className="text-muted-foreground">{group.items.length} events{group.riskCount ? ` • ${group.riskCount} risk` : ""}</span>
+                  </a>
+                ))}
+                {data.groups.length === 0 ? <EmptyState title="No months to show" description="Adjust filters to restore timeline results." /> : null}
+              </CardContent>
+            </Card>
+          </div>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2"><CalendarDays className="h-5 w-5" /> Longitudinal history</CardTitle>
+              <CardDescription>Events are grouped by month and ordered from newest to oldest.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-8">
+              {data.groups.map((group) => (
+                <section key={group.key} id={`month-${group.key}`} className="space-y-3 scroll-mt-24">
+                  <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border/60 pb-2">
+                    <div className="flex items-center gap-2">
+                      <Workflow className="h-4 w-4 text-muted-foreground" />
+                      <h2 className="font-semibold">{group.label}</h2>
+                    </div>
+                    <div className="flex gap-2">
+                      <Badge>{group.items.length} events</Badge>
+                      {group.riskCount ? <StatusPill tone="warning">{group.riskCount} review</StatusPill> : null}
+                    </div>
+                  </div>
+                  <div className="space-y-3">
+                    {group.items.map((item) => <TimelineItemCard key={`${item.type}-${item.id}`} item={item} />)}
+                  </div>
+                </section>
+              ))}
+              {data.visibleItems.length === 0 ? <EmptyState title="No timeline items found" description="Try clearing filters or adding health records first." /> : null}
+            </CardContent>
+          </Card>
+        </div>
       </div>
     </AppShell>
   );

--- a/app/timeline/print/page.tsx
+++ b/app/timeline/print/page.tsx
@@ -1,0 +1,89 @@
+import { AutoPrintOnLoad } from "@/components/auto-print-on-load";
+import { StatusPill } from "@/components/common";
+import { requireUser } from "@/lib/session";
+import { getTimelineWorkspaceData, type TimelineItem } from "@/lib/timeline";
+
+function formatDateTime(value: Date | null | undefined) {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat("en-PH", { dateStyle: "medium", timeStyle: "short" }).format(value);
+}
+
+function typeLabel(value: string) {
+  return value.replaceAll("_", " ").toLowerCase().replace(/(^|\s)\S/g, (letter) => letter.toUpperCase());
+}
+
+function PrintTimelineItem({ item }: { item: TimelineItem }) {
+  return (
+    <div className="break-inside-avoid rounded-2xl border border-slate-200 p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="mb-2 flex flex-wrap gap-2">
+            <StatusPill tone={item.tone}>{typeLabel(item.type)}</StatusPill>
+            <StatusPill tone={item.riskLevel === "urgent" ? "danger" : item.riskLevel === "watch" ? "warning" : "neutral"}>{item.riskLevel}</StatusPill>
+          </div>
+          <h3 className="font-semibold text-slate-950">{item.title}</h3>
+          <p className="mt-1 text-sm text-slate-600">{item.description}</p>
+        </div>
+        <p className="whitespace-nowrap text-right text-xs text-slate-500">{formatDateTime(item.occurredAt)}</p>
+      </div>
+    </div>
+  );
+}
+
+export default async function TimelinePrintPage({ searchParams }: { searchParams?: Promise<Record<string, string | string[] | undefined>> }) {
+  const user = await requireUser();
+  const params = (await searchParams) ?? {};
+  const filters = {
+    type: typeof params.type === "string" ? params.type : "all",
+    tone: typeof params.tone === "string" ? params.tone : "all",
+    q: typeof params.q === "string" ? params.q : "",
+    from: typeof params.from === "string" ? params.from : "",
+    to: typeof params.to === "string" ? params.to : "",
+  };
+  const autoprint = params.autoprint === "1";
+  const data = await getTimelineWorkspaceData(user.id!, filters);
+
+  return (
+    <main className="min-h-screen bg-white p-8 text-slate-950 print:p-0">
+      {autoprint ? <AutoPrintOnLoad /> : null}
+      <div className="mx-auto max-w-5xl space-y-8 print:max-w-none">
+        <header className="border-b border-slate-200 pb-6">
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500">VitaVault</p>
+          <div className="mt-3 flex flex-wrap items-end justify-between gap-4">
+            <div>
+              <h1 className="text-3xl font-bold tracking-tight">Patient Timeline Packet</h1>
+              <p className="mt-2 text-sm text-slate-600">Generated {formatDateTime(new Date())}</p>
+            </div>
+            <div className="text-right text-sm text-slate-600">
+              <p>{data.summary.visibleItems} visible events</p>
+              <p>{data.summary.urgentItems} urgent • {data.summary.watchItems} watch</p>
+            </div>
+          </div>
+        </header>
+
+        <section className="grid gap-4 sm:grid-cols-4">
+          <div className="rounded-2xl border border-slate-200 p-4"><p className="text-xs text-slate-500">Events</p><p className="mt-1 text-2xl font-bold">{data.summary.visibleItems}</p></div>
+          <div className="rounded-2xl border border-slate-200 p-4"><p className="text-xs text-slate-500">Urgent</p><p className="mt-1 text-2xl font-bold">{data.summary.urgentItems}</p></div>
+          <div className="rounded-2xl border border-slate-200 p-4"><p className="text-xs text-slate-500">Watch</p><p className="mt-1 text-2xl font-bold">{data.summary.watchItems}</p></div>
+          <div className="rounded-2xl border border-slate-200 p-4"><p className="text-xs text-slate-500">Types</p><p className="mt-1 text-2xl font-bold">{data.summary.recordTypesCovered}</p></div>
+        </section>
+
+        {data.groups.map((group) => (
+          <section key={group.key} className="break-inside-avoid space-y-3">
+            <div className="flex items-center justify-between border-b border-slate-200 pb-2">
+              <h2 className="text-xl font-semibold">{group.label}</h2>
+              <p className="text-sm text-slate-500">{group.items.length} events{group.riskCount ? ` • ${group.riskCount} review` : ""}</p>
+            </div>
+            <div className="space-y-3">
+              {group.items.map((item) => <PrintTimelineItem key={`${item.type}-${item.id}`} item={item} />)}
+            </div>
+          </section>
+        ))}
+
+        {data.visibleItems.length === 0 ? (
+          <div className="rounded-2xl border border-dashed border-slate-300 p-6 text-sm text-slate-600">No timeline items matched the selected filters.</div>
+        ) : null}
+      </div>
+    </main>
+  );
+}

--- a/docs/PATCH_35B_TIMELINE_TYPECHECK_FIX.md
+++ b/docs/PATCH_35B_TIMELINE_TYPECHECK_FIX.md
@@ -1,0 +1,19 @@
+# Patch 35B — Timeline Typecheck Fix
+
+This hotfix cleans up validation issues after Patch 35.
+
+## Changes
+
+- Replaces the unsupported `Timeline` lucide icon import with the already-supported `CalendarDays` icon on the timeline page.
+- Removes an unused `AppointmentStatus` import from the notification center test.
+- Keeps Patient Timeline v2 behavior unchanged.
+
+## Validation
+
+Run:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:run
+```

--- a/docs/PATCH_35_PATIENT_TIMELINE_V2.md
+++ b/docs/PATCH_35_PATIENT_TIMELINE_V2.md
@@ -1,0 +1,36 @@
+# Patch 35 — Patient Timeline v2
+
+## Summary
+
+This patch upgrades VitaVault's patient timeline into a stronger longitudinal health history workspace.
+
+## Added
+
+- Filterable `/timeline` workspace
+- Search across timeline title, description, source, type, tone, and risk level
+- Record type filter
+- Tone/status filter
+- Date range filters
+- Month-grouped timeline sections
+- Month index sidebar
+- Risk markers for urgent and watch items
+- Timeline summary cards
+- Print-ready `/timeline/print` route
+- Filter-aware print timeline packet
+
+## Sources included
+
+- Appointments
+- Lab results
+- Vitals
+- Symptoms
+- Vaccinations
+- Documents
+- Reminders
+- Alerts
+
+## Notes
+
+- No Prisma migration required.
+- Existing `getTimelineItems()` behavior remains compatible while adding richer metadata.
+- The print route reuses the same filters as the main timeline page.

--- a/lib/timeline.ts
+++ b/lib/timeline.ts
@@ -14,6 +14,16 @@ export type TimelineItemType =
   | "REMINDER"
   | "ALERT";
 
+export type TimelineRiskLevel = "routine" | "watch" | "urgent";
+
+export type TimelineFilters = {
+  type?: string;
+  tone?: string;
+  q?: string;
+  from?: string;
+  to?: string;
+};
+
 export type TimelineItem = {
   id: string;
   type: TimelineItemType;
@@ -22,6 +32,39 @@ export type TimelineItem = {
   occurredAt: Date;
   href: string;
   tone: TimelineTone;
+  riskLevel: TimelineRiskLevel;
+  source: string;
+  monthKey: string;
+  monthLabel: string;
+  searchText: string;
+};
+
+export type TimelineMonthGroup = {
+  key: string;
+  label: string;
+  items: TimelineItem[];
+  riskCount: number;
+};
+
+export type TimelineSummary = {
+  totalItems: number;
+  visibleItems: number;
+  urgentItems: number;
+  watchItems: number;
+  documentItems: number;
+  recordTypesCovered: number;
+  newestItemAt: Date | null;
+  oldestItemAt: Date | null;
+};
+
+export type TimelineWorkspaceData = {
+  allItems: TimelineItem[];
+  visibleItems: TimelineItem[];
+  groups: TimelineMonthGroup[];
+  summary: TimelineSummary;
+  availableTypes: TimelineItemType[];
+  availableTones: TimelineTone[];
+  appliedFilters: Required<TimelineFilters>;
 };
 
 function getAppointmentTone(status: AppointmentStatus): TimelineTone {
@@ -66,7 +109,90 @@ function getReminderTone(state: ReminderState, completed: boolean): TimelineTone
   return "info";
 }
 
-export async function getTimelineItems(userId: string, limit = 100): Promise<TimelineItem[]> {
+function getRiskLevel(tone: TimelineTone): TimelineRiskLevel {
+  if (tone === "danger") return "urgent";
+  if (tone === "warning") return "watch";
+  return "routine";
+}
+
+function getMonthKey(value: Date) {
+  return `${value.getFullYear()}-${String(value.getMonth() + 1).padStart(2, "0")}`;
+}
+
+function getMonthLabel(value: Date) {
+  return new Intl.DateTimeFormat("en-PH", { month: "long", year: "numeric" }).format(value);
+}
+
+function withTimelineMeta(item: Omit<TimelineItem, "riskLevel" | "source" | "monthKey" | "monthLabel" | "searchText"> & { source?: string }): TimelineItem {
+  const riskLevel = getRiskLevel(item.tone);
+  const source = item.source ?? item.type.replaceAll("_", " ");
+  const monthKey = getMonthKey(item.occurredAt);
+  const monthLabel = getMonthLabel(item.occurredAt);
+
+  return {
+    ...item,
+    riskLevel,
+    source,
+    monthKey,
+    monthLabel,
+    searchText: [item.type, item.title, item.description, source, item.tone, riskLevel].join(" ").toLowerCase(),
+  };
+}
+
+function normalizeFilterValue(value: string | undefined, fallback = "all") {
+  const normalized = value?.trim();
+  return normalized ? normalized : fallback;
+}
+
+function parseDateFilter(value: string) {
+  if (!value) return null;
+  const parsed = new Date(`${value}T00:00:00`);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function parseEndDateFilter(value: string) {
+  if (!value) return null;
+  const parsed = new Date(`${value}T23:59:59`);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function applyTimelineFilters(items: TimelineItem[], filters: Required<TimelineFilters>) {
+  const query = filters.q.trim().toLowerCase();
+  const fromDate = parseDateFilter(filters.from);
+  const toDate = parseEndDateFilter(filters.to);
+
+  return items.filter((item) => {
+    if (filters.type !== "all" && item.type !== filters.type) return false;
+    if (filters.tone !== "all" && item.tone !== filters.tone) return false;
+    if (query && !item.searchText.includes(query)) return false;
+    if (fromDate && item.occurredAt < fromDate) return false;
+    if (toDate && item.occurredAt > toDate) return false;
+    return true;
+  });
+}
+
+function groupTimelineItems(items: TimelineItem[]): TimelineMonthGroup[] {
+  const grouped = new Map<string, TimelineMonthGroup>();
+
+  for (const item of items) {
+    const existing = grouped.get(item.monthKey);
+    if (existing) {
+      existing.items.push(item);
+      if (item.riskLevel !== "routine") existing.riskCount += 1;
+    } else {
+      grouped.set(item.monthKey, {
+        key: item.monthKey,
+        label: item.monthLabel,
+        items: [item],
+        riskCount: item.riskLevel !== "routine" ? 1 : 0,
+      });
+    }
+  }
+
+  return Array.from(grouped.values()).sort((a, b) => b.key.localeCompare(a.key));
+}
+
+export async function getTimelineItems(userId: string, limit = 160, filters?: TimelineFilters): Promise<TimelineItem[]> {
   const [appointments, labs, vitals, symptoms, vaccinations, documents, reminders, alerts] = await Promise.all([
     db.appointment.findMany({
       where: { userId },
@@ -111,25 +237,27 @@ export async function getTimelineItems(userId: string, limit = 100): Promise<Tim
   ]);
 
   const items: TimelineItem[] = [
-    ...appointments.map((item): TimelineItem => ({
+    ...appointments.map((item): TimelineItem => withTimelineMeta({
       id: item.id,
       type: "APPOINTMENT",
       title: item.doctorName || item.clinic || "Appointment",
-      description: item.purpose,
+      description: [item.purpose, item.clinic, item.status].filter(Boolean).join(" • "),
       occurredAt: item.scheduledAt,
       href: buildRecordHref("/appointments", item.id),
       tone: getAppointmentTone(item.status),
+      source: "Appointment",
     })),
-    ...labs.map((item): TimelineItem => ({
+    ...labs.map((item): TimelineItem => withTimelineMeta({
       id: item.id,
       type: "LAB_RESULT",
       title: item.testName,
-      description: item.resultSummary,
+      description: [item.resultSummary, item.referenceRange ? `Reference: ${item.referenceRange}` : null, item.flag].filter(Boolean).join(" • "),
       occurredAt: item.dateTaken,
       href: buildRecordHref("/labs", item.id),
       tone: getLabTone(item.flag),
+      source: "Lab result",
     })),
-    ...vitals.map((item): TimelineItem => ({
+    ...vitals.map((item): TimelineItem => withTimelineMeta({
       id: item.id,
       type: "VITAL",
       title: "Vital record",
@@ -140,54 +268,61 @@ export async function getTimelineItems(userId: string, limit = 100): Promise<Tim
           item.temperatureC ? `Temp ${item.temperatureC}°C` : null,
           item.bloodSugar ? `Sugar ${item.bloodSugar}` : null,
           item.oxygenSaturation ? `SpO2 ${item.oxygenSaturation}%` : null,
+          item.weightKg ? `Weight ${item.weightKg}kg` : null,
+          item.readingSource !== "MANUAL" ? `Source: ${item.readingSource}` : null,
         ]
           .filter(Boolean)
           .join(" • ") || "Vital record added",
       occurredAt: item.recordedAt,
       href: buildRecordHref("/vitals", item.id),
       tone: "info",
+      source: "Vital record",
     })),
-    ...symptoms.map((item): TimelineItem => ({
+    ...symptoms.map((item): TimelineItem => withTimelineMeta({
       id: item.id,
       type: "SYMPTOM",
       title: item.title,
-      description: item.notes || item.bodyArea || item.duration || "Symptom recorded",
+      description: [item.severity, item.resolved ? "Resolved" : "Unresolved", item.bodyArea, item.duration, item.notes].filter(Boolean).join(" • "),
       occurredAt: item.startedAt,
       href: buildRecordHref("/symptoms", item.id),
       tone: getSymptomTone(item.severity, item.resolved),
+      source: "Symptom",
     })),
-    ...vaccinations.map((item): TimelineItem => ({
+    ...vaccinations.map((item): TimelineItem => withTimelineMeta({
       id: item.id,
       type: "VACCINATION",
       title: item.vaccineName,
-      description: `Dose ${item.doseNumber}${item.location ? ` • ${item.location}` : ""}`,
+      description: [`Dose ${item.doseNumber}`, item.location, item.nextDueDate ? `Next due ${item.nextDueDate.toLocaleDateString()}` : null].filter(Boolean).join(" • "),
       occurredAt: item.dateTaken,
       href: buildRecordHref("/vaccinations", item.id),
       tone: "success",
+      source: "Vaccination",
     })),
-    ...documents.map((item): TimelineItem => ({
+    ...documents.map((item): TimelineItem => withTimelineMeta({
       id: item.id,
       type: "DOCUMENT",
       title: item.title,
-      description: `${item.type} • ${item.fileName}`,
+      description: [item.type, item.fileName, item.linkedRecordType ? `Linked to ${item.linkedRecordType}` : "Unlinked", item.notes].filter(Boolean).join(" • "),
       occurredAt: item.createdAt,
       href: buildRecordHref("/documents", item.id),
-      tone: "neutral",
+      tone: item.linkedRecordType ? "success" : "neutral",
+      source: "Document",
     })),
-    ...reminders.map((item): TimelineItem => ({
+    ...reminders.map((item): TimelineItem => withTimelineMeta({
       id: item.id,
       type: "REMINDER",
       title: item.title,
-      description: item.description || item.type.replaceAll("_", " "),
+      description: [item.description, item.type.replaceAll("_", " "), item.state].filter(Boolean).join(" • "),
       occurredAt: item.dueAt,
       href: buildRecordHref("/reminders", item.id),
       tone: getReminderTone(item.state, item.completed),
+      source: "Reminder",
     })),
-    ...alerts.map((item): TimelineItem => ({
+    ...alerts.map((item): TimelineItem => withTimelineMeta({
       id: item.id,
       type: "ALERT",
       title: item.title,
-      description: item.message,
+      description: [item.message, item.severity, item.status].filter(Boolean).join(" • "),
       occurredAt: item.createdAt,
       href: `/alerts/${item.id}`,
       tone:
@@ -198,8 +333,55 @@ export async function getTimelineItems(userId: string, limit = 100): Promise<Tim
             : item.status === "RESOLVED"
               ? "success"
               : "info",
+      source: "Alert",
     })),
   ];
 
-  return items.sort((a, b) => b.occurredAt.getTime() - a.occurredAt.getTime()).slice(0, limit);
+  const sorted = items.sort((a, b) => b.occurredAt.getTime() - a.occurredAt.getTime()).slice(0, limit);
+
+  if (!filters) return sorted;
+
+  const appliedFilters = {
+    type: normalizeFilterValue(filters.type),
+    tone: normalizeFilterValue(filters.tone),
+    q: filters.q?.trim() ?? "",
+    from: filters.from?.trim() ?? "",
+    to: filters.to?.trim() ?? "",
+  };
+
+  return applyTimelineFilters(sorted, appliedFilters);
+}
+
+export async function getTimelineWorkspaceData(userId: string, filters: TimelineFilters = {}): Promise<TimelineWorkspaceData> {
+  const appliedFilters = {
+    type: normalizeFilterValue(filters.type),
+    tone: normalizeFilterValue(filters.tone),
+    q: filters.q?.trim() ?? "",
+    from: filters.from?.trim() ?? "",
+    to: filters.to?.trim() ?? "",
+  };
+  const allItems = await getTimelineItems(userId, 220);
+  const visibleItems = applyTimelineFilters(allItems, appliedFilters);
+  const groups = groupTimelineItems(visibleItems);
+  const availableTypes = Array.from(new Set(allItems.map((item) => item.type))).sort();
+  const availableTones = Array.from(new Set(allItems.map((item) => item.tone))).sort();
+
+  return {
+    allItems,
+    visibleItems,
+    groups,
+    availableTypes,
+    availableTones,
+    appliedFilters,
+    summary: {
+      totalItems: allItems.length,
+      visibleItems: visibleItems.length,
+      urgentItems: visibleItems.filter((item) => item.riskLevel === "urgent").length,
+      watchItems: visibleItems.filter((item) => item.riskLevel === "watch").length,
+      documentItems: visibleItems.filter((item) => item.type === "DOCUMENT").length,
+      recordTypesCovered: availableTypes.length,
+      newestItemAt: allItems[0]?.occurredAt ?? null,
+      oldestItemAt: allItems.at(-1)?.occurredAt ?? null,
+    },
+  };
 }

--- a/tests/notification-center.test.ts
+++ b/tests/notification-center.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   AlertSeverity,
   AlertStatus,
-  AppointmentStatus,
   CareAccessStatus,
   DeviceConnectionStatus,
   LabFlag,


### PR DESCRIPTION
This PR adds Patch 35: Patient Timeline v2.

Changes:
- Upgrades /timeline into a filterable longitudinal health history workspace
- Adds search, record type, tone/status, and date range filters
- Adds summary cards for visible events, urgent items, watch items, documents, and record type coverage
- Adds month-grouped timeline sections and a month index sidebar
- Adds urgent/watch/routine risk markers for timeline events
- Adds a print-ready /timeline/print route
- Keeps timeline data sourced from appointments, labs, vitals, symptoms, vaccinations, documents, reminders, and alerts
- Requires no Prisma migration