### PR TITLE
Patch 40: Role-Based Experience Polish

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 import Link from "next/link";
-import { redirect } from "next/navigation";
 import { AppRole } from "@prisma/client";
 import { AlertTriangle, Ban, CheckCircle2, Cpu, MailCheck, RotateCcw, Shield, UserPlus, Users } from "lucide-react";
 
@@ -9,8 +8,7 @@ import { EmptyState, PageHeader, StatusPill } from "@/components/common";
 import { Badge, Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Table, TBody, TD, Textarea, TH, THead, TR } from "@/components/ui";
 import { isEmailDeliveryConfigured } from "@/lib/account-email";
 import { getAdminWorkspaceData } from "@/lib/admin-dashboard";
-import { APP_ROLES } from "@/lib/domain/enums";
-import { requireUser } from "@/lib/session";
+import { requireRoutePolicy } from "@/lib/route-policy";
 import { deactivateUserAction, reactivateUserAction, resendVerificationForUserAction, revokeUserMobileSessionsAction } from "./actions";
 
 type AdminWorkspaceData = Awaited<ReturnType<typeof getAdminWorkspaceData>>;
@@ -155,8 +153,7 @@ function JobCard({ item }: { item: RecentJobRunItem }) {
 }
 
 export default async function AdminPage() {
-  const user = await requireUser();
-  if (user.role !== APP_ROLES.ADMIN) redirect("/dashboard");
+  const user = await requireRoutePolicy("admin");
 
   const data = await getAdminWorkspaceData();
   const emailEnabled = isEmailDeliveryConfigured();

--- a/app/audit-log/page.tsx
+++ b/app/audit-log/page.tsx
@@ -28,6 +28,7 @@ import {
   TR,
 } from "@/components/ui";
 import { getSecurityAuditCenterData, parseAuditFilters, type SecurityAuditEvent } from "@/lib/audit-log";
+import { isAdminRole } from "@/lib/route-policy";
 import { requireUser } from "@/lib/session";
 
 function formatDateTime(value: Date) {
@@ -109,12 +110,14 @@ export default async function AuditLogPage({
               >
                 Security center
               </Link>
-              <Link
-                href="/jobs"
-                className="inline-flex items-center justify-center rounded-2xl bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground shadow-sm hover:opacity-95"
-              >
-                Job runs
-              </Link>
+              {isAdminRole(user.role) ? (
+                <Link
+                  href="/jobs"
+                  className="inline-flex items-center justify-center rounded-2xl bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground shadow-sm hover:opacity-95"
+                >
+                  Job runs
+                </Link>
+              ) : null}
             </div>
           }
         />

--- a/app/jobs/page.tsx
+++ b/app/jobs/page.tsx
@@ -4,9 +4,8 @@ import { PageHeader, StatusPill } from "@/components/common";
 import { JobDispatchPanel } from "@/components/job-dispatch-panel";
 import { Badge, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
 import { db } from "@/lib/db";
-import { APP_ROLES } from "@/lib/domain/enums";
 import { getJobsDashboardData } from "@/lib/jobs/dashboard";
-import { requireUser } from "@/lib/session";
+import { requireRoutePolicy } from "@/lib/route-policy";
 
 function formatDateTime(value: Date | null | undefined) {
   if (!value) return "—";
@@ -25,17 +24,11 @@ function runTone(status: string) {
 }
 
 export default async function JobsDashboardPage() {
-  const user = await requireUser();
+  await requireRoutePolicy("jobs");
 
   const [dashboard, deviceConnections] = await Promise.all([
     getJobsDashboardData(),
     db.deviceConnection.findMany({
-      where:
-        user.role === APP_ROLES.ADMIN
-          ? undefined
-          : {
-              userId: user.id,
-            },
       select: {
         id: true,
         deviceLabel: true,
@@ -74,21 +67,6 @@ export default async function JobsDashboardPage() {
           </Card>
         ) : null}
 
-        {user.role !== APP_ROLES.ADMIN ? (
-          <Card className="border border-border/60">
-            <CardContent className="pt-6">
-              <div className="flex items-start gap-3">
-                <Cpu className="mt-0.5 h-5 w-5 text-primary" />
-                <div>
-                  <p className="font-medium">Scoped dashboard view</p>
-                  <p className="text-sm text-muted-foreground">
-                    This account is not an admin, so the operational view is best treated as a personal activity panel.
-                  </p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        ) : null}
 
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
           {dashboard.queueCounts.map((queue) => (

--- a/app/ops/page.tsx
+++ b/app/ops/page.tsx
@@ -13,7 +13,7 @@ import { AppShell } from "@/components/app-shell";
 import { PageHeader, StatusPill } from "@/components/common";
 import { Badge, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
 import { getOpsHealthData, type OpsTone } from "@/lib/ops-health";
-import { requireUser } from "@/lib/session";
+import { requireRoutePolicy } from "@/lib/route-policy";
 
 function formatDateTime(value: Date | null | undefined) {
   if (!value) return "—";
@@ -59,8 +59,8 @@ function StatCard({ title, value, description, icon }: { title: string; value: n
 }
 
 export default async function OpsPage() {
-  const user = await requireUser();
-  const data = await getOpsHealthData(user.id!, user.role);
+  const user = await requireRoutePolicy("ops");
+  const data = await getOpsHealthData(user.id, user.role);
 
   return (
     <AppShell>

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -140,3 +140,8 @@ Recommended next action:
 6. Caregiver shared patient workspace
 7. Audit log and security center upgrade
 8. Printable emergency health card
+
+
+## Patch 40 route policy note
+
+Admin-only operational routes are now centrally described in `lib/route-policy.ts`. `/admin`, `/jobs`, and `/ops` are enforced as admin-only direct routes. `/audit-log` remains available to authenticated users with scoped visibility, while `/api-docs` remains an authenticated reviewer/developer reference surface.

--- a/docs/PATCH_40_HOTFIX_ROUTE_POLICY_TEST.md
+++ b/docs/PATCH_40_HOTFIX_ROUTE_POLICY_TEST.md
@@ -1,0 +1,31 @@
+# Patch 40 Hotfix: Route Policy Test Isolation
+
+## Summary
+
+This hotfix keeps the Patch 40 role policy behavior intact while making the pure route policy helpers safe to import in Vitest.
+
+## Problem fixed
+
+`tests/route-policy.test.ts` imported `lib/route-policy.ts`. The previous version of `lib/route-policy.ts` had top-level imports from `next/navigation` and `@/lib/session`. That caused Vitest to follow the Auth.js / Next.js server module chain and fail with:
+
+```txt
+Cannot find module 'next/server' imported from next-auth/lib/env.js
+Did you mean to import "next/server.js"?
+```
+
+## Change
+
+- Removed server-only imports from the top level of `lib/route-policy.ts`.
+- Kept pure helpers importable by tests:
+  - `routePolicies`
+  - `canAccessRoutePolicy`
+  - `isAdminRole`
+- Moved server-only imports into `requireRoutePolicy()` through dynamic imports.
+
+## Safety
+
+- No Prisma changes.
+- No package changes.
+- No route behavior change.
+- No test expectation changes.
+- This only fixes test import isolation.

--- a/docs/PATCH_40_ROLE_BASED_EXPERIENCE_POLISH.md
+++ b/docs/PATCH_40_ROLE_BASED_EXPERIENCE_POLISH.md
@@ -1,0 +1,27 @@
+# Patch 40 — Role-Based Experience Polish
+
+Patch 40 tightens the difference between authenticated user-facing surfaces and administrator-only operations surfaces.
+
+## What changed
+
+- Added `lib/route-policy.ts` as the central policy map for sensitive direct routes.
+- Enforced admin-only direct access for `/admin`, `/jobs`, and `/ops` through shared server-side policy helpers.
+- Kept `/audit-log` visible for regular users as a scoped security/audit workspace while preserving admin-wide visibility in the data layer.
+- Moved `/api-docs` out of the Admin & Ops navigation group and into authenticated account-level navigation for reviewer/mobile API visibility.
+- Hid admin-only audit links from non-admin audit views.
+- Added route-policy tests covering navigation visibility and direct route policy rules.
+
+## Policy after this patch
+
+| Route | Sidebar visibility | Direct access |
+| --- | --- | --- |
+| `/admin` | Admin only | Admin only |
+| `/jobs` | Admin only | Admin only |
+| `/ops` | Admin only | Admin only |
+| `/audit-log` | Authenticated users | Scoped for regular users, wider for admins |
+| `/api-docs` | Authenticated users | Authenticated users |
+| `/device-connection` | Authenticated users | Authenticated users |
+
+## Migration note
+
+This patch intentionally does not touch Prisma schema or migrations. The previously identified reminder migration safety issue should remain a separate focused hotfix.

--- a/lib/app-routes.ts
+++ b/lib/app-routes.ts
@@ -255,38 +255,41 @@ export const accountRoutes: AppRouteItem[] = [
     description: "Password rotation and mobile session visibility",
     icon: ShieldCheck,
   },
-];
-
-export const adminOpsRoutes: AppRouteItem[] = [
   {
     title: "Audit Log",
     href: "/audit-log",
-    description: "Unified audit trail across access, alerts, reminders, jobs, and sessions",
+    description: "Scoped security, access, jobs, reminders, and session audit trail",
     icon: ScrollText,
   },
+  {
+    title: "API Docs",
+    href: "/api-docs",
+    description: "Reviewer-facing mobile and device API reference",
+    icon: BookOpen,
+  },
+];
+
+export const adminOpsRoutes: AppRouteItem[] = [
   {
     title: "Admin",
     href: "/admin",
     description: "User oversight, audit review, and system visibility",
     icon: Users,
+    allowedRoles: ["ADMIN" as AppRole],
   },
   {
     title: "Jobs",
     href: "/jobs",
     description: "Inspect worker queues, retries, and job runs",
     icon: Workflow,
+    allowedRoles: ["ADMIN" as AppRole],
   },
   {
     title: "Operations",
     href: "/ops",
     description: "Deployment readiness, workload risk, and operational runbooks",
     icon: ServerCog,
-  },
-  {
-    title: "API Docs",
-    href: "/api-docs",
-    description: "Mobile and device API reference for reviewers and future clients",
-    icon: BookOpen,
+    allowedRoles: ["ADMIN" as AppRole],
   },
 ];
 
@@ -318,7 +321,7 @@ export const navigationSections: AppRouteSection[] = [
   },
   {
     label: "Admin & Ops",
-    description: "System audit, users, jobs, operations, and API visibility",
+    description: "Admin-only users, jobs, operations, and system controls",
     items: adminOpsRoutes,
     allowedRoles: ["ADMIN" as AppRole],
   },

--- a/lib/route-policy.ts
+++ b/lib/route-policy.ts
@@ -1,0 +1,87 @@
+import { AppRole } from "@prisma/client";
+
+export type RouteAccessLevel = "authenticated" | "admin";
+
+export type RoutePolicy = {
+  title: string;
+  href: string;
+  access: RouteAccessLevel;
+  description: string;
+};
+
+export const routePolicies = {
+  admin: {
+    title: "Admin Command Center",
+    href: "/admin",
+    access: "admin",
+    description: "Admin-only account lifecycle, audit, and system visibility.",
+  },
+  jobs: {
+    title: "Background Jobs",
+    href: "/jobs",
+    access: "admin",
+    description: "Admin-only worker queue, retry, and job-run operations.",
+  },
+  ops: {
+    title: "Operations",
+    href: "/ops",
+    access: "admin",
+    description: "Admin-only deployment readiness, workload risk, and operational runbooks.",
+  },
+  auditLog: {
+    title: "Audit Log",
+    href: "/audit-log",
+    access: "authenticated",
+    description: "Scoped audit visibility for regular users and system-wide visibility for admins.",
+  },
+  apiDocs: {
+    title: "API Docs",
+    href: "/api-docs",
+    access: "authenticated",
+    description: "Authenticated reviewer-facing mobile and device API reference.",
+  },
+  deviceConnection: {
+    title: "Device Connections",
+    href: "/device-connection",
+    access: "authenticated",
+    description: "Authenticated roadmap surface for health-device and mobile integration planning.",
+  },
+} as const satisfies Record<string, RoutePolicy>;
+
+export type RoutePolicyKey = keyof typeof routePolicies;
+
+export function canAccessRoutePolicy(
+  policy: RoutePolicy,
+  role: AppRole | null | undefined
+) {
+  if (!role) return false;
+  if (policy.access === "admin") return role === AppRole.ADMIN;
+  return true;
+}
+
+export function isAdminRole(role: AppRole | null | undefined) {
+  return role === AppRole.ADMIN;
+}
+
+export async function requireRoutePolicy(
+  policyKey: RoutePolicyKey,
+  redirectTo = "/dashboard"
+) {
+  const [{ redirect }, { requireUser }] = await Promise.all([
+    import("next/navigation"),
+    import("@/lib/session"),
+  ]);
+
+  const user = await requireUser();
+  const policy = routePolicies[policyKey];
+
+  if (!canAccessRoutePolicy(policy, user.role)) {
+    redirect(redirectTo);
+  }
+
+  return user;
+}
+
+export async function requireAdminRoute(redirectTo = "/dashboard") {
+  return requireRoutePolicy("admin", redirectTo);
+}

--- a/tests/route-policy.test.ts
+++ b/tests/route-policy.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { AppRole } from "@prisma/client";
+
+import {
+  canAccessRoutePolicy,
+  isAdminRole,
+  routePolicies,
+} from "../lib/route-policy";
+import {
+  getAllAppRoutesForRole,
+  getNavigationSectionsForRole,
+} from "../lib/app-routes";
+
+describe("role-based route policy", () => {
+  it("keeps admin and ops surfaces out of non-admin navigation", () => {
+    const patientRoutes = getAllAppRoutesForRole(AppRole.PATIENT).map(
+      (route) => route.href
+    );
+
+    expect(patientRoutes).not.toContain("/admin");
+    expect(patientRoutes).not.toContain("/jobs");
+    expect(patientRoutes).not.toContain("/ops");
+    expect(patientRoutes).toContain("/audit-log");
+    expect(patientRoutes).toContain("/api-docs");
+  });
+
+  it("keeps admin navigation grouped in an admin-only section", () => {
+    const adminSections = getNavigationSectionsForRole(AppRole.ADMIN);
+    const adminOpsSection = adminSections.find(
+      (section) => section.label === "Admin & Ops"
+    );
+
+    expect(adminOpsSection).toBeDefined();
+    expect(adminOpsSection?.items.map((item) => item.href)).toEqual([
+      "/admin",
+      "/jobs",
+      "/ops",
+    ]);
+  });
+
+  it("marks direct route policies consistently", () => {
+    expect(canAccessRoutePolicy(routePolicies.admin, AppRole.ADMIN)).toBe(true);
+    expect(canAccessRoutePolicy(routePolicies.jobs, AppRole.ADMIN)).toBe(true);
+    expect(canAccessRoutePolicy(routePolicies.ops, AppRole.ADMIN)).toBe(true);
+
+    expect(canAccessRoutePolicy(routePolicies.admin, AppRole.PATIENT)).toBe(false);
+    expect(canAccessRoutePolicy(routePolicies.jobs, AppRole.CAREGIVER)).toBe(false);
+    expect(canAccessRoutePolicy(routePolicies.ops, AppRole.DOCTOR)).toBe(false);
+
+    expect(canAccessRoutePolicy(routePolicies.auditLog, AppRole.PATIENT)).toBe(true);
+    expect(canAccessRoutePolicy(routePolicies.apiDocs, AppRole.CAREGIVER)).toBe(true);
+    expect(isAdminRole(AppRole.ADMIN)).toBe(true);
+    expect(isAdminRole(AppRole.PATIENT)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

This patch improves VitaVault’s role-based experience by making admin/ops surfaces more consistent across sidebar visibility and direct route access.

## Changes

- Added `lib/route-policy.ts` as a central route policy helper.
- Enforced admin-only direct access for:
  - `/admin`
  - `/jobs`
  - `/ops`
- Moved `/audit-log` into authenticated Account navigation because it supports scoped visibility for regular users.
- Moved `/api-docs` out of Admin & Ops so reviewer-facing API docs are not hidden behind admin navigation.
- Hid admin-only audit actions from non-admin users.
- Added route policy tests for navigation and direct route access expectations.
- Added Patch 40 documentation and updated known limitations.

## Safety

- No Prisma schema changes.
- No migration changes.
- No package changes.
- Focused patch only.

## Checks to run

```bash
npm install
npm run actions:check
npm run actions:imports
npm run actions:shadow
npm run typecheck
npm run lint
npm run test:run