### PR TITLE
Add notification actions

### DIFF
--- a/app/notifications/actions.ts
+++ b/app/notifications/actions.ts
@@ -1,0 +1,201 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { AlertStatus, ReminderChannel, ReminderSourceType, ReminderState, ReminderType } from "@prisma/client";
+import { db } from "@/lib/db";
+import { requireUser } from "@/lib/session";
+import { createAlertAuditLog } from "@/lib/alerts/audit";
+import { createReminderAuditLog, snoozeReminder, updateReminderState } from "@/lib/reminders/service";
+
+type NotificationSource = "ALERT" | "REMINDER" | "APPOINTMENT" | "LAB" | "DOCUMENT" | "CARE" | "DEVICE";
+
+function requiredString(formData: FormData, key: string) {
+  const value = String(formData.get(key) ?? "").trim();
+  if (!value) throw new Error(`${key} is required.`);
+  return value;
+}
+
+function optionalString(formData: FormData, key: string) {
+  const value = String(formData.get(key) ?? "").trim();
+  return value.length ? value : null;
+}
+
+function parseSource(value: string): NotificationSource {
+  const normalized = value.toUpperCase();
+  if (["ALERT", "REMINDER", "APPOINTMENT", "LAB", "DOCUMENT", "CARE", "DEVICE"].includes(normalized)) {
+    return normalized as NotificationSource;
+  }
+  return "REMINDER";
+}
+
+function followUpDueAt() {
+  const dueAt = new Date();
+  dueAt.setDate(dueAt.getDate() + 1);
+  dueAt.setHours(9, 0, 0, 0);
+  return dueAt;
+}
+
+function revalidateNotificationSurfaces() {
+  revalidatePath("/notifications");
+  revalidatePath("/dashboard");
+  revalidatePath("/care-plan");
+  revalidatePath("/review-queue");
+  revalidatePath("/summary");
+}
+
+export async function acknowledgeNotificationAlertAction(formData: FormData) {
+  const user = await requireUser();
+  const alertId = requiredString(formData, "alertId");
+  const now = new Date();
+
+  await db.alertEvent.updateMany({
+    where: {
+      id: alertId,
+      userId: user.id!,
+      status: AlertStatus.OPEN,
+    },
+    data: {
+      status: AlertStatus.ACKNOWLEDGED,
+      ownerAcknowledgedAt: now,
+    },
+  });
+
+  await createAlertAuditLog({
+    userId: user.id!,
+    alertId,
+    actorUserId: user.id!,
+    action: "notification.alert_acknowledged",
+    note: optionalString(formData, "note") ?? "Acknowledged from Notification Center.",
+  });
+
+  revalidateNotificationSurfaces();
+  revalidatePath("/alerts");
+}
+
+export async function resolveNotificationAlertAction(formData: FormData) {
+  const user = await requireUser();
+  const alertId = requiredString(formData, "alertId");
+  const now = new Date();
+
+  await db.alertEvent.updateMany({
+    where: {
+      id: alertId,
+      userId: user.id!,
+      status: { in: [AlertStatus.OPEN, AlertStatus.ACKNOWLEDGED] },
+    },
+    data: {
+      status: AlertStatus.RESOLVED,
+      resolvedAt: now,
+    },
+  });
+
+  await createAlertAuditLog({
+    userId: user.id!,
+    alertId,
+    actorUserId: user.id!,
+    action: "notification.alert_resolved",
+    note: optionalString(formData, "note") ?? "Resolved from Notification Center.",
+  });
+
+  revalidateNotificationSurfaces();
+  revalidatePath("/alerts");
+}
+
+export async function completeNotificationReminderAction(formData: FormData) {
+  const user = await requireUser();
+  const reminderId = requiredString(formData, "reminderId");
+
+  await updateReminderState({
+    userId: user.id!,
+    reminderId,
+    nextState: ReminderState.COMPLETED,
+    actorUserId: user.id!,
+    note: "Completed from Notification Center.",
+  });
+
+  revalidateNotificationSurfaces();
+  revalidatePath("/reminders");
+}
+
+export async function skipNotificationReminderAction(formData: FormData) {
+  const user = await requireUser();
+  const reminderId = requiredString(formData, "reminderId");
+
+  await updateReminderState({
+    userId: user.id!,
+    reminderId,
+    nextState: ReminderState.SKIPPED,
+    actorUserId: user.id!,
+    note: "Skipped from Notification Center.",
+  });
+
+  revalidateNotificationSurfaces();
+  revalidatePath("/reminders");
+}
+
+export async function snoozeNotificationReminderAction(formData: FormData) {
+  const user = await requireUser();
+  const reminderId = requiredString(formData, "reminderId");
+  const minutesRaw = Number(formData.get("minutes") ?? 60);
+  const minutes = Number.isFinite(minutesRaw) ? Math.max(15, minutesRaw) : 60;
+
+  await snoozeReminder({
+    userId: user.id!,
+    reminderId,
+    minutes,
+    actorUserId: user.id!,
+    note: `Snoozed for ${minutes} minutes from Notification Center.`,
+  });
+
+  revalidateNotificationSurfaces();
+  revalidatePath("/reminders");
+}
+
+export async function createNotificationFollowUpReminderAction(formData: FormData) {
+  const user = await requireUser();
+  const source = parseSource(requiredString(formData, "source"));
+  const sourceId = requiredString(formData, "sourceId");
+  const title = requiredString(formData, "title");
+  const description = optionalString(formData, "description") ?? "Follow up on this notification.";
+  const dedupeKey = `notification-follow-up:${user.id}:${source}:${sourceId}`;
+
+  const reminder = await db.reminder.upsert({
+    where: { dedupeKey },
+    update: {
+      state: ReminderState.DUE,
+      dueAt: followUpDueAt(),
+      completed: false,
+      completedAt: null,
+      skippedAt: null,
+      missedAt: null,
+    },
+    create: {
+      userId: user.id!,
+      type: ReminderType.GENERAL,
+      title: `Follow up: ${title}`.slice(0, 180),
+      description,
+      dueAt: followUpDueAt(),
+      completed: false,
+      state: ReminderState.DUE,
+      channel: ReminderChannel.IN_APP,
+      gracePeriodMinutes: 240,
+      timezone: "Asia/Manila",
+      sourceType: ReminderSourceType.GENERAL,
+      sourceId,
+      dedupeKey,
+    },
+    select: { id: true },
+  });
+
+  await createReminderAuditLog({
+    userId: user.id!,
+    reminderId: reminder.id,
+    actorUserId: user.id!,
+    action: "notification.follow_up_created",
+    note: `Created from ${source} notification ${sourceId}.`,
+    metadata: { source, sourceId },
+  });
+
+  revalidateNotificationSurfaces();
+  revalidatePath("/reminders");
+}

