### PR TITLE
Patch 43: Report Builder Presets + History Polish

### DIFF
--- a/app/report-builder/page.tsx
+++ b/app/report-builder/page.tsx
@@ -3,9 +3,18 @@ import { ArrowRight, CalendarDays, CheckCircle2, FileText, Printer, SlidersHoriz
 import { AppShell } from "@/components/app-shell";
 import { EmptyState, PageHeader, StatusPill } from "@/components/common";
 import { Badge, Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Input, Label, Select } from "@/components/ui";
-import { ModuleHero, DataCard } from "@/components/module-sections";
+import { DataCard, ModuleHero } from "@/components/module-sections";
 import { PageTransition, StaggerItem } from "@/components/page-transition";
-import { getReportBuilderData, isSectionSelected, sectionQuery, type ReportActionItem, type ReportType } from "@/lib/report-builder";
+import {
+  buildReportBuilderHref,
+  buildReportPrintHref,
+  getReportBuilderData,
+  isSectionSelected,
+  sectionQuery,
+  type ReportActionItem,
+  type ReportHistoryItem,
+  type ReportType,
+} from "@/lib/report-builder";
 
 const reportTypeOptions: Array<{ value: ReportType; label: string; description: string }> = [
   { value: "patient", label: "Patient summary", description: "Broad personal record packet" },
@@ -19,6 +28,16 @@ function priorityTone(priority: ReportActionItem["priority"]) {
   if (priority === "high") return "danger" as const;
   if (priority === "medium") return "warning" as const;
   return "success" as const;
+}
+
+function historyTone(status: ReportHistoryItem["status"]) {
+  if (status === "attention") return "danger" as const;
+  if (status === "review") return "warning" as const;
+  return "success" as const;
+}
+
+function formatDateTime(value: Date) {
+  return new Intl.DateTimeFormat("en-PH", { dateStyle: "medium", timeStyle: "short" }).format(value);
 }
 
 function ProgressBar({ value }: { value: number }) {
@@ -46,12 +65,14 @@ function ActionCard({ item }: { item: ReportActionItem }) {
 
 export default async function ReportBuilderPage({ searchParams }: { searchParams?: Promise<Record<string, string | string[] | undefined>> }) {
   const params = (await searchParams) ?? {};
+  const preset = typeof params.preset === "string" ? params.preset : undefined;
   const reportType = typeof params.type === "string" ? params.type : "patient";
   const sections = Array.isArray(params.sections) ? params.sections.join(",") : typeof params.sections === "string" ? params.sections : undefined;
   const from = typeof params.from === "string" ? params.from : "";
   const to = typeof params.to === "string" ? params.to : "";
-  const data = await getReportBuilderData({ reportType, sections, from, to });
-  const printHref = `/report-builder/print?type=${data.reportType}&sections=${encodeURIComponent(sectionQuery(data.selectedSections))}${from ? `&from=${from}` : ""}${to ? `&to=${to}` : ""}`;
+  const data = await getReportBuilderData({ preset, reportType, sections, from, to });
+  const selectedSectionsQuery = sectionQuery(data.selectedSections);
+  const printHref = buildReportPrintHref({ preset: data.selectedPreset?.id, reportType: data.reportType, sections: selectedSectionsQuery, from: data.range.from, to: data.range.to });
 
   return (
     <AppShell>
@@ -59,7 +80,7 @@ export default async function ReportBuilderPage({ searchParams }: { searchParams
         <PageTransition>
           <PageHeader
             title="Report Builder"
-            description="Assemble custom patient, doctor, emergency, and care-team report packets with section controls, date ranges, and readiness checks."
+            description="Assemble custom patient, doctor, emergency, and care-team report packets with presets, section controls, date ranges, readiness checks, and print previews."
             action={
               <div className="flex flex-wrap gap-2">
                 <Link href={printHref} className="inline-flex h-10 items-center justify-center rounded-2xl bg-primary px-4 text-sm font-medium text-primary-foreground shadow-sm hover:opacity-95">
@@ -75,15 +96,42 @@ export default async function ReportBuilderPage({ searchParams }: { searchParams
           <ModuleHero
             eyebrow="Custom reporting"
             title="Build a report packet from the records that matter for the situation"
-            description="Pick the packet type, choose sections, narrow the date range, and open a print-ready preview before sharing with a provider, caregiver, or emergency contact."
+            description="Start from a provider, emergency, care-team, medication, or lab preset, then fine-tune the sections and date range before opening a print-ready packet."
             stats={[
               { label: "Readiness", value: `${data.summary.readinessScore}%`, hint: "Section coverage, data coverage, documents, and adherence" },
-              { label: "Sections", value: `${data.summary.selectedSectionCount}/${data.summary.availableSectionCount}`, hint: "Selected for this packet" },
+              { label: "Sections", value: `${data.summary.selectedSectionCount}/${data.summary.availableSectionCount}`, hint: data.selectedPreset ? `${data.selectedPreset.label} preset` : "Selected for this packet" },
               { label: "Records", value: data.summary.totalRecords, hint: data.range.label },
               { label: "Document links", value: `${data.summary.documentLinkRate}%`, hint: "Linked to source records" },
             ]}
           />
         </PageTransition>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Packet presets</CardTitle>
+            <CardDescription className="mt-1">Use scenario-based shortcuts for common healthcare handoffs, then adjust the controls below.</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+            {data.presets.map((presetItem) => {
+              const href = buildReportBuilderHref({ preset: presetItem.id });
+              const isActive = data.selectedPreset?.id === presetItem.id;
+              return (
+                <Link
+                  key={presetItem.id}
+                  href={href}
+                  className={`rounded-2xl border p-4 transition hover:border-border hover:bg-muted/40 ${isActive ? "border-primary/50 bg-primary/5" : "border-border/60 bg-background/50"}`}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <Badge>{presetItem.badge}</Badge>
+                    {isActive ? <CheckCircle2 className="h-4 w-4 text-primary" /> : null}
+                  </div>
+                  <p className="mt-3 font-medium">{presetItem.label}</p>
+                  <p className="mt-1 text-xs text-muted-foreground">{presetItem.description}</p>
+                </Link>
+              );
+            })}
+          </CardContent>
+        </Card>
 
         <div className="grid gap-6 xl:grid-cols-[0.95fr_1.05fr]">
           <Card>
@@ -103,17 +151,17 @@ export default async function ReportBuilderPage({ searchParams }: { searchParams
                     <Label htmlFor="type">Report type</Label>
                     <Select id="type" name="type" defaultValue={data.reportType}>
                       {reportTypeOptions.map((option) => (
-                        <option key={option.value} value={option.value}>{option.label}</option>
+                        <option key={option.value} value={option.value}>{option.label} — {option.description}</option>
                       ))}
                     </Select>
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="from">From</Label>
-                    <Input id="from" name="from" type="date" defaultValue={from} />
+                    <Input id="from" name="from" type="date" defaultValue={data.range.from} />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="to">To</Label>
-                    <Input id="to" name="to" type="date" defaultValue={to} />
+                    <Input id="to" name="to" type="date" defaultValue={data.range.to} />
                   </div>
                 </div>
 
@@ -234,6 +282,26 @@ export default async function ReportBuilderPage({ searchParams }: { searchParams
             </Card>
           </StaggerItem>
         </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Recent packet history</CardTitle>
+            <CardDescription className="mt-1">A lightweight generated history of the current draft, latest source event, and pre-share checks.</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-3 md:grid-cols-3">
+            {data.reportHistory.map((item) => (
+              <Link key={item.id} href={item.href} className="rounded-2xl border border-border/60 bg-background/50 p-4 transition hover:border-border hover:bg-muted/40">
+                <div className="flex items-start justify-between gap-3">
+                  <StatusPill tone={historyTone(item.status)}>{item.status}</StatusPill>
+                  <Badge>{item.recordCount} item{item.recordCount === 1 ? "" : "s"}</Badge>
+                </div>
+                <p className="mt-3 font-medium">{item.title}</p>
+                <p className="mt-1 text-sm text-muted-foreground">{item.description || "No additional checks required."}</p>
+                <p className="mt-3 text-xs text-muted-foreground">{formatDateTime(item.generatedAt)}</p>
+              </Link>
+            ))}
+          </CardContent>
+        </Card>
 
         <Card className="bg-background/40">
           <CardContent className="flex flex-col gap-4 p-5 md:flex-row md:items-center md:justify-between">

--- a/app/report-builder/print/page.tsx
+++ b/app/report-builder/print/page.tsx
@@ -41,12 +41,13 @@ function PrintTimelineItem({ item }: { item: ReportTimelineItem }) {
 
 export default async function ReportBuilderPrintPage({ searchParams }: { searchParams?: Promise<Record<string, string | string[] | undefined>> }) {
   const params = (await searchParams) ?? {};
+  const preset = typeof params.preset === "string" ? params.preset : undefined;
   const reportType = typeof params.type === "string" ? params.type : "patient";
   const sections = Array.isArray(params.sections) ? params.sections.join(",") : typeof params.sections === "string" ? params.sections : undefined;
   const from = typeof params.from === "string" ? params.from : "";
   const to = typeof params.to === "string" ? params.to : "";
   const autoprint = params.autoprint === "1";
-  const data = await getReportBuilderData({ reportType, sections, from, to });
+  const data = await getReportBuilderData({ preset, reportType, sections, from, to });
 
   return (
     <main className="min-h-screen bg-white p-8 text-slate-950 print:p-0">
@@ -58,6 +59,7 @@ export default async function ReportBuilderPrintPage({ searchParams }: { searchP
             <div>
               <h1 className="text-3xl font-bold tracking-tight">{data.reportTitle}</h1>
               <p className="mt-2 text-sm text-slate-600">Generated {formatDateTime(new Date())} • {data.range.label}</p>
+              {data.selectedPreset ? <p className="mt-1 text-xs font-medium uppercase tracking-wide text-slate-500">Preset: {data.selectedPreset.label}</p> : null}
             </div>
             <div className="text-right text-sm text-slate-600">
               <p>{data.summary.selectedSectionCount} sections selected</p>

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -167,3 +167,15 @@ The mobile/device API docs, demo data, and validation contract now use the same 
 - `/api/mobile/device-readings`
 
 `SLEEP_MINUTES` is intentionally documented as unsupported until a Prisma enum migration adds it. The current API accepts only schema-backed `DeviceReadingType` values.
+
+---
+
+## Patch 43 update: report builder presets and generated history
+
+The Report Builder now supports scenario-based presets and a generated packet history panel. This improves the portfolio/demo experience without introducing a new database table.
+
+Remaining reporting limitation:
+
+- report history is generated from current records and query parameters, not persisted as saved report records
+- real saved report history, share links, and export audit retention should be added later with a dedicated Prisma model
+- preset templates are intentionally code-defined for safety and simple review

--- a/docs/PATCH_43_REPORT_BUILDER_PRESETS_HISTORY.md
+++ b/docs/PATCH_43_REPORT_BUILDER_PRESETS_HISTORY.md
@@ -1,0 +1,49 @@
+# Patch 43: Report Builder Presets + History Polish
+
+## Summary
+
+Patch 43 improves the Report Builder experience without adding database tables or Prisma migrations. The report surface now has scenario-based presets, cleaner generated links, and a lightweight packet history panel based on the current report draft and source events.
+
+## What changed
+
+- Added `lib/report-builder-presets.ts` as a pure, testable report preset contract.
+- Added presets for:
+  - Doctor visit packet
+  - Emergency handoff
+  - Care-team weekly review
+  - Medication review
+  - Lab follow-up
+- Updated `/report-builder` to show preset cards above manual controls.
+- Presets now generate report type, section selection, and date ranges through query parameters.
+- Added a recent packet history panel for:
+  - current draft
+  - latest source event
+  - pre-share checks
+- Updated `/report-builder/print` to preserve preset context and display the selected preset label.
+- Added unit tests for preset resolution, generated links, override behavior, and invalid preset handling.
+
+## Safety notes
+
+- No Prisma schema changes.
+- No migration changes.
+- No package changes.
+- The packet history is computed from current report data and does not create a persistence requirement.
+- Presets are query-driven, so they are safe for demo, portfolio, and local review flows.
+
+## Checks
+
+Run:
+
+```bash
+npm run db:validate:ci
+npm run actions:check
+npm run actions:imports
+npm run actions:shadow
+npm run typecheck
+npm run lint
+npm run test:run
+```
+
+## Future upgrade path
+
+A later patch can add persistent saved reports with a proper Prisma model if VitaVault needs real report history, share links, or export audit retention.

--- a/lib/report-builder-presets.ts
+++ b/lib/report-builder-presets.ts
@@ -1,0 +1,157 @@
+export type ReportSectionKey =
+  | "profile"
+  | "medications"
+  | "vitals"
+  | "labs"
+  | "symptoms"
+  | "appointments"
+  | "documents"
+  | "alerts"
+  | "careTeam"
+  | "aiInsights"
+  | "timeline";
+
+export type ReportType = "patient" | "doctor" | "emergency" | "care" | "custom";
+
+export type ReportPresetId =
+  | "doctor-visit"
+  | "emergency-handoff"
+  | "care-team-weekly"
+  | "medication-review"
+  | "lab-follow-up";
+
+export type ReportPresetDefinition = {
+  id: ReportPresetId;
+  label: string;
+  description: string;
+  reportType: ReportType;
+  sections: ReportSectionKey[];
+  rangeDays?: number;
+  badge: string;
+};
+
+export type ReportBuilderControlInput = {
+  preset?: string;
+  reportType?: string;
+  sections?: string;
+  from?: string;
+  to?: string;
+};
+
+export type ResolvedReportBuilderControls = {
+  presetId?: ReportPresetId;
+  reportType: ReportType;
+  sections?: string;
+  from: string;
+  to: string;
+};
+
+export const reportBuilderPresets: ReportPresetDefinition[] = [
+  {
+    id: "doctor-visit",
+    label: "Doctor visit packet",
+    description: "Provider-ready summary with medications, vitals, labs, symptoms, appointments, documents, AI context, and timeline.",
+    reportType: "doctor",
+    sections: ["profile", "medications", "vitals", "labs", "symptoms", "appointments", "documents", "alerts", "aiInsights", "timeline"],
+    rangeDays: 90,
+    badge: "Provider handoff",
+  },
+  {
+    id: "emergency-handoff",
+    label: "Emergency handoff",
+    description: "Fast critical snapshot focused on identity, allergies, medications, latest vitals, alerts, and emergency context.",
+    reportType: "emergency",
+    sections: ["profile", "medications", "vitals", "alerts"],
+    badge: "Critical snapshot",
+  },
+  {
+    id: "care-team-weekly",
+    label: "Care-team weekly review",
+    description: "Collaboration packet for caregivers with alerts, care access, appointments, symptoms, documents, and recent timeline activity.",
+    reportType: "care",
+    sections: ["profile", "medications", "vitals", "symptoms", "appointments", "documents", "alerts", "careTeam", "timeline"],
+    rangeDays: 7,
+    badge: "Care review",
+  },
+  {
+    id: "medication-review",
+    label: "Medication review",
+    description: "Medication-focused packet for adherence checks, active prescriptions, safety alerts, and provider conversations.",
+    reportType: "doctor",
+    sections: ["profile", "medications", "vitals", "alerts", "documents", "timeline"],
+    rangeDays: 30,
+    badge: "Safety check",
+  },
+  {
+    id: "lab-follow-up",
+    label: "Lab follow-up",
+    description: "Lab-focused packet with abnormal results, related vitals, documents, AI questions, and follow-up timeline.",
+    reportType: "doctor",
+    sections: ["profile", "labs", "vitals", "documents", "alerts", "aiInsights", "timeline"],
+    rangeDays: 180,
+    badge: "Results review",
+  },
+];
+
+const reportTypeValues = new Set<ReportType>(["patient", "doctor", "emergency", "care", "custom"]);
+
+export function asReportType(value: string | undefined): ReportType {
+  return value && reportTypeValues.has(value as ReportType) ? (value as ReportType) : "patient";
+}
+
+export function getReportBuilderPreset(value: string | undefined) {
+  return reportBuilderPresets.find((preset) => preset.id === value);
+}
+
+function formatDateInput(value: Date) {
+  return value.toISOString().slice(0, 10);
+}
+
+function subtractDays(value: Date, days: number) {
+  const next = new Date(value);
+  next.setDate(next.getDate() - days);
+  return next;
+}
+
+function cleanDateInput(value: string | undefined) {
+  if (!value) return "";
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? "" : value;
+}
+
+export function sectionQuery(sections: ReportSectionKey[]) {
+  return sections.join(",");
+}
+
+export function resolveReportBuilderControls(input: ReportBuilderControlInput = {}, baseDate = new Date()): ResolvedReportBuilderControls {
+  const preset = getReportBuilderPreset(input.preset);
+  const to = cleanDateInput(input.to) || (preset?.rangeDays ? formatDateInput(baseDate) : "");
+  const from = cleanDateInput(input.from) || (preset?.rangeDays ? formatDateInput(subtractDays(baseDate, preset.rangeDays)) : "");
+
+  return {
+    presetId: preset?.id,
+    reportType: asReportType(input.reportType || preset?.reportType),
+    sections: input.sections || (preset ? sectionQuery(preset.sections) : undefined),
+    from,
+    to,
+  };
+}
+
+export function buildReportBuilderHref(input: ReportBuilderControlInput = {}, baseDate = new Date()) {
+  const resolved = resolveReportBuilderControls(input, baseDate);
+  const params = new URLSearchParams();
+
+  if (resolved.presetId) params.set("preset", resolved.presetId);
+  params.set("type", resolved.reportType);
+  if (resolved.sections) params.set("sections", resolved.sections);
+  if (resolved.from) params.set("from", resolved.from);
+  if (resolved.to) params.set("to", resolved.to);
+
+  const query = params.toString();
+  return `/report-builder${query ? `?${query}` : ""}`;
+}
+
+export function buildReportPrintHref(input: ReportBuilderControlInput = {}, baseDate = new Date()) {
+  const href = buildReportBuilderHref(input, baseDate);
+  return href.replace("/report-builder", "/report-builder/print");
+}

--- a/lib/report-builder.ts
+++ b/lib/report-builder.ts
@@ -7,24 +7,22 @@ import {
   SymptomSeverity,
 } from "@prisma/client";
 import { db } from "@/lib/db";
+import {
+  buildReportPrintHref,
+  getReportBuilderPreset,
+  reportBuilderPresets,
+  resolveReportBuilderControls,
+  sectionQuery,
+  type ReportSectionKey,
+  type ReportType,
+} from "@/lib/report-builder-presets";
 import { requireUser } from "@/lib/session";
 
-export type ReportSectionKey =
-  | "profile"
-  | "medications"
-  | "vitals"
-  | "labs"
-  | "symptoms"
-  | "appointments"
-  | "documents"
-  | "alerts"
-  | "careTeam"
-  | "aiInsights"
-  | "timeline";
-
-export type ReportType = "patient" | "doctor" | "emergency" | "care" | "custom";
+export { buildReportBuilderHref, buildReportPrintHref, reportBuilderPresets, sectionQuery } from "@/lib/report-builder-presets";
+export type { ReportPresetDefinition, ReportPresetId, ReportSectionKey, ReportType } from "@/lib/report-builder-presets";
 
 export type ReportBuilderOptions = {
+  preset?: string;
   reportType?: string;
   sections?: string;
   from?: string;
@@ -54,6 +52,16 @@ export type ReportTimelineItem = {
   risk: "urgent" | "watch" | "routine";
 };
 
+export type ReportHistoryItem = {
+  id: string;
+  title: string;
+  description: string;
+  href: string;
+  generatedAt: Date;
+  status: "ready" | "review" | "attention";
+  recordCount: number;
+};
+
 export const reportSections: ReportSectionDefinition[] = [
   { key: "profile", label: "Profile", description: "Identity, emergency contact, allergies, and baseline context.", recommendedFor: ["patient", "doctor", "emergency", "care", "custom"] },
   { key: "medications", label: "Medications", description: "Active medications, provider links, schedules, and recent adherence.", recommendedFor: ["patient", "doctor", "emergency", "care", "custom"] },
@@ -75,11 +83,6 @@ const reportTypeLabels: Record<ReportType, string> = {
   care: "Care-team review packet",
   custom: "Custom report packet",
 };
-
-function asReportType(value: string | undefined): ReportType {
-  if (value === "patient" || value === "doctor" || value === "emergency" || value === "care" || value === "custom") return value;
-  return "patient";
-}
 
 function parseDate(value: string | undefined) {
   if (!value) return undefined;
@@ -150,11 +153,16 @@ function vitalSummary(vital: {
 
 export async function getReportBuilderData(options: ReportBuilderOptions = {}) {
   const user = await requireUser();
-  const reportType = asReportType(options.reportType);
-  const selectedSections = parseSections(options.sections, reportType);
-  const from = parseDate(options.from);
-  const to = parseDate(options.to);
   const now = new Date();
+  const controls = resolveReportBuilderControls(
+    { preset: options.preset, reportType: options.reportType, sections: options.sections, from: options.from, to: options.to },
+    now,
+  );
+  const reportType = controls.reportType;
+  const selectedSections = parseSections(controls.sections, reportType);
+  const from = parseDate(controls.from);
+  const to = parseDate(controls.to);
+  const selectedPreset = getReportBuilderPreset(controls.presetId);
   const thirtyDaysAgo = new Date(now);
   thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
@@ -286,14 +294,49 @@ export async function getReportBuilderData(options: ReportBuilderOptions = {}) {
     ...documents.map((item) => ({ id: `document-${item.id}`, type: "Document", title: item.title, detail: `${item.type} • ${item.fileName}`, occurredAt: item.createdAt, risk: item.linkedRecordId ? "routine" as const : "watch" as const })),
   ].sort((a, b) => b.occurredAt.getTime() - a.occurredAt.getTime()).slice(0, 20);
 
+  const printHref = buildReportPrintHref({ reportType, sections: sectionQuery(selectedSections), from: controls.from, to: controls.to, preset: controls.presetId });
+  const reportHistory: ReportHistoryItem[] = [
+    {
+      id: "current-draft",
+      title: selectedPreset ? `${selectedPreset.label} draft` : `${reportTypeLabels[reportType]} draft`,
+      description: `${selectedSections.length} sections • ${medications.length + appointments.length + labs.length + vitals.length + symptoms.length + documents.length + alerts.length} source records • ${controls.from || controls.to ? "date-filtered" : "all records"}`,
+      href: printHref,
+      generatedAt: now,
+      status: readinessScore >= 75 ? "ready" : readinessScore >= 50 ? "review" : "attention",
+      recordCount: medications.length + appointments.length + labs.length + vitals.length + symptoms.length + documents.length + alerts.length,
+    },
+    ...(timeline[0]
+      ? [{
+          id: "latest-event",
+          title: `Latest packet event: ${timeline[0].title}`,
+          description: `${timeline[0].type} • ${timeline[0].detail}`,
+          href: `/timeline`,
+          generatedAt: timeline[0].occurredAt,
+          status: timeline[0].risk === "urgent" ? "attention" as const : timeline[0].risk === "watch" ? "review" as const : "ready" as const,
+          recordCount: timeline.length,
+        }]
+      : []),
+    {
+      id: "pre-share-checks",
+      title: "Pre-share review queue",
+      description: actionItems.map((item) => item.title).slice(0, 2).join(" • "),
+      href: actionItems[0]?.href || printHref,
+      generatedAt: now,
+      status: actionItems.some((item) => item.priority === "high") ? "attention" : actionItems.some((item) => item.priority === "medium") ? "review" : "ready",
+      recordCount: actionItems.length,
+    },
+  ];
+
   return {
     reportType,
     reportTitle: reportTypeLabels[reportType],
+    selectedPreset,
+    presets: reportBuilderPresets,
     selectedSections,
     sectionDefinitions: reportSections,
     range: {
-      from: options.from || "",
-      to: options.to || "",
+      from: controls.from,
+      to: controls.to,
       label: from || to ? `${from ? formatDate(from) : "Beginning"} to ${to ? formatDate(to) : "Today"}` : "All available records",
     },
     summary: {
@@ -319,11 +362,8 @@ export async function getReportBuilderData(options: ReportBuilderOptions = {}) {
     aiInsight,
     actionItems,
     timeline,
+    reportHistory,
   };
-}
-
-export function sectionQuery(sections: ReportSectionKey[]) {
-  return sections.join(",");
 }
 
 export function isSectionSelected(sections: ReportSectionKey[], key: ReportSectionKey) {

--- a/tests/report-builder-presets.test.ts
+++ b/tests/report-builder-presets.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildReportBuilderHref,
+  buildReportPrintHref,
+  getReportBuilderPreset,
+  reportBuilderPresets,
+  resolveReportBuilderControls,
+} from "@/lib/report-builder-presets";
+
+describe("report builder presets", () => {
+  it("keeps every preset tied to at least one report section", () => {
+    expect(reportBuilderPresets.length).toBeGreaterThanOrEqual(5);
+    expect(reportBuilderPresets.every((preset) => preset.sections.length > 0)).toBe(true);
+  });
+
+  it("resolves a doctor visit preset into a dated provider packet", () => {
+    const resolved = resolveReportBuilderControls({ preset: "doctor-visit" }, new Date("2026-05-06T00:00:00.000Z"));
+
+    expect(resolved.presetId).toBe("doctor-visit");
+    expect(resolved.reportType).toBe("doctor");
+    expect(resolved.sections).toContain("medications");
+    expect(resolved.sections).toContain("timeline");
+    expect(resolved.from).toBe("2026-02-05");
+    expect(resolved.to).toBe("2026-05-06");
+  });
+
+  it("allows explicit controls to override preset dates and report type", () => {
+    const resolved = resolveReportBuilderControls(
+      { preset: "care-team-weekly", reportType: "custom", sections: "profile,alerts", from: "2026-04-01", to: "2026-04-30" },
+      new Date("2026-05-06T00:00:00.000Z"),
+    );
+
+    expect(resolved.presetId).toBe("care-team-weekly");
+    expect(resolved.reportType).toBe("custom");
+    expect(resolved.sections).toBe("profile,alerts");
+    expect(resolved.from).toBe("2026-04-01");
+    expect(resolved.to).toBe("2026-04-30");
+  });
+
+  it("builds report and print links from preset controls", () => {
+    const baseDate = new Date("2026-05-06T00:00:00.000Z");
+    const reportHref = buildReportBuilderHref({ preset: "lab-follow-up" }, baseDate);
+    const printHref = buildReportPrintHref({ preset: "lab-follow-up" }, baseDate);
+
+    expect(reportHref).toContain("/report-builder?");
+    expect(reportHref).toContain("preset=lab-follow-up");
+    expect(reportHref).toContain("type=doctor");
+    expect(printHref).toContain("/report-builder/print?");
+    expect(printHref).toContain("preset=lab-follow-up");
+  });
+
+  it("ignores unknown preset ids safely", () => {
+    expect(getReportBuilderPreset("unknown-preset")).toBeUndefined();
+    expect(resolveReportBuilderControls({ preset: "unknown-preset" }).reportType).toBe("patient");
+  });
+});


### PR DESCRIPTION
## Summary

This patch improves VitaVault’s Report Builder with scenario-based presets, generated report links, print preset context, and a lightweight recent packet history panel.

## Changes

- Added `lib/report-builder-presets.ts` as a pure preset contract.
- Added presets for:
  - Doctor visit packet
  - Emergency handoff
  - Care-team weekly review
  - Medication review
  - Lab follow-up
- Updated `/report-builder` with preset cards and selected preset state.
- Added preset-driven date ranges and section selections.
- Added generated recent packet history based on the current report draft, latest source event, and pre-share checks.
- Updated `/report-builder/print` to preserve and display preset context.
- Added preset unit tests.
- Updated patch documentation and known limitations.

## Safety

- No Prisma schema changes.
- No migration changes.
- No package changes.
- No persisted report history yet; history is generated from current report data only.

## Checks to run

```bash
npm run db:validate:ci
npm run actions:check
npm run actions:imports
npm run actions:shadow
npm run typecheck
npm run lint
npm run test:run