### PR TITLE
Patch 42: Mobile API v2 Consistency

### DIFF
--- a/app/api-docs/page.tsx
+++ b/app/api-docs/page.tsx
@@ -91,7 +91,6 @@ const supportedReadings = [
   ["BLOOD_GLUCOSE", "valueFloat", "Mirrors into bloodSugar"],
   ["TEMPERATURE", "valueFloat", "Mirrors into temperatureC"],
   ["STEPS", "valueInt", "Stored as device reading only"],
-  ["SLEEP_MINUTES", "valueInt or metadata", "Stored as device reading only"],
 ];
 
 const loginRequest = `POST ${baseUrl}/api/mobile/auth/login
@@ -264,7 +263,7 @@ export default function ApiDocsPage() {
               <p className="text-xs text-muted-foreground">documented endpoints</p>
             </div>
             <div className="rounded-3xl border border-border/60 bg-background/60 p-4">
-              <p className="text-2xl font-semibold">8</p>
+              <p className="text-2xl font-semibold">7</p>
               <p className="text-xs text-muted-foreground">reading types</p>
             </div>
             <div className="rounded-3xl border border-border/60 bg-background/60 p-4">
@@ -481,7 +480,7 @@ export default function ApiDocsPage() {
               Supported reading types
             </CardTitle>
             <CardDescription>
-              The current API accepts these device reading types. Several are mirrored into normal vitals.
+              The current API accepts these schema-backed device reading types. Several are mirrored into normal vitals.
             </CardDescription>
           </CardHeader>
           <CardContent>

--- a/app/api/mobile/device-readings/route.ts
+++ b/app/api/mobile/device-readings/route.ts
@@ -1,79 +1,11 @@
 import { NextResponse } from "next/server";
-import {
-  DevicePlatform,
-  DeviceReadingType,
-  ReadingSource,
-} from "@prisma/client";
-import { z } from "zod";
 import { requireMobileUser } from "@/lib/mobile-auth";
+import { mobileDeviceSyncSchema } from "@/lib/mobile-device-api";
 import {
   ingestDeviceReadings,
   upsertDeviceConnection,
   type IncomingReading,
 } from "@/lib/mobile-readings";
-
-const readingSchema = z
-  .object({
-    readingType: z.nativeEnum(DeviceReadingType),
-    capturedAt: z.string().min(1),
-    clientReadingId: z.string().trim().min(1).max(191).optional(),
-    unit: z.string().trim().max(40).optional(),
-    valueInt: z.number().int().optional(),
-    valueFloat: z.number().optional(),
-    systolic: z.number().int().optional(),
-    diastolic: z.number().int().optional(),
-    metadata: z.any().optional(),
-    rawPayload: z.any().optional(),
-  })
-  .superRefine((value, ctx) => {
-    if (value.readingType === DeviceReadingType.BLOOD_PRESSURE) {
-      if (value.systolic == null || value.diastolic == null) {
-        ctx.addIssue({
-          code: "custom",
-          message: "Blood pressure readings require systolic and diastolic values.",
-        });
-      }
-      return;
-    }
-
-    if (
-      value.readingType === DeviceReadingType.HEART_RATE ||
-      value.readingType === DeviceReadingType.OXYGEN_SATURATION ||
-      value.readingType === DeviceReadingType.STEPS
-    ) {
-      if (value.valueInt == null) {
-        ctx.addIssue({
-          code: "custom",
-          message: `${value.readingType} requires valueInt.`,
-        });
-      }
-      return;
-    }
-
-    if (
-      value.readingType === DeviceReadingType.WEIGHT ||
-      value.readingType === DeviceReadingType.BLOOD_GLUCOSE ||
-      value.readingType === DeviceReadingType.TEMPERATURE
-    ) {
-      if (value.valueFloat == null) {
-        ctx.addIssue({
-          code: "custom",
-          message: `${value.readingType} requires valueFloat.`,
-        });
-      }
-    }
-  });
-
-const syncSchema = z.object({
-  source: z.nativeEnum(ReadingSource),
-  platform: z.nativeEnum(DevicePlatform),
-  clientDeviceId: z.string().trim().min(1).max(191),
-  deviceLabel: z.string().trim().max(191).optional(),
-  appVersion: z.string().trim().max(60).optional(),
-  scopes: z.array(z.string().trim().min(1).max(120)).max(50).optional(),
-  syncMetadata: z.any().optional(),
-  readings: z.array(readingSchema).min(1).max(500),
-});
 
 export async function POST(request: Request) {
   const user = await requireMobileUser(request);
@@ -87,7 +19,7 @@ export async function POST(request: Request) {
 
   try {
     const body = await request.json();
-    const parsed = syncSchema.safeParse(body);
+    const parsed = mobileDeviceSyncSchema.safeParse(body);
 
     if (!parsed.success) {
       return NextResponse.json(

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -85,18 +85,20 @@ Recommended next action:
 
 ---
 
-### 6. Mobile and device APIs need documentation
+### 6. Mobile and device APIs still need production hardening
 
-The mobile and device ingestion endpoints are one of the strongest backend foundations, but they need clearer product-facing documentation.
+The mobile and device API documentation now matches the implemented endpoints and schema-backed reading types. The remaining work is production hardening, not basic documentation.
 
 Impact:
 
-- reviewers may miss the depth of the API work
-- future mobile integration will be slower without request/response examples
+- mobile tokens and device sync are ready for demo/review flows
+- production use still needs stronger throttling, device management, and possibly OpenAPI/Postman exports
 
 Recommended next action:
 
-- add an API documentation page with authentication, endpoint examples, payload shapes, and error responses
+- add rate limiting around mobile login and device reading ingestion
+- add a Postman/OpenAPI export for QA handoff
+- add device revoke/rename controls in the Security or Device Connection workspace
 
 ---
 
@@ -151,3 +153,17 @@ Remaining database caution:
 - do not reset production databases unless data loss is intended
 - if a local migration attempt already failed, inspect `_prisma_migrations` before retrying
 - keep future Prisma migrations small and focused when changing required columns
+
+---
+
+## Patch 42 update: mobile API v2 consistency
+
+The mobile/device API docs, demo data, and validation contract now use the same current routes:
+
+- `/api/mobile/auth/login`
+- `/api/mobile/auth/me`
+- `/api/mobile/auth/logout`
+- `/api/mobile/connections`
+- `/api/mobile/device-readings`
+
+`SLEEP_MINUTES` is intentionally documented as unsupported until a Prisma enum migration adds it. The current API accepts only schema-backed `DeviceReadingType` values.

--- a/docs/MOBILE_DEVICE_API.md
+++ b/docs/MOBILE_DEVICE_API.md
@@ -1,6 +1,6 @@
 # VitaVault Mobile and Device API
 
-This document summarizes the current VitaVault mobile/device API foundation for Android, mobile sync, QA, and future Postman/OpenAPI work.
+This document summarizes the current VitaVault mobile/device API foundation for Android, mobile sync, QA, and future Postman/OpenAPI work. It intentionally lists only reading types currently backed by the Prisma `DeviceReadingType` enum.
 
 The same information is also available as a product-facing page at:
 
@@ -207,7 +207,10 @@ Content-Type: application/json
 | `BLOOD_GLUCOSE` | `valueFloat` | Mirrors into `bloodSugar` |
 | `TEMPERATURE` | `valueFloat` | Mirrors into `temperatureC` |
 | `STEPS` | `valueInt` | Stored as device reading only |
-| `SLEEP_MINUTES` | `valueInt` or metadata | Stored as device reading only |
+
+### Unsupported or future reading types
+
+`SLEEP_MINUTES` is intentionally not listed as a supported request value yet because it is not present in the current Prisma `DeviceReadingType` enum. Add a dedicated schema migration before exposing sleep tracking to mobile clients.
 
 ## Error responses
 

--- a/docs/PATCH_42_HOTFIX_MOBILE_API_TEST.md
+++ b/docs/PATCH_42_HOTFIX_MOBILE_API_TEST.md
@@ -1,0 +1,27 @@
+# Patch 42 Hotfix: Mobile API Test Fixture Alignment
+
+## Summary
+
+This hotfix aligns the Patch 42 mobile API contract test fixture with the actual Prisma `ReadingSource` enum values in the current VitaVault schema.
+
+## Fixed
+
+- Replaced the invalid test-only enum reference `ReadingSource.MOBILE_APP` with `ReadingSource.ANDROID_HEALTH_CONNECT`.
+- Keeps Patch 42 behavior unchanged.
+- No Prisma schema changes.
+- No migration changes.
+- No package changes.
+
+## Why
+
+The current Prisma schema supports these reading sources: `MANUAL`, `ANDROID_HEALTH_CONNECT`, `APPLE_HEALTH`, `FITBIT`, `SMART_BP_MONITOR`, `SMART_SCALE`, `PULSE_OXIMETER`, and `OTHER`. `MOBILE_APP` does not exist, so TypeScript and Vitest correctly failed on the new Patch 42 test file.
+
+## Checks
+
+Run:
+
+```bash
+npm run typecheck
+npm run lint
+npm run test:run
+```

--- a/docs/PATCH_42_MOBILE_API_V2_CONSISTENCY.md
+++ b/docs/PATCH_42_MOBILE_API_V2_CONSISTENCY.md
@@ -1,0 +1,41 @@
+# Patch 42: Mobile API v2 Consistency
+
+## Summary
+
+This patch aligns the mobile/device API route, docs, demo data, and validation contract so the public product story matches the actual Prisma-backed implementation.
+
+## What changed
+
+- Added `lib/mobile-device-api.ts` as the shared mobile API contract for supported reading types, endpoints, and payload validation.
+- Updated `/api/mobile/device-readings` to use the shared validation schema instead of keeping its own local copy.
+- Removed `SLEEP_MINUTES` from the supported reading table because it is not present in the current Prisma `DeviceReadingType` enum.
+- Added a clear future-reading note explaining that sleep support needs a dedicated Prisma migration before clients send it.
+- Normalized demo API route references to the implemented routes:
+  - `/api/mobile/auth/login`
+  - `/api/mobile/auth/me`
+  - `/api/mobile/auth/logout`
+  - `/api/mobile/connections`
+  - `/api/mobile/device-readings`
+- Added tests for mobile API schema-backed reading types, valid mixed payloads, unsupported sleep readings, invalid timestamps, and missing required reading values.
+- Updated known limitations to reflect that mobile API documentation now exists and the remaining work is production hardening.
+
+## Safety notes
+
+- No Prisma schema changes.
+- No migration changes.
+- No package changes.
+- Sleep tracking is intentionally left as a future feature instead of being added halfway through the API contract.
+
+## Verification
+
+Run:
+
+```bash
+npm run db:validate:ci
+npm run actions:check
+npm run actions:imports
+npm run actions:shadow
+npm run typecheck
+npm run lint
+npm run test:run
+```

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -501,11 +501,11 @@ export const demoAuditLogHub = [
 
 export const demoApiDocsHub = {
   endpoints: [
-    { method: "POST", path: "/api/mobile/login", purpose: "Create bearer-token mobile session" },
-    { method: "GET", path: "/api/mobile/me", purpose: "Validate current mobile user" },
-    { method: "POST", path: "/api/mobile/logout", purpose: "Revoke mobile token" },
-    { method: "GET", path: "/api/device-connections", purpose: "List connected providers" },
-    { method: "POST", path: "/api/device-readings", purpose: "Ingest device reading payloads" },
+    { method: "POST", path: "/api/mobile/auth/login", purpose: "Create bearer-token mobile session" },
+    { method: "GET", path: "/api/mobile/auth/me", purpose: "Validate current mobile user" },
+    { method: "POST", path: "/api/mobile/auth/logout", purpose: "Revoke mobile token" },
+    { method: "GET", path: "/api/mobile/connections", purpose: "List connected providers" },
+    { method: "POST", path: "/api/mobile/device-readings", purpose: "Ingest device reading payloads" },
   ],
   security: [
     "Bearer tokens are scoped to mobile sessions and can be revoked from the Security or Admin workspace.",

--- a/lib/mobile-device-api.ts
+++ b/lib/mobile-device-api.ts
@@ -1,0 +1,163 @@
+import {
+  DevicePlatform,
+  DeviceReadingType,
+  ReadingSource,
+} from "@prisma/client";
+import { z } from "zod";
+
+export const SUPPORTED_DEVICE_READINGS = [
+  {
+    type: DeviceReadingType.HEART_RATE,
+    requiredValue: "valueInt",
+    behavior: "Mirrors into heartRate",
+  },
+  {
+    type: DeviceReadingType.BLOOD_PRESSURE,
+    requiredValue: "systolic + diastolic",
+    behavior: "Mirrors into systolic/diastolic",
+  },
+  {
+    type: DeviceReadingType.OXYGEN_SATURATION,
+    requiredValue: "valueInt",
+    behavior: "Mirrors into oxygenSaturation",
+  },
+  {
+    type: DeviceReadingType.WEIGHT,
+    requiredValue: "valueFloat",
+    behavior: "Mirrors into weightKg",
+  },
+  {
+    type: DeviceReadingType.BLOOD_GLUCOSE,
+    requiredValue: "valueFloat",
+    behavior: "Mirrors into bloodSugar",
+  },
+  {
+    type: DeviceReadingType.TEMPERATURE,
+    requiredValue: "valueFloat",
+    behavior: "Mirrors into temperatureC",
+  },
+  {
+    type: DeviceReadingType.STEPS,
+    requiredValue: "valueInt",
+    behavior: "Stored as device reading only",
+  },
+] as const;
+
+export const SUPPORTED_DEVICE_READING_TYPES = SUPPORTED_DEVICE_READINGS.map(
+  (reading) => reading.type
+);
+
+export const MOBILE_DEVICE_ENDPOINTS = [
+  {
+    method: "POST",
+    path: "/api/mobile/auth/login",
+    auth: "Public credentials",
+    purpose: "Validate email/password and issue a mobile bearer token.",
+  },
+  {
+    method: "GET",
+    path: "/api/mobile/auth/me",
+    auth: "Bearer token",
+    purpose: "Validate current mobile session and return the mobile user.",
+  },
+  {
+    method: "POST",
+    path: "/api/mobile/auth/logout",
+    auth: "Bearer token",
+    purpose: "Revoke the active mobile bearer token.",
+  },
+  {
+    method: "GET",
+    path: "/api/mobile/connections",
+    auth: "Bearer token",
+    purpose: "List device connections, platform, source, status, sync time, and error state.",
+  },
+  {
+    method: "POST",
+    path: "/api/mobile/device-readings",
+    auth: "Bearer token",
+    purpose: "Upsert the device connection, persist raw readings, create a sync job, and mirror supported vitals.",
+  },
+] as const;
+
+function isValidDateTime(value: string) {
+  const date = new Date(value);
+  return !Number.isNaN(date.getTime());
+}
+
+const metadataSchema = z.record(z.unknown());
+
+export const mobileDeviceReadingSchema = z
+  .object({
+    readingType: z.nativeEnum(DeviceReadingType),
+    capturedAt: z.string().trim().min(1, "capturedAt is required."),
+    clientReadingId: z.string().trim().min(1).max(191).optional(),
+    unit: z.string().trim().max(40).optional(),
+    valueInt: z.number().int().optional(),
+    valueFloat: z.number().optional(),
+    systolic: z.number().int().optional(),
+    diastolic: z.number().int().optional(),
+    metadata: metadataSchema.optional(),
+    rawPayload: metadataSchema.optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (!isValidDateTime(value.capturedAt)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["capturedAt"],
+        message: "capturedAt must be a valid ISO date/time value.",
+      });
+    }
+
+    if (value.readingType === DeviceReadingType.BLOOD_PRESSURE) {
+      if (value.systolic == null || value.diastolic == null) {
+        ctx.addIssue({
+          code: "custom",
+          message: "Blood pressure readings require systolic and diastolic values.",
+        });
+      }
+      return;
+    }
+
+    if (
+      value.readingType === DeviceReadingType.HEART_RATE ||
+      value.readingType === DeviceReadingType.OXYGEN_SATURATION ||
+      value.readingType === DeviceReadingType.STEPS
+    ) {
+      if (value.valueInt == null) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["valueInt"],
+          message: `${value.readingType} requires valueInt.`,
+        });
+      }
+      return;
+    }
+
+    if (
+      value.readingType === DeviceReadingType.WEIGHT ||
+      value.readingType === DeviceReadingType.BLOOD_GLUCOSE ||
+      value.readingType === DeviceReadingType.TEMPERATURE
+    ) {
+      if (value.valueFloat == null) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["valueFloat"],
+          message: `${value.readingType} requires valueFloat.`,
+        });
+      }
+    }
+  });
+
+export const mobileDeviceSyncSchema = z.object({
+  source: z.nativeEnum(ReadingSource),
+  platform: z.nativeEnum(DevicePlatform),
+  clientDeviceId: z.string().trim().min(1).max(191),
+  deviceLabel: z.string().trim().max(191).optional(),
+  appVersion: z.string().trim().max(60).optional(),
+  scopes: z.array(z.string().trim().min(1).max(120)).max(50).optional(),
+  syncMetadata: metadataSchema.optional(),
+  readings: z.array(mobileDeviceReadingSchema).min(1).max(500),
+});
+
+export type MobileDeviceSyncPayload = z.infer<typeof mobileDeviceSyncSchema>;

--- a/tests/mobile-device-api.test.ts
+++ b/tests/mobile-device-api.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import {
+  DevicePlatform,
+  DeviceReadingType,
+  ReadingSource,
+} from "@prisma/client";
+import {
+  SUPPORTED_DEVICE_READING_TYPES,
+  mobileDeviceSyncSchema,
+} from "@/lib/mobile-device-api";
+
+const basePayload = {
+  source: ReadingSource.ANDROID_HEALTH_CONNECT,
+  platform: DevicePlatform.ANDROID,
+  clientDeviceId: "android-pixel-8-pro",
+  deviceLabel: "Pixel 8 Pro",
+  appVersion: "1.0.0",
+  scopes: ["vitals:write", "device:sync"],
+  syncMetadata: {
+    batteryLevel: 88,
+    network: "wifi",
+  },
+};
+
+describe("mobile device API contract", () => {
+  it("lists only schema-backed device reading types", () => {
+    expect(SUPPORTED_DEVICE_READING_TYPES).toEqual([
+      DeviceReadingType.HEART_RATE,
+      DeviceReadingType.BLOOD_PRESSURE,
+      DeviceReadingType.OXYGEN_SATURATION,
+      DeviceReadingType.WEIGHT,
+      DeviceReadingType.BLOOD_GLUCOSE,
+      DeviceReadingType.TEMPERATURE,
+      DeviceReadingType.STEPS,
+    ]);
+    expect(SUPPORTED_DEVICE_READING_TYPES).not.toContain("SLEEP_MINUTES");
+  });
+
+  it("accepts a valid mixed reading sync payload", () => {
+    const result = mobileDeviceSyncSchema.safeParse({
+      ...basePayload,
+      readings: [
+        {
+          readingType: DeviceReadingType.HEART_RATE,
+          capturedAt: "2026-04-29T08:35:00.000Z",
+          clientReadingId: "hr-001",
+          unit: "bpm",
+          valueInt: 78,
+        },
+        {
+          readingType: DeviceReadingType.BLOOD_PRESSURE,
+          capturedAt: "2026-04-29T08:36:00.000Z",
+          clientReadingId: "bp-001",
+          unit: "mmHg",
+          systolic: 118,
+          diastolic: 76,
+        },
+        {
+          readingType: DeviceReadingType.WEIGHT,
+          capturedAt: "2026-04-29T08:37:00.000Z",
+          clientReadingId: "weight-001",
+          unit: "kg",
+          valueFloat: 71.4,
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unsupported sleep readings until the schema adds them", () => {
+    const result = mobileDeviceSyncSchema.safeParse({
+      ...basePayload,
+      readings: [
+        {
+          readingType: "SLEEP_MINUTES",
+          capturedAt: "2026-04-29T08:35:00.000Z",
+          clientReadingId: "sleep-001",
+          unit: "minutes",
+          valueInt: 420,
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid capturedAt values as a 400-level validation problem", () => {
+    const result = mobileDeviceSyncSchema.safeParse({
+      ...basePayload,
+      readings: [
+        {
+          readingType: DeviceReadingType.HEART_RATE,
+          capturedAt: "not-a-date",
+          clientReadingId: "hr-001",
+          unit: "bpm",
+          valueInt: 78,
+        },
+      ],
+    });
+
+    if (result.success) {
+      throw new Error("Expected invalid capturedAt to fail validation.");
+    }
+
+    expect(JSON.stringify(result.error.flatten())).toContain(
+      "capturedAt must be a valid ISO date/time value."
+    );
+  });
+
+  it("enforces required value fields per reading type", () => {
+    const result = mobileDeviceSyncSchema.safeParse({
+      ...basePayload,
+      readings: [
+        {
+          readingType: DeviceReadingType.BLOOD_GLUCOSE,
+          capturedAt: "2026-04-29T08:35:00.000Z",
+          clientReadingId: "glucose-001",
+          unit: "mg/dL",
+        },
+      ],
+    });
+
+    if (result.success) {
+      throw new Error("Expected missing valueFloat to fail validation.");
+    }
+
+    expect(JSON.stringify(result.error.flatten())).toContain(
+      "BLOOD_GLUCOSE requires valueFloat."
+    );
+  });
+});


### PR DESCRIPTION
## Summary

This patch aligns VitaVault’s mobile/device API documentation, demo data, route validation, and schema-backed reading type contract.

## Changes

- Added `lib/mobile-device-api.ts` as the shared mobile API contract.
- Updated `/api/mobile/device-readings` to use shared payload validation.
- Removed `SLEEP_MINUTES` from supported reading tables because it is not currently in the Prisma enum.
- Added a future-note explaining that sleep support requires a dedicated enum/schema migration.
- Normalized outdated demo API routes to the implemented `/api/mobile/...` endpoints.
- Added validation for invalid `capturedAt` values.
- Added mobile API contract tests.

## Safety

- No Prisma schema changes.
- No migration changes.
- No package changes.
- Keeps sleep tracking as a future feature instead of adding an unsafe partial enum change.

## Checks to run

```bash
npm install
npm run db:validate:ci
npm run actions:check
npm run actions:imports
npm run actions:shadow
npm run typecheck
npm run lint
npm run test:run