--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -9,10 +9,13 @@ import {
   Inbox,
   RadioTower,
   Users,
+  CheckCircle2,
+  Clock3,
+  RotateCcw,
 } from "lucide-react";
 import { AppShell } from "@/components/app-shell";
 import { EmptyState, PageHeader, StatusPill } from "@/components/common";
-import { Badge, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
+import { Badge, Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
 import { requireUser } from "@/lib/session";
 import {
   getNotificationCenterData,
@@ -21,6 +24,14 @@ import {
   type NotificationSource,
   type NotificationTone,
 } from "@/lib/notification-center";
+import {
+  acknowledgeNotificationAlertAction,
+  completeNotificationReminderAction,
+  createNotificationFollowUpReminderAction,
+  resolveNotificationAlertAction,
+  skipNotificationReminderAction,
+  snoozeNotificationReminderAction,
+} from "./actions";
 
 const sourceLabels: Record<NotificationSource, string> = {
   ALERT: "Alerts",
@@ -70,14 +81,79 @@ function filterHref(params: Record<string, string | undefined>) {
   return qs ? `/notifications?${qs}` : "/notifications";
 }
 
+function FollowUpForm({ item }: { item: NotificationItem }) {
+  return (
+    <form action={createNotificationFollowUpReminderAction}>
+      <input type="hidden" name="source" value={item.source} />
+      <input type="hidden" name="sourceId" value={item.sourceId} />
+      <input type="hidden" name="title" value={item.title} />
+      <input type="hidden" name="description" value={item.description} />
+      <Button type="submit" size="sm" variant="outline">
+        <Clock3 className="h-4 w-4" /> Follow up
+      </Button>
+    </form>
+  );
+}
+
+function NotificationActions({ item }: { item: NotificationItem }) {
+  if (item.source === "ALERT") {
+    return (
+      <div className="flex flex-wrap gap-2">
+        {item.status === "OPEN" ? (
+          <form action={acknowledgeNotificationAlertAction}>
+            <input type="hidden" name="alertId" value={item.sourceId} />
+            <Button type="submit" size="sm" variant="secondary">
+              <CheckCircle2 className="h-4 w-4" /> Acknowledge
+            </Button>
+          </form>
+        ) : null}
+        <form action={resolveNotificationAlertAction}>
+          <input type="hidden" name="alertId" value={item.sourceId} />
+          <Button type="submit" size="sm">
+            <CheckCircle2 className="h-4 w-4" /> Resolve
+          </Button>
+        </form>
+        <FollowUpForm item={item} />
+      </div>
+    );
+  }
+
+  if (item.source === "REMINDER") {
+    return (
+      <div className="flex flex-wrap gap-2">
+        <form action={completeNotificationReminderAction}>
+          <input type="hidden" name="reminderId" value={item.sourceId} />
+          <Button type="submit" size="sm">
+            <CheckCircle2 className="h-4 w-4" /> Complete
+          </Button>
+        </form>
+        <form action={snoozeNotificationReminderAction}>
+          <input type="hidden" name="reminderId" value={item.sourceId} />
+          <input type="hidden" name="minutes" value="60" />
+          <Button type="submit" size="sm" variant="outline">
+            <RotateCcw className="h-4 w-4" /> Snooze 1h
+          </Button>
+        </form>
+        <form action={skipNotificationReminderAction}>
+          <input type="hidden" name="reminderId" value={item.sourceId} />
+          <Button type="submit" size="sm" variant="ghost">Skip</Button>
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <FollowUpForm item={item} />
+    </div>
+  );
+}
+
 function NotificationCard({ item }: { item: NotificationItem }) {
   const Icon = sourceIcons[item.source];
 
   return (
-    <Link
-      href={item.href}
-      className="block rounded-3xl border border-border/60 bg-background/50 p-5 transition hover:border-border hover:bg-muted/30"
-    >
+    <div className="rounded-3xl border border-border/60 bg-background/50 p-5 transition hover:border-border hover:bg-muted/30">
       <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
         <div className="flex gap-4">
           <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-border/60 bg-background/70">
@@ -90,9 +166,13 @@ function NotificationCard({ item }: { item: NotificationItem }) {
               <Badge>{item.status}</Badge>
             </div>
             <div>
-              <h3 className="font-semibold tracking-tight">{item.title}</h3>
+              <Link href={item.href} className="font-semibold tracking-tight hover:underline">
+                {item.title}
+              </Link>
               <p className="mt-1 text-sm leading-6 text-muted-foreground">{item.description}</p>
+              <p className="mt-2 text-xs text-muted-foreground">Recommended action: {item.actionHint}</p>
             </div>
+            <NotificationActions item={item} />
           </div>
         </div>
         <div className="shrink-0 text-left text-xs text-muted-foreground md:text-right">
@@ -100,7 +180,7 @@ function NotificationCard({ item }: { item: NotificationItem }) {
           <p className="mt-1">{formatDateTime(item.dueAt || item.createdAt)}</p>
         </div>
       </div>
-    </Link>
+    </div>
   );
 }
 
@@ -139,7 +219,7 @@ export default async function NotificationsPage({
       <div className="mx-auto max-w-7xl space-y-6 p-6">
         <PageHeader
           title="Notification Center"
-          description="A unified inbox for alerts, reminders, upcoming care tasks, abnormal results, document hygiene, care invites, and device sync issues."
+          description="A unified action inbox for alerts, reminders, follow-ups, abnormal results, document hygiene, care invites, and device sync issues."
           action={
             <div className="flex flex-wrap gap-2">
               <Link href="/alerts" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium hover:bg-muted/50">Alerts</Link>
@@ -192,7 +272,7 @@ export default async function NotificationsPage({
             <Card>
               <CardHeader>
                 <CardTitle>Recommended next actions</CardTitle>
-                <CardDescription>Generated from the current notification workload.</CardDescription>
+                <CardDescription>Generated from the current notification workload. Use item actions to resolve, complete, snooze, or create follow-up reminders.</CardDescription>
               </CardHeader>
               <CardContent className="space-y-3">
                 {data.nextActions.map((action) => (

--- a/docs/PATCH_37_NOTIFICATION_ACTIONS.md
+++ b/docs/PATCH_37_NOTIFICATION_ACTIONS.md
@@ -1,0 +1,30 @@
+# Patch 37 — Notification Actions
+
+This patch turns the Notification Center from a passive inbox into an action-oriented workflow surface.
+
+## Added
+
+- New `app/notifications/actions.ts` server actions.
+- Acknowledge alert directly from `/notifications`.
+- Resolve alert directly from `/notifications`.
+- Complete reminder directly from `/notifications`.
+- Snooze reminder for one hour directly from `/notifications`.
+- Skip reminder directly from `/notifications`.
+- Create a follow-up reminder from any notification item.
+- Added source IDs and action hints to notification items.
+- Updated notification cards so source navigation and actions are separate.
+
+## Safety notes
+
+- No Prisma migration required.
+- Uses existing `AlertEvent`, `Reminder`, `AlertAuditLog`, and `ReminderAuditLog` models.
+- Alert and reminder actions are scoped to the authenticated user.
+- Follow-up reminders use a deterministic `dedupeKey` to avoid duplicate follow-ups for the same notification source.
+
+## Manual checks
+
+- `/notifications`
+- Complete or snooze a due reminder.
+- Acknowledge or resolve an open alert.
+- Create a follow-up from a lab/document/device notification.
+- Confirm `/reminders`, `/alerts`, `/dashboard`, and `/care-plan` refresh after actions.

--- a/lib/notification-center.ts
+++ b/lib/notification-center.ts
@@ -32,6 +32,8 @@ export type NotificationItem = {
   dueAt?: Date | null;
   status: string;
   meta: string;
+  sourceId: string;
+  actionHint: string;
 };
 
 export type NotificationCenterFilters = {
@@ -226,6 +228,7 @@ export async function getNotificationCenterData(userId: string, filters: Notific
   const items: NotificationItem[] = [
     ...alerts.map((alert) => ({
       id: `alert-${alert.id}`,
+      sourceId: alert.id,
       source: "ALERT" as const,
       title: alert.title,
       description: alert.message,
@@ -235,9 +238,11 @@ export async function getNotificationCenterData(userId: string, filters: Notific
       createdAt: alert.createdAt,
       status: alert.status,
       meta: `${alert.category} • ${alert.severity}`,
+      actionHint: alert.status === AlertStatus.OPEN ? "Acknowledge or resolve this alert." : "Resolve this acknowledged alert.",
     })),
     ...reminders.map((reminder) => ({
       id: `reminder-${reminder.id}`,
+      sourceId: reminder.id,
       source: "REMINDER" as const,
       title: reminder.title,
       description: reminder.description || `${reminder.type} reminder due ${reminder.dueAt.toLocaleString()}`,
@@ -248,9 +253,11 @@ export async function getNotificationCenterData(userId: string, filters: Notific
       dueAt: reminder.dueAt,
       status: reminder.state,
       meta: reminder.type,
+      actionHint: "Complete, skip, or snooze this reminder.",
     })),
     ...appointments.map((appointment) => ({
       id: `appointment-${appointment.id}`,
+      sourceId: appointment.id,
       source: "APPOINTMENT" as const,
       title: appointment.purpose,
       description: `${appointment.doctorName} • ${appointment.clinic}`,
@@ -261,9 +268,11 @@ export async function getNotificationCenterData(userId: string, filters: Notific
       dueAt: appointment.scheduledAt,
       status: "UPCOMING",
       meta: "Upcoming visit",
+      actionHint: "Open the appointment or create a prep reminder.",
     })),
     ...labs.map((lab) => ({
       id: `lab-${lab.id}`,
+      sourceId: lab.id,
       source: "LAB" as const,
       title: lab.testName,
       description: lab.resultSummary,
@@ -274,12 +283,14 @@ export async function getNotificationCenterData(userId: string, filters: Notific
       dueAt: lab.dateTaken,
       status: lab.flag,
       meta: "Lab follow-up",
+      actionHint: "Open lab review or create a follow-up reminder.",
     })),
     ...documents.map((document) => {
       const needsLink = !document.linkedRecordType;
       const needsNotes = !document.notes;
       return {
         id: `document-${document.id}`,
+        sourceId: document.id,
         source: "DOCUMENT" as const,
         title: document.title,
         description: needsLink
@@ -291,10 +302,12 @@ export async function getNotificationCenterData(userId: string, filters: Notific
         createdAt: document.createdAt,
         status: needsLink ? "UNLINKED" : needsNotes ? "NEEDS_NOTES" : "READY",
         meta: document.type,
+        actionHint: needsLink ? "Open document hub and link this file." : "Open document hub and add notes.",
       };
     }),
     ...careInvites.map((invite) => ({
       id: `care-${invite.id}`,
+      sourceId: invite.id,
       source: "CARE" as const,
       title: `Pending invite for ${invite.email}`,
       description: `${invite.accessRole} access expires ${invite.expiresAt.toLocaleDateString()}`,
@@ -305,9 +318,11 @@ export async function getNotificationCenterData(userId: string, filters: Notific
       dueAt: invite.expiresAt,
       status: invite.status,
       meta: invite.accessRole,
+      actionHint: "Open care-team invite management.",
     })),
     ...deviceConnections.map((device) => ({
       id: `device-${device.id}`,
+      sourceId: device.id,
       source: "DEVICE" as const,
       title: device.deviceLabel || `${device.platform} ${device.source}`,
       description: device.lastError || `Last synced ${device.lastSyncedAt ? device.lastSyncedAt.toLocaleDateString() : "never"}`,
@@ -318,6 +333,7 @@ export async function getNotificationCenterData(userId: string, filters: Notific
       dueAt: device.lastSyncedAt,
       status: device.status,
       meta: `${device.source} • ${device.platform}`,
+      actionHint: "Open device connection review or create a sync follow-up reminder.",
     })),
   ];
 


### PR DESCRIPTION
This PR adds Patch 37: Notification Actions.

Changes:
- Adds server actions for notification workflows
- Allows alerts to be acknowledged or resolved directly from Notification Center
- Allows reminders to be completed, snoozed, or skipped directly from Notification Center
- Allows any notification item to create a follow-up reminder
- Adds action hints and source IDs to notification items
- Keeps actions scoped to the authenticated user
- Adds audit logging through existing alert and reminder audit log models
- Requires no Prisma migration