### PR TITLE
Fix report builder typecheck issues

### DIFF
--- a/app/report-builder/page.tsx
+++ b/app/report-builder/page.tsx
@@ -1,0 +1,253 @@
+import Link from "next/link";
+import { ArrowRight, CalendarDays, CheckCircle2, FileText, Printer, SlidersHorizontal } from "lucide-react";
+import { AppShell } from "@/components/app-shell";
+import { EmptyState, PageHeader, StatusPill } from "@/components/common";
+import { Badge, Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Input, Label, Select } from "@/components/ui";
+import { ModuleHero, DataCard } from "@/components/module-sections";
+import { PageTransition, StaggerItem } from "@/components/page-transition";
+import { getReportBuilderData, isSectionSelected, sectionQuery, type ReportActionItem, type ReportType } from "@/lib/report-builder";
+
+const reportTypeOptions: Array<{ value: ReportType; label: string; description: string }> = [
+  { value: "patient", label: "Patient summary", description: "Broad personal record packet" },
+  { value: "doctor", label: "Doctor visit", description: "Provider-focused handoff" },
+  { value: "emergency", label: "Emergency", description: "Critical care snapshot" },
+  { value: "care", label: "Care-team", description: "Collaboration and follow-up" },
+  { value: "custom", label: "Custom", description: "Manual section selection" },
+];
+
+function priorityTone(priority: ReportActionItem["priority"]) {
+  if (priority === "high") return "danger" as const;
+  if (priority === "medium") return "warning" as const;
+  return "success" as const;
+}
+
+function ProgressBar({ value }: { value: number }) {
+  const safeValue = Math.max(0, Math.min(100, value));
+  return (
+    <div className="h-2 overflow-hidden rounded-full bg-muted">
+      <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${safeValue}%` }} />
+    </div>
+  );
+}
+
+function ActionCard({ item }: { item: ReportActionItem }) {
+  return (
+    <Link href={item.href} className="block rounded-2xl border border-border/60 bg-background/50 p-4 transition hover:border-border hover:bg-muted/40">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="font-medium">{item.title}</p>
+          <p className="mt-1 text-sm text-muted-foreground">{item.description}</p>
+        </div>
+        <StatusPill tone={priorityTone(item.priority)}>{item.priority}</StatusPill>
+      </div>
+    </Link>
+  );
+}
+
+export default async function ReportBuilderPage({ searchParams }: { searchParams?: Promise<Record<string, string | string[] | undefined>> }) {
+  const params = (await searchParams) ?? {};
+  const reportType = typeof params.type === "string" ? params.type : "patient";
+  const sections = Array.isArray(params.sections) ? params.sections.join(",") : typeof params.sections === "string" ? params.sections : undefined;
+  const from = typeof params.from === "string" ? params.from : "";
+  const to = typeof params.to === "string" ? params.to : "";
+  const data = await getReportBuilderData({ reportType, sections, from, to });
+  const printHref = `/report-builder/print?type=${data.reportType}&sections=${encodeURIComponent(sectionQuery(data.selectedSections))}${from ? `&from=${from}` : ""}${to ? `&to=${to}` : ""}`;
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-7xl space-y-6 p-6">
+        <PageTransition>
+          <PageHeader
+            title="Report Builder"
+            description="Assemble custom patient, doctor, emergency, and care-team report packets with section controls, date ranges, and readiness checks."
+            action={
+              <div className="flex flex-wrap gap-2">
+                <Link href={printHref} className="inline-flex h-10 items-center justify-center rounded-2xl bg-primary px-4 text-sm font-medium text-primary-foreground shadow-sm hover:opacity-95">
+                  <Printer className="mr-2 h-4 w-4" />
+                  Preview packet
+                </Link>
+              </div>
+            }
+          />
+        </PageTransition>
+
+        <PageTransition delay={0.04}>
+          <ModuleHero
+            eyebrow="Custom reporting"
+            title="Build a report packet from the records that matter for the situation"
+            description="Pick the packet type, choose sections, narrow the date range, and open a print-ready preview before sharing with a provider, caregiver, or emergency contact."
+            stats={[
+              { label: "Readiness", value: `${data.summary.readinessScore}%`, hint: "Section coverage, data coverage, documents, and adherence" },
+              { label: "Sections", value: `${data.summary.selectedSectionCount}/${data.summary.availableSectionCount}`, hint: "Selected for this packet" },
+              { label: "Records", value: data.summary.totalRecords, hint: data.range.label },
+              { label: "Document links", value: `${data.summary.documentLinkRate}%`, hint: "Linked to source records" },
+            ]}
+          />
+        </PageTransition>
+
+        <div className="grid gap-6 xl:grid-cols-[0.95fr_1.05fr]">
+          <Card>
+            <CardHeader>
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <CardTitle>Packet controls</CardTitle>
+                  <CardDescription className="mt-1">Change packet type, section selection, and date boundaries.</CardDescription>
+                </div>
+                <SlidersHorizontal className="h-5 w-5 text-primary" />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <form className="space-y-5">
+                <div className="grid gap-4 md:grid-cols-3">
+                  <div className="space-y-2 md:col-span-1">
+                    <Label htmlFor="type">Report type</Label>
+                    <Select id="type" name="type" defaultValue={data.reportType}>
+                      {reportTypeOptions.map((option) => (
+                        <option key={option.value} value={option.value}>{option.label}</option>
+                      ))}
+                    </Select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="from">From</Label>
+                    <Input id="from" name="from" type="date" defaultValue={from} />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="to">To</Label>
+                    <Input id="to" name="to" type="date" defaultValue={to} />
+                  </div>
+                </div>
+
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <Label>Sections</Label>
+                    <Badge>{data.summary.selectedSectionCount} selected</Badge>
+                  </div>
+                  <div className="grid gap-3 md:grid-cols-2">
+                    {data.sectionDefinitions.map((section) => (
+                      <label key={section.key} className="flex cursor-pointer items-start gap-3 rounded-2xl border border-border/60 bg-background/50 p-4 transition hover:border-border hover:bg-muted/40">
+                        <input
+                          type="checkbox"
+                          name="sections"
+                          value={section.key}
+                          defaultChecked={isSectionSelected(data.selectedSections, section.key)}
+                          className="mt-1 h-4 w-4 rounded border-border"
+                        />
+                        <span>
+                          <span className="font-medium">{section.label}</span>
+                          <span className="mt-1 block text-xs text-muted-foreground">{section.description}</span>
+                        </span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap gap-2">
+                  <Button type="submit">Apply controls</Button>
+                  <Link href="/report-builder" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium transition hover:bg-muted/60">Reset</Link>
+                </div>
+              </form>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Readiness and pre-report actions</CardTitle>
+              <CardDescription className="mt-1">Review these before printing or sharing a report packet.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-center justify-between gap-4">
+                <div>
+                  <p className="text-3xl font-semibold">{data.summary.readinessScore}%</p>
+                  <p className="text-sm text-muted-foreground">Report readiness</p>
+                </div>
+                <StatusPill tone={data.summary.readinessScore >= 75 ? "success" : data.summary.readinessScore >= 50 ? "warning" : "danger"}>
+                  {data.summary.readinessScore >= 75 ? "Ready" : "Review first"}
+                </StatusPill>
+              </div>
+              <ProgressBar value={data.summary.readinessScore} />
+              <div className="grid gap-3 sm:grid-cols-3">
+                <DataCard className="rounded-2xl p-4"><p className="text-xs text-muted-foreground">High-risk alerts</p><p className="mt-1 text-2xl font-semibold">{data.summary.highRiskAlerts}</p></DataCard>
+                <DataCard className="rounded-2xl p-4"><p className="text-xs text-muted-foreground">Abnormal labs</p><p className="mt-1 text-2xl font-semibold">{data.summary.abnormalLabs}</p></DataCard>
+                <DataCard className="rounded-2xl p-4"><p className="text-xs text-muted-foreground">Open symptoms</p><p className="mt-1 text-2xl font-semibold">{data.summary.unresolvedSymptoms}</p></DataCard>
+              </div>
+              <div className="space-y-3">
+                {data.actionItems.map((item) => <ActionCard key={`${item.title}-${item.href}`} item={item} />)}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
+          <StaggerItem>
+            <Card>
+              <CardHeader>
+                <CardTitle>Selected section preview</CardTitle>
+                <CardDescription className="mt-1">A quick snapshot of what will be included in the generated packet.</CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-3 md:grid-cols-2">
+                {data.sectionDefinitions
+                  .filter((section) => isSectionSelected(data.selectedSections, section.key))
+                  .map((section) => (
+                    <DataCard key={section.key} className="rounded-2xl p-4">
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className="font-medium">{section.label}</p>
+                          <p className="mt-1 text-sm text-muted-foreground">{section.description}</p>
+                        </div>
+                        <CheckCircle2 className="h-5 w-5 text-emerald-500" />
+                      </div>
+                    </DataCard>
+                  ))}
+              </CardContent>
+            </Card>
+          </StaggerItem>
+
+          <StaggerItem>
+            <Card>
+              <CardHeader>
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <CardTitle>Recent report timeline</CardTitle>
+                    <CardDescription className="mt-1">The highest-value events that can appear in the print packet.</CardDescription>
+                  </div>
+                  <CalendarDays className="h-5 w-5 text-primary" />
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {data.timeline.slice(0, 8).map((item) => (
+                  <div key={item.id} className="rounded-2xl border border-border/60 bg-background/50 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <div className="flex flex-wrap gap-2">
+                          <StatusPill tone={item.risk === "urgent" ? "danger" : item.risk === "watch" ? "warning" : "neutral"}>{item.risk}</StatusPill>
+                          <Badge>{item.type}</Badge>
+                        </div>
+                        <p className="mt-3 font-medium">{item.title}</p>
+                        <p className="mt-1 text-sm text-muted-foreground">{item.detail}</p>
+                      </div>
+                      <ArrowRight className="h-4 w-4 text-muted-foreground" />
+                    </div>
+                  </div>
+                ))}
+                {data.timeline.length === 0 ? <EmptyState title="No timeline events" description="Records in the selected range will appear here." /> : null}
+              </CardContent>
+            </Card>
+          </StaggerItem>
+        </div>
+
+        <Card className="bg-background/40">
+          <CardContent className="flex flex-col gap-4 p-5 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="font-semibold">Ready to review the packet?</p>
+              <p className="text-sm text-muted-foreground">Open a print-friendly preview using the selected sections and date range.</p>
+            </div>
+            <Link href={printHref} className="inline-flex h-10 items-center justify-center rounded-2xl bg-primary px-4 text-sm font-medium text-primary-foreground shadow-sm hover:opacity-95">
+              <FileText className="mr-2 h-4 w-4" />
+              Open print preview
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    </AppShell>
+  );
+}

--- a/app/report-builder/print/page.tsx
+++ b/app/report-builder/print/page.tsx
@@ -1,0 +1,150 @@
+import { AutoPrintOnLoad } from "@/components/auto-print-on-load";
+import { StatusPill } from "@/components/common";
+import { getReportBuilderData, isSectionSelected, type ReportTimelineItem } from "@/lib/report-builder";
+
+function formatDate(value: Date | null | undefined) {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat("en-PH", { dateStyle: "medium" }).format(value);
+}
+
+function formatDateTime(value: Date | null | undefined) {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat("en-PH", { dateStyle: "medium", timeStyle: "short" }).format(value);
+}
+
+function PrintRow({ label, value }: { label: string; value: string | number | null | undefined }) {
+  return (
+    <div className="rounded-2xl border border-slate-200 p-3">
+      <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{label}</p>
+      <p className="mt-1 text-sm font-medium text-slate-950">{value || "—"}</p>
+    </div>
+  );
+}
+
+function PrintTimelineItem({ item }: { item: ReportTimelineItem }) {
+  return (
+    <div className="break-inside-avoid rounded-2xl border border-slate-200 p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="mb-2 flex flex-wrap gap-2">
+            <StatusPill tone={item.risk === "urgent" ? "danger" : item.risk === "watch" ? "warning" : "neutral"}>{item.risk}</StatusPill>
+            <span className="rounded-full border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600">{item.type}</span>
+          </div>
+          <h3 className="font-semibold text-slate-950">{item.title}</h3>
+          <p className="mt-1 text-sm text-slate-600">{item.detail}</p>
+        </div>
+        <p className="whitespace-nowrap text-right text-xs text-slate-500">{formatDateTime(item.occurredAt)}</p>
+      </div>
+    </div>
+  );
+}
+
+export default async function ReportBuilderPrintPage({ searchParams }: { searchParams?: Promise<Record<string, string | string[] | undefined>> }) {
+  const params = (await searchParams) ?? {};
+  const reportType = typeof params.type === "string" ? params.type : "patient";
+  const sections = Array.isArray(params.sections) ? params.sections.join(",") : typeof params.sections === "string" ? params.sections : undefined;
+  const from = typeof params.from === "string" ? params.from : "";
+  const to = typeof params.to === "string" ? params.to : "";
+  const autoprint = params.autoprint === "1";
+  const data = await getReportBuilderData({ reportType, sections, from, to });
+
+  return (
+    <main className="min-h-screen bg-white p-8 text-slate-950 print:p-0">
+      {autoprint ? <AutoPrintOnLoad /> : null}
+      <div className="mx-auto max-w-5xl space-y-8 print:max-w-none">
+        <header className="border-b border-slate-200 pb-6">
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500">VitaVault</p>
+          <div className="mt-3 flex flex-wrap items-end justify-between gap-4">
+            <div>
+              <h1 className="text-3xl font-bold tracking-tight">{data.reportTitle}</h1>
+              <p className="mt-2 text-sm text-slate-600">Generated {formatDateTime(new Date())} • {data.range.label}</p>
+            </div>
+            <div className="text-right text-sm text-slate-600">
+              <p>{data.summary.selectedSectionCount} sections selected</p>
+              <p>{data.summary.totalRecords} source records • {data.summary.readinessScore}% ready</p>
+            </div>
+          </div>
+        </header>
+
+        <section className="grid gap-4 sm:grid-cols-4">
+          <PrintRow label="Readiness" value={`${data.summary.readinessScore}%`} />
+          <PrintRow label="High-risk alerts" value={data.summary.highRiskAlerts} />
+          <PrintRow label="Abnormal labs" value={data.summary.abnormalLabs} />
+          <PrintRow label="Document links" value={`${data.summary.documentLinkRate}%`} />
+        </section>
+
+        {isSectionSelected(data.selectedSections, "profile") ? (
+          <section className="break-inside-avoid space-y-3">
+            <h2 className="border-b border-slate-200 pb-2 text-xl font-semibold">Profile and emergency context</h2>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <PrintRow label="Full name" value={data.profile?.fullName} />
+              <PrintRow label="Date of birth" value={formatDate(data.profile?.dateOfBirth)} />
+              <PrintRow label="Blood type" value={data.profile?.bloodType} />
+              <PrintRow label="Emergency contact" value={[data.profile?.emergencyContactName, data.profile?.emergencyContactPhone].filter(Boolean).join(" • ")} />
+              <PrintRow label="Allergies" value={data.profile?.allergiesSummary} />
+              <PrintRow label="Chronic conditions" value={data.profile?.chronicConditions} />
+            </div>
+          </section>
+        ) : null}
+
+        {isSectionSelected(data.selectedSections, "medications") ? (
+          <section className="break-inside-avoid space-y-3">
+            <h2 className="border-b border-slate-200 pb-2 text-xl font-semibold">Medications</h2>
+            <div className="space-y-3">
+              {data.medications.map((item) => (
+                <div key={item.id} className="rounded-2xl border border-slate-200 p-4">
+                  <p className="font-semibold">{item.name} • {item.dosage}</p>
+                  <p className="mt-1 text-sm text-slate-600">{item.frequency}{item.doctor ? ` • ${item.doctor.name}` : ""}</p>
+                  <p className="mt-1 text-sm text-slate-600">Schedule: {item.schedules.map((schedule) => schedule.timeOfDay).join(", ") || "No schedule listed"}</p>
+                </div>
+              ))}
+              {!data.medications.length ? <p className="text-sm text-slate-500">No active medications found.</p> : null}
+            </div>
+          </section>
+        ) : null}
+
+        {isSectionSelected(data.selectedSections, "labs") ? (
+          <section className="break-inside-avoid space-y-3">
+            <h2 className="border-b border-slate-200 pb-2 text-xl font-semibold">Labs</h2>
+            <div className="space-y-3">
+              {data.labs.map((item) => (
+                <div key={item.id} className="rounded-2xl border border-slate-200 p-4">
+                  <p className="font-semibold">{item.testName}</p>
+                  <p className="mt-1 text-sm text-slate-600">{item.flag} • {item.resultSummary}</p>
+                  <p className="mt-1 text-xs text-slate-500">Taken {formatDate(item.dateTaken)}{item.referenceRange ? ` • Ref: ${item.referenceRange}` : ""}</p>
+                </div>
+              ))}
+              {!data.labs.length ? <p className="text-sm text-slate-500">No labs found for this range.</p> : null}
+            </div>
+          </section>
+        ) : null}
+
+        {isSectionSelected(data.selectedSections, "timeline") ? (
+          <section className="break-inside-avoid space-y-3">
+            <h2 className="border-b border-slate-200 pb-2 text-xl font-semibold">Timeline preview</h2>
+            <div className="space-y-3">
+              {data.timeline.map((item) => <PrintTimelineItem key={item.id} item={item} />)}
+              {!data.timeline.length ? <p className="text-sm text-slate-500">No timeline events found for this report range.</p> : null}
+            </div>
+          </section>
+        ) : null}
+
+        <section className="break-inside-avoid rounded-2xl border border-slate-200 p-4">
+          <h2 className="text-lg font-semibold">Recommended pre-share checks</h2>
+          <div className="mt-3 space-y-2">
+            {data.actionItems.map((item) => (
+              <div key={item.title} className="rounded-xl bg-slate-50 p-3">
+                <p className="font-medium">{item.title}</p>
+                <p className="mt-1 text-sm text-slate-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <footer className="border-t border-slate-200 pt-4 text-xs text-slate-500">
+          <p>This report is generated from VitaVault records and should be reviewed by the user before sharing with a care provider or caregiver.</p>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/docs/PATCH_38B_REPORT_BUILDER_TYPECHECK_FIX.md
+++ b/docs/PATCH_38B_REPORT_BUILDER_TYPECHECK_FIX.md
@@ -1,0 +1,20 @@
+# Patch 38B - Report Builder Typecheck Fix
+
+Fixes validation issues from Patch 38.
+
+## Changes
+
+- Replaces the unsupported `className` prop on `StaggerGroup` with a normal grid wrapper.
+- Removes unused `ReportSectionKey` import from the Report Builder page.
+- Removes unused `sectionQuery` import from the Report Builder print page.
+- Removes unused `ReminderState` import from the report builder helper.
+
+## Validation
+
+Run:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:run
+```

--- a/docs/PATCH_38_REPORT_BUILDER.md
+++ b/docs/PATCH_38_REPORT_BUILDER.md
@@ -1,0 +1,38 @@
+# Patch 38 — Report Builder
+
+This patch adds a custom report builder to VitaVault so users can assemble print-ready packets without adding a new database table.
+
+## Added
+
+- New protected `/report-builder` workspace
+- New print-ready `/report-builder/print` route
+- Shared report data helper at `lib/report-builder.ts`
+- Report type presets:
+  - Patient summary
+  - Doctor visit
+  - Emergency handoff
+  - Care-team review
+  - Custom packet
+- Section selector for:
+  - Profile
+  - Medications
+  - Vitals
+  - Labs
+  - Symptoms
+  - Appointments
+  - Documents
+  - Alerts
+  - Care Team
+  - AI Insights
+  - Timeline
+- Date range controls
+- Readiness scoring
+- Pre-share action queue
+- Recent report timeline preview
+- Sidebar navigation entry under Sharing & Reports
+
+## Notes
+
+- No Prisma migration is required.
+- The builder reuses existing records and print/report workflows.
+- The print route supports query-string driven report type, section selection, and date filtering.

--- a/lib/app-routes.ts
+++ b/lib/app-routes.ts
@@ -9,6 +9,7 @@ import {
   ClipboardList,
   FileBarChart2,
   FileHeart,
+  FileText,
   HeartPulse,
   Inbox,
   LayoutDashboard,
@@ -238,6 +239,12 @@ export const sharingReportRoutes: AppRouteItem[] = [
     href: "/exports",
     description: "Export records and reports",
     icon: FileBarChart2,
+  },
+  {
+    title: "Report Builder",
+    href: "/report-builder",
+    description: "Build custom patient, doctor, emergency, and care-team packets",
+    icon: FileText,
   },
 ];
 

--- a/lib/report-builder.ts
+++ b/lib/report-builder.ts
@@ -1,0 +1,331 @@
+import {
+  AlertSeverity,
+  AlertStatus,
+  LabFlag,
+  MedicationLogStatus,
+  MedicationStatus,
+  SymptomSeverity,
+} from "@prisma/client";
+import { db } from "@/lib/db";
+import { requireUser } from "@/lib/session";
+
+export type ReportSectionKey =
+  | "profile"
+  | "medications"
+  | "vitals"
+  | "labs"
+  | "symptoms"
+  | "appointments"
+  | "documents"
+  | "alerts"
+  | "careTeam"
+  | "aiInsights"
+  | "timeline";
+
+export type ReportType = "patient" | "doctor" | "emergency" | "care" | "custom";
+
+export type ReportBuilderOptions = {
+  reportType?: string;
+  sections?: string;
+  from?: string;
+  to?: string;
+};
+
+export type ReportSectionDefinition = {
+  key: ReportSectionKey;
+  label: string;
+  description: string;
+  recommendedFor: ReportType[];
+};
+
+export type ReportActionItem = {
+  title: string;
+  description: string;
+  href: string;
+  priority: "high" | "medium" | "low";
+};
+
+export type ReportTimelineItem = {
+  id: string;
+  type: string;
+  title: string;
+  detail: string;
+  occurredAt: Date;
+  risk: "urgent" | "watch" | "routine";
+};
+
+export const reportSections: ReportSectionDefinition[] = [
+  { key: "profile", label: "Profile", description: "Identity, emergency contact, allergies, and baseline context.", recommendedFor: ["patient", "doctor", "emergency", "care", "custom"] },
+  { key: "medications", label: "Medications", description: "Active medications, provider links, schedules, and recent adherence.", recommendedFor: ["patient", "doctor", "emergency", "care", "custom"] },
+  { key: "vitals", label: "Vitals", description: "Latest vitals and device/manual capture context.", recommendedFor: ["patient", "doctor", "care", "custom"] },
+  { key: "labs", label: "Labs", description: "Recent results, abnormal flags, and review context.", recommendedFor: ["patient", "doctor", "care", "custom"] },
+  { key: "symptoms", label: "Symptoms", description: "Unresolved symptoms, severity, and notes coverage.", recommendedFor: ["patient", "doctor", "care", "custom"] },
+  { key: "appointments", label: "Appointments", description: "Upcoming and recent visit history.", recommendedFor: ["patient", "doctor", "care", "custom"] },
+  { key: "documents", label: "Documents", description: "Medical files, linking coverage, and document hygiene.", recommendedFor: ["patient", "doctor", "care", "custom"] },
+  { key: "alerts", label: "Alerts", description: "Open alerts, high-risk signals, and follow-up context.", recommendedFor: ["patient", "doctor", "care", "custom"] },
+  { key: "careTeam", label: "Care Team", description: "Shared access, caregivers, and active care relationships.", recommendedFor: ["patient", "care", "custom"] },
+  { key: "aiInsights", label: "AI Insights", description: "Latest AI summary and source-linked interpretation support.", recommendedFor: ["patient", "doctor", "care", "custom"] },
+  { key: "timeline", label: "Timeline", description: "Longitudinal record and care event history.", recommendedFor: ["patient", "doctor", "care", "custom"] },
+];
+
+const reportTypeLabels: Record<ReportType, string> = {
+  patient: "Patient summary packet",
+  doctor: "Doctor visit packet",
+  emergency: "Emergency handoff packet",
+  care: "Care-team review packet",
+  custom: "Custom report packet",
+};
+
+function asReportType(value: string | undefined): ReportType {
+  if (value === "patient" || value === "doctor" || value === "emergency" || value === "care" || value === "custom") return value;
+  return "patient";
+}
+
+function parseDate(value: string | undefined) {
+  if (!value) return undefined;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+function pct(value: number, total: number) {
+  if (total <= 0) return 0;
+  return Math.round((value / total) * 100);
+}
+
+function clampScore(value: number) {
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function defaultSectionsForType(reportType: ReportType): ReportSectionKey[] {
+  if (reportType === "emergency") return ["profile", "medications", "vitals", "alerts"];
+  if (reportType === "doctor") return ["profile", "medications", "vitals", "labs", "symptoms", "appointments", "documents", "alerts", "aiInsights", "timeline"];
+  if (reportType === "care") return ["profile", "medications", "vitals", "labs", "symptoms", "appointments", "documents", "alerts", "careTeam", "aiInsights", "timeline"];
+  return ["profile", "medications", "vitals", "labs", "symptoms", "appointments", "documents", "alerts", "timeline"];
+}
+
+function parseSections(value: string | undefined, reportType: ReportType): ReportSectionKey[] {
+  const allowed = new Set(reportSections.map((section) => section.key));
+  const fromQuery = (value || "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item): item is ReportSectionKey => allowed.has(item as ReportSectionKey));
+
+  const selected = fromQuery.length ? fromQuery : defaultSectionsForType(reportType);
+  return Array.from(new Set(selected));
+}
+
+function dateWhere(field: "createdAt" | "scheduledAt" | "dateTaken" | "recordedAt" | "startedAt", from?: Date, to?: Date) {
+  if (!from && !to) return {};
+  return {
+    [field]: {
+      ...(from ? { gte: from } : {}),
+      ...(to ? { lte: to } : {}),
+    },
+  };
+}
+
+function formatDate(value: Date | null | undefined) {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat("en-PH", { dateStyle: "medium" }).format(value);
+}
+
+function vitalSummary(vital: {
+  systolic: number | null;
+  diastolic: number | null;
+  heartRate: number | null;
+  bloodSugar: number | null;
+  oxygenSaturation: number | null;
+  temperatureC: number | null;
+  weightKg: number | null;
+}) {
+  return [
+    vital.systolic && vital.diastolic ? `${vital.systolic}/${vital.diastolic} BP` : null,
+    vital.heartRate ? `${vital.heartRate} bpm` : null,
+    vital.bloodSugar ? `${vital.bloodSugar} glucose` : null,
+    vital.oxygenSaturation ? `${vital.oxygenSaturation}% SpO2` : null,
+    vital.temperatureC ? `${vital.temperatureC}°C` : null,
+    vital.weightKg ? `${vital.weightKg} kg` : null,
+  ].filter(Boolean).join(" • ") || "Vitals captured";
+}
+
+export async function getReportBuilderData(options: ReportBuilderOptions = {}) {
+  const user = await requireUser();
+  const reportType = asReportType(options.reportType);
+  const selectedSections = parseSections(options.sections, reportType);
+  const from = parseDate(options.from);
+  const to = parseDate(options.to);
+  const now = new Date();
+  const thirtyDaysAgo = new Date(now);
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+  const [
+    profile,
+    medications,
+    medicationLogs30d,
+    missedMedicationLogs30d,
+    appointments,
+    labs,
+    vitals,
+    symptoms,
+    documents,
+    linkedDocuments,
+    alerts,
+    highRiskAlerts,
+    careAccess,
+    aiInsight,
+  ] = await Promise.all([
+    db.healthProfile.findUnique({ where: { userId: user.id } }),
+    db.medication.findMany({
+      where: { userId: user.id, status: MedicationStatus.ACTIVE },
+      orderBy: { createdAt: "desc" },
+      take: 8,
+      select: {
+        id: true,
+        name: true,
+        dosage: true,
+        frequency: true,
+        instructions: true,
+        startDate: true,
+        endDate: true,
+        doctor: { select: { name: true, specialty: true } },
+        schedules: { select: { timeOfDay: true }, orderBy: { timeOfDay: "asc" } },
+      },
+    }),
+    db.medicationLog.count({ where: { userId: user.id, loggedAt: { gte: thirtyDaysAgo } } }),
+    db.medicationLog.count({ where: { userId: user.id, loggedAt: { gte: thirtyDaysAgo }, status: { in: [MedicationLogStatus.MISSED, MedicationLogStatus.SKIPPED] } } }),
+    db.appointment.findMany({
+      where: { userId: user.id, ...dateWhere("scheduledAt", from, to) },
+      orderBy: { scheduledAt: "desc" },
+      take: 8,
+      select: { id: true, doctorName: true, clinic: true, purpose: true, scheduledAt: true, status: true, notes: true },
+    }),
+    db.labResult.findMany({
+      where: { userId: user.id, ...dateWhere("dateTaken", from, to) },
+      orderBy: { dateTaken: "desc" },
+      take: 8,
+      select: { id: true, testName: true, resultSummary: true, referenceRange: true, flag: true, dateTaken: true },
+    }),
+    db.vitalRecord.findMany({
+      where: { userId: user.id, ...dateWhere("recordedAt", from, to) },
+      orderBy: { recordedAt: "desc" },
+      take: 8,
+      select: { id: true, recordedAt: true, systolic: true, diastolic: true, heartRate: true, bloodSugar: true, oxygenSaturation: true, temperatureC: true, weightKg: true, readingSource: true },
+    }),
+    db.symptomEntry.findMany({
+      where: { userId: user.id, ...dateWhere("startedAt", from, to) },
+      orderBy: { startedAt: "desc" },
+      take: 8,
+      select: { id: true, title: true, severity: true, bodyArea: true, startedAt: true, resolved: true, notes: true },
+    }),
+    db.medicalDocument.findMany({
+      where: { userId: user.id, ...dateWhere("createdAt", from, to) },
+      orderBy: { createdAt: "desc" },
+      take: 8,
+      select: { id: true, title: true, type: true, fileName: true, linkedRecordType: true, linkedRecordId: true, createdAt: true },
+    }),
+    db.medicalDocument.count({ where: { userId: user.id, linkedRecordType: { not: null }, linkedRecordId: { not: null } } }),
+    db.alertEvent.findMany({
+      where: { userId: user.id, status: AlertStatus.OPEN, ...dateWhere("createdAt", from, to) },
+      orderBy: { createdAt: "desc" },
+      take: 8,
+      select: { id: true, title: true, message: true, severity: true, category: true, createdAt: true },
+    }),
+    db.alertEvent.count({ where: { userId: user.id, status: AlertStatus.OPEN, severity: { in: [AlertSeverity.HIGH, AlertSeverity.CRITICAL] } } }),
+    db.careAccess.findMany({
+      where: { ownerUserId: user.id, status: "ACTIVE" },
+      orderBy: { createdAt: "desc" },
+      take: 8,
+      select: { id: true, accessRole: true, canViewRecords: true, canAddNotes: true, canExport: true, member: { select: { name: true, email: true } } },
+    }),
+    db.aiInsight.findFirst({
+      where: { ownerUserId: user.id },
+      orderBy: { createdAt: "desc" },
+      select: { id: true, title: true, summary: true, adherenceRisk: true, trendFlagsJson: true, suggestedQuestionsJson: true, recommendedFollowUpJson: true, createdAt: true },
+    }),
+  ]);
+
+  const abnormalLabs = labs.filter((lab) => lab.flag !== LabFlag.NORMAL).length;
+  const severeSymptoms = symptoms.filter((symptom) => symptom.severity === SymptomSeverity.SEVERE && !symptom.resolved).length;
+  const unresolvedSymptoms = symptoms.filter((symptom) => !symptom.resolved).length;
+  const documentLinkRate = pct(linkedDocuments, documents.length);
+  const medicationAdherenceRate = medicationLogs30d > 0 ? Math.max(0, 100 - pct(missedMedicationLogs30d, medicationLogs30d)) : 0;
+  const profileReady = Boolean(profile?.fullName && profile?.dateOfBirth && profile?.emergencyContactName && profile?.emergencyContactPhone);
+  const sectionsScore = pct(selectedSections.length, reportSections.length);
+  const dataScore = pct(
+    [profileReady, medications.length > 0, vitals.length > 0, labs.length > 0, symptoms.length > 0, documents.length > 0, appointments.length > 0].filter(Boolean).length,
+    7,
+  );
+  const readinessScore = clampScore((sectionsScore * 0.35) + (dataScore * 0.45) + (documentLinkRate * 0.1) + (medicationAdherenceRate * 0.1));
+
+  const actionItems: ReportActionItem[] = [];
+  if (!profileReady) {
+    actionItems.push({ title: "Complete identity and emergency basics", description: "Report packets are stronger when date of birth, emergency contact, and allergy context are complete.", href: "/onboarding", priority: "high" });
+  }
+  if (highRiskAlerts > 0) {
+    actionItems.push({ title: "Review high-risk alerts before sharing", description: `${highRiskAlerts} high-risk alert${highRiskAlerts === 1 ? "" : "s"} should be reviewed before a report leaves the workspace.`, href: "/alerts", priority: "high" });
+  }
+  if (abnormalLabs > 0) {
+    actionItems.push({ title: "Add lab interpretation context", description: `${abnormalLabs} recent lab result${abnormalLabs === 1 ? "" : "s"} need review notes or follow-up context.`, href: "/lab-review", priority: "medium" });
+  }
+  if (severeSymptoms > 0) {
+    actionItems.push({ title: "Include unresolved severe symptoms", description: `${severeSymptoms} severe unresolved symptom${severeSymptoms === 1 ? "" : "s"} should be included in the provider handoff.`, href: "/symptom-review", priority: "high" });
+  }
+  if (documents.length > 0 && documentLinkRate < 60) {
+    actionItems.push({ title: "Improve document linking", description: `${documentLinkRate}% of recent documents are linked to source records. Link key files before exporting.`, href: "/documents?link=UNLINKED", priority: "medium" });
+  }
+  if (actionItems.length === 0) {
+    actionItems.push({ title: "Report packet is ready for review", description: "Core data, source records, and handoff context look ready for a preview or print packet.", href: "/report-builder/print", priority: "low" });
+  }
+
+  const timeline: ReportTimelineItem[] = [
+    ...appointments.map((item) => ({ id: `appointment-${item.id}`, type: "Appointment", title: item.purpose, detail: `${item.doctorName} • ${item.clinic}`, occurredAt: item.scheduledAt, risk: item.scheduledAt >= now ? "watch" as const : "routine" as const })),
+    ...labs.map((item) => ({ id: `lab-${item.id}`, type: "Lab", title: item.testName, detail: `${item.flag} • ${item.resultSummary}`, occurredAt: item.dateTaken, risk: item.flag === LabFlag.NORMAL ? "routine" as const : "watch" as const })),
+    ...vitals.map((item) => ({ id: `vital-${item.id}`, type: "Vital", title: "Vital reading", detail: `${vitalSummary(item)} • ${item.readingSource}`, occurredAt: item.recordedAt, risk: "routine" as const })),
+    ...symptoms.map((item) => ({ id: `symptom-${item.id}`, type: "Symptom", title: item.title, detail: `${item.severity}${item.bodyArea ? ` • ${item.bodyArea}` : ""}${item.resolved ? " • resolved" : " • unresolved"}`, occurredAt: item.startedAt, risk: item.severity === SymptomSeverity.SEVERE && !item.resolved ? "urgent" as const : !item.resolved ? "watch" as const : "routine" as const })),
+    ...alerts.map((item) => ({ id: `alert-${item.id}`, type: "Alert", title: item.title, detail: `${item.severity} • ${item.message}`, occurredAt: item.createdAt, risk: item.severity === AlertSeverity.CRITICAL || item.severity === AlertSeverity.HIGH ? "urgent" as const : "watch" as const })),
+    ...documents.map((item) => ({ id: `document-${item.id}`, type: "Document", title: item.title, detail: `${item.type} • ${item.fileName}`, occurredAt: item.createdAt, risk: item.linkedRecordId ? "routine" as const : "watch" as const })),
+  ].sort((a, b) => b.occurredAt.getTime() - a.occurredAt.getTime()).slice(0, 20);
+
+  return {
+    reportType,
+    reportTitle: reportTypeLabels[reportType],
+    selectedSections,
+    sectionDefinitions: reportSections,
+    range: {
+      from: options.from || "",
+      to: options.to || "",
+      label: from || to ? `${from ? formatDate(from) : "Beginning"} to ${to ? formatDate(to) : "Today"}` : "All available records",
+    },
+    summary: {
+      readinessScore,
+      selectedSectionCount: selectedSections.length,
+      availableSectionCount: reportSections.length,
+      totalRecords: medications.length + appointments.length + labs.length + vitals.length + symptoms.length + documents.length + alerts.length,
+      highRiskAlerts,
+      abnormalLabs,
+      unresolvedSymptoms,
+      documentLinkRate,
+      medicationAdherenceRate,
+    },
+    profile,
+    medications,
+    appointments,
+    labs,
+    vitals,
+    symptoms,
+    documents,
+    alerts,
+    careAccess,
+    aiInsight,
+    actionItems,
+    timeline,
+  };
+}
+
+export function sectionQuery(sections: ReportSectionKey[]) {
+  return sections.join(",");
+}
+
+export function isSectionSelected(sections: ReportSectionKey[], key: ReportSectionKey) {
+  return sections.includes(key);
+}


### PR DESCRIPTION
This PR fixes Patch 38 validation issues.

Changes:
- Replaces invalid StaggerGroup className usage with a normal grid wrapper
- Removes unused imports from the report builder page, print page, and helper
- Keeps Report Builder behavior intact
- Requires no Prisma migration