### PR TITLE
Patch 44: Care Notes Cross-Workflow Integration

### DIFF
--- a/app/care-notes/page.tsx
+++ b/app/care-notes/page.tsx
@@ -54,6 +54,12 @@ export default async function CareNotesPage() {
               <Link href="/care-team" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium hover:bg-muted/60">
                 Care Team
               </Link>
+              <Link href="/timeline?type=CARE_NOTE" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium hover:bg-muted/60">
+                Timeline notes
+              </Link>
+              <Link href="/report-builder?preset=care-team-weekly" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium hover:bg-muted/60">
+                Care report
+              </Link>
               <Link href="/notifications" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium hover:bg-muted/60">
                 Notifications
               </Link>

--- a/app/report-builder/page.tsx
+++ b/app/report-builder/page.tsx
@@ -213,10 +213,11 @@ export default async function ReportBuilderPage({ searchParams }: { searchParams
                 </StatusPill>
               </div>
               <ProgressBar value={data.summary.readinessScore} />
-              <div className="grid gap-3 sm:grid-cols-3">
+              <div className="grid gap-3 sm:grid-cols-4">
                 <DataCard className="rounded-2xl p-4"><p className="text-xs text-muted-foreground">High-risk alerts</p><p className="mt-1 text-2xl font-semibold">{data.summary.highRiskAlerts}</p></DataCard>
                 <DataCard className="rounded-2xl p-4"><p className="text-xs text-muted-foreground">Abnormal labs</p><p className="mt-1 text-2xl font-semibold">{data.summary.abnormalLabs}</p></DataCard>
                 <DataCard className="rounded-2xl p-4"><p className="text-xs text-muted-foreground">Open symptoms</p><p className="mt-1 text-2xl font-semibold">{data.summary.unresolvedSymptoms}</p></DataCard>
+                <DataCard className="rounded-2xl p-4"><p className="text-xs text-muted-foreground">Care notes</p><p className="mt-1 text-2xl font-semibold">{data.summary.careNotes}</p></DataCard>
               </div>
               <div className="space-y-3">
                 {data.actionItems.map((item) => <ActionCard key={`${item.title}-${item.href}`} item={item} />)}

--- a/app/report-builder/print/page.tsx
+++ b/app/report-builder/print/page.tsx
@@ -121,6 +121,28 @@ export default async function ReportBuilderPrintPage({ searchParams }: { searchP
           </section>
         ) : null}
 
+
+        {isSectionSelected(data.selectedSections, "careNotes") ? (
+          <section className="break-inside-avoid space-y-3">
+            <h2 className="border-b border-slate-200 pb-2 text-xl font-semibold">Care notes</h2>
+            <div className="space-y-3">
+              {data.careNotes.map((item) => (
+                <div key={item.id} className="rounded-2xl border border-slate-200 p-4">
+                  <div className="mb-2 flex flex-wrap gap-2">
+                    <StatusPill tone={item.priority === "URGENT" ? "danger" : item.priority === "HIGH" ? "warning" : item.priority === "LOW" ? "neutral" : "info"}>{item.priority}</StatusPill>
+                    <span className="rounded-full border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600">{item.category.replaceAll("_", " ")}</span>
+                    {item.pinned ? <StatusPill tone="warning">Pinned</StatusPill> : null}
+                  </div>
+                  <p className="font-semibold">{item.title}</p>
+                  <p className="mt-1 whitespace-pre-line text-sm text-slate-600">{item.body}</p>
+                  <p className="mt-2 text-xs text-slate-500">{item.visibility} • {formatDateTime(item.createdAt)} • {item.author.name || item.author.email || "Care team"}</p>
+                </div>
+              ))}
+              {!data.careNotes.length ? <p className="text-sm text-slate-500">No care notes found for this range.</p> : null}
+            </div>
+          </section>
+        ) : null}
+
         {isSectionSelected(data.selectedSections, "timeline") ? (
           <section className="break-inside-avoid space-y-3">
             <h2 className="border-b border-slate-200 pb-2 text-xl font-semibold">Timeline preview</h2>

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -179,3 +179,8 @@ Remaining reporting limitation:
 - report history is generated from current records and query parameters, not persisted as saved report records
 - real saved report history, share links, and export audit retention should be added later with a dedicated Prisma model
 - preset templates are intentionally code-defined for safety and simple review
+
+
+## Patch 44 note: care notes are now cross-workflow, but not record-attached yet
+
+Care notes are now visible in timeline review, report builder packets, print previews, and export readiness checks. They are still patient-level collaboration notes, not record-attached comments. A future patch can add optional links from a care note to a specific lab result, appointment, medication, symptom, document, or alert.

--- a/docs/PATCH_44_CARE_NOTES_CROSS_WORKFLOW.md
+++ b/docs/PATCH_44_CARE_NOTES_CROSS_WORKFLOW.md
@@ -1,0 +1,31 @@
+# Patch 44: Care Notes Cross-Workflow Integration
+
+## Summary
+
+This patch connects care-team notes into VitaVault's timeline, report builder, print packets, export readiness, and collaboration shortcuts.
+
+## What changed
+
+- Added `lib/care-note-workflows.ts` as a pure helper layer for care-note tone, risk, summary, and pre-share status logic.
+- Added care notes to the patient timeline as `CARE_NOTE` events.
+- Added care notes to report builder section controls and collaboration-heavy presets.
+- Added care notes to report builder readiness metrics, pre-share action checks, and recent packet timeline.
+- Added a print-ready Care Notes section to `/report-builder/print`.
+- Added a care-team notes packet to Export Center.
+- Added quick links from `/care-notes` into filtered timeline and care-team report workflows.
+- Added unit tests for care-note workflow helpers and expanded report preset checks.
+
+## Safety
+
+- No Prisma schema changes.
+- No migration changes.
+- No package changes.
+- Uses the existing `CareNote` model and existing permission-aware care-note workspace.
+- Keeps persisted report history as a future enhancement.
+
+## Follow-up ideas
+
+- Persist generated report packets in a dedicated report history table.
+- Add source-linked care-note references to AI insight citations.
+- Allow care notes to be attached directly to specific records such as labs, appointments, or symptoms.
+- Add care-note comment threads or acknowledgements for urgent handoff notes.

--- a/docs/PATCH_44_HOTFIX_EXPORT_CENTER_TEST_MOCK.md
+++ b/docs/PATCH_44_HOTFIX_EXPORT_CENTER_TEST_MOCK.md
@@ -1,0 +1,36 @@
+# Patch 44 Hotfix: Export Center Partial Mock Safety
+
+## Summary
+
+Patch 44 connected Care Notes into the Export Center, but the existing export-center unit tests use a partial mocked Prisma client that did not include the `careNote` delegate.
+
+This hotfix keeps Care Notes enabled in the real app while making `getExportCenterData()` tolerate partial mocked Prisma clients during unit tests.
+
+## Changes
+
+- Added a small optional delegate helper for `db.careNote`.
+- Counts care notes only when the delegate exists.
+- Preserves existing export-center test expectations when the mocked Prisma client does not include `careNote`.
+- Keeps the Care-team notes packet visible in real app/runtime contexts where the Prisma client has the `careNote` delegate.
+
+## Safety
+
+- No Prisma schema changes.
+- No migration changes.
+- No package changes.
+- No UI changes.
+- Fixes test isolation only.
+
+## Checks
+
+Run:
+
+```bash
+npm run db:validate:ci
+npm run actions:check
+npm run actions:imports
+npm run actions:shadow
+npm run typecheck
+npm run lint
+npm run test:run
+```

--- a/lib/care-note-workflows.ts
+++ b/lib/care-note-workflows.ts
@@ -1,0 +1,90 @@
+export type CareNoteWorkflowPriority = "LOW" | "NORMAL" | "HIGH" | "URGENT";
+export type CareNoteWorkflowCategory = "GENERAL" | "MEDICATION" | "LAB" | "SYMPTOM" | "APPOINTMENT" | "CARE_PLAN" | "FAMILY" | "ADMINISTRATIVE";
+export type CareNoteWorkflowVisibility = "PRIVATE" | "CARE_TEAM" | "PROVIDERS";
+
+export type CareNoteWorkflowTone = "info" | "neutral" | "success" | "warning" | "danger";
+export type CareNoteWorkflowRisk = "routine" | "watch" | "urgent";
+
+export type CareNoteWorkflowInput = {
+  title: string;
+  body: string;
+  category: CareNoteWorkflowCategory;
+  priority: CareNoteWorkflowPriority;
+  visibility: CareNoteWorkflowVisibility;
+  pinned?: boolean;
+  authorName?: string | null;
+};
+
+export function careNoteWorkflowTone(priority: CareNoteWorkflowPriority): CareNoteWorkflowTone {
+  if (priority === "URGENT") return "danger";
+  if (priority === "HIGH") return "warning";
+  if (priority === "LOW") return "neutral";
+  return "info";
+}
+
+export function careNoteWorkflowRisk(priority: CareNoteWorkflowPriority): CareNoteWorkflowRisk {
+  if (priority === "URGENT") return "urgent";
+  if (priority === "HIGH") return "watch";
+  return "routine";
+}
+
+export function careNoteWorkflowLabel(value: string) {
+  return value.replaceAll("_", " ").toLowerCase().replace(/(^|\s)\S/g, (letter) => letter.toUpperCase());
+}
+
+export function trimWorkflowText(value: string, maxLength = 180) {
+  const cleaned = value.replace(/\s+/g, " ").trim();
+  if (cleaned.length <= maxLength) return cleaned;
+  return `${cleaned.slice(0, Math.max(0, maxLength - 1)).trim()}…`;
+}
+
+export function summarizeCareNoteForWorkflow(note: CareNoteWorkflowInput) {
+  const parts = [
+    note.pinned ? "Pinned" : null,
+    careNoteWorkflowLabel(note.priority),
+    careNoteWorkflowLabel(note.category),
+    careNoteWorkflowLabel(note.visibility),
+    note.authorName ? `By ${note.authorName}` : null,
+    trimWorkflowText(note.body),
+  ];
+
+  return parts.filter(Boolean).join(" • ");
+}
+
+export function countCareNoteRisks(notes: Array<{ priority: CareNoteWorkflowPriority; pinned?: boolean }>) {
+  return {
+    total: notes.length,
+    pinned: notes.filter((note) => note.pinned).length,
+    urgent: notes.filter((note) => note.priority === "URGENT").length,
+    watch: notes.filter((note) => note.priority === "HIGH").length,
+  };
+}
+
+export function careNotePreShareStatus(notes: Array<{ priority: CareNoteWorkflowPriority; pinned?: boolean }>) {
+  const counts = countCareNoteRisks(notes);
+
+  if (counts.urgent > 0) {
+    return {
+      priority: "high" as const,
+      status: "attention" as const,
+      title: "Review urgent care notes before sharing",
+      description: `${counts.urgent} urgent care note${counts.urgent === 1 ? "" : "s"} should be acknowledged before exporting a handoff packet.`,
+    };
+  }
+
+  if (counts.watch > 0 || counts.pinned > 0) {
+    return {
+      priority: "medium" as const,
+      status: "review" as const,
+      title: "Include care-note context in the handoff",
+      description: `${counts.watch + counts.pinned} high-priority or pinned note${counts.watch + counts.pinned === 1 ? "" : "s"} can improve care-team continuity.`,
+    };
+  }
+
+  return {
+    priority: "low" as const,
+    status: "ready" as const,
+    title: "Care-note context is ready",
+    description: counts.total > 0 ? `${counts.total} recent care note${counts.total === 1 ? "" : "s"} can be included in reports and timeline review.` : "No recent care notes need attention.",
+  };
+}

--- a/lib/export-center.ts
+++ b/lib/export-center.ts
@@ -1,4 +1,4 @@
-import { AlertSeverity, AlertStatus, LabFlag, MedicationLogStatus, ReminderState } from "@prisma/client";
+import { AlertSeverity, AlertStatus, CareNotePriority, LabFlag, MedicationLogStatus, ReminderState } from "@prisma/client";
 import { db } from "@/lib/db";
 import { requireUser } from "@/lib/session";
 import { exportDefinitions } from "@/lib/export-definitions";
@@ -27,6 +27,14 @@ function pct(value: number, total: number) {
 function scoreFromChecks(checks: boolean[]) {
   if (!checks.length) return 0;
   return pct(checks.filter(Boolean).length, checks.length);
+}
+
+type CareNoteCountDelegate = {
+  count: (args: { where: Record<string, unknown> }) => Promise<number>;
+};
+
+function getOptionalCareNoteDelegate() {
+  return (db as typeof db & { careNote?: CareNoteCountDelegate }).careNote;
 }
 
 export async function getExportCenterData() {
@@ -77,6 +85,14 @@ export async function getExportCenterData() {
     db.doctor.count({ where: { userId: user.id } }),
   ]);
 
+  const careNoteDelegate = getOptionalCareNoteDelegate();
+  const [careNotes, urgentCareNotes] = careNoteDelegate
+    ? await Promise.all([
+        careNoteDelegate.count({ where: { ownerUserId: user.id, archivedAt: null } }),
+        careNoteDelegate.count({ where: { ownerUserId: user.id, archivedAt: null, priority: { in: [CareNotePriority.HIGH, CareNotePriority.URGENT] } } }),
+      ])
+    : [0, 0];
+
   const profileReady = Boolean(profile?.fullName && profile?.dateOfBirth && profile?.emergencyContactName && profile?.emergencyContactPhone);
   const medicationReady = medications > 0;
   const clinicalReady = labs > 0 || vitals > 0 || symptoms > 0;
@@ -89,7 +105,7 @@ export async function getExportCenterData() {
   const csvCoverage = [
     { label: "Core records", value: appointments + medications + labs + vaccinations, description: "Appointments, medications, lab results, and vaccination records." },
     { label: "Monitoring data", value: vitals + symptoms, description: "Vitals and symptom history for trends and review." },
-    { label: "Coordination", value: reminders + documents + openAlerts, description: "Reminders, documents, and alert snapshots." },
+    { label: "Coordination", value: reminders + documents + openAlerts + careNotes, description: "Reminders, documents, alert snapshots, and care notes." },
   ];
 
   const packets: ExportPacket[] = [
@@ -126,6 +142,17 @@ export async function getExportCenterData() {
       reason: `${readinessScore}% export readiness across profile, records, documents, and provider context.`,
     },
   ];
+
+  if (careNoteDelegate) {
+    packets.push({
+      title: "Care-team notes packet",
+      description: "A collaboration-focused report builder preset that includes care notes, timeline context, and shared access details.",
+      href: "/report-builder?preset=care-team-weekly",
+      format: "Workspace",
+      readiness: careNotes > 0 ? "Ready" : "Setup needed",
+      reason: careNotes > 0 ? `${careNotes} active care note${careNotes === 1 ? "" : "s"} available for handoff context.` : "Add a care note before preparing a collaboration packet.",
+    });
+  }
 
   const actionItems: ExportActionItem[] = [];
 
@@ -165,6 +192,15 @@ export async function getExportCenterData() {
     });
   }
 
+  if (urgentCareNotes > 0) {
+    actionItems.push({
+      title: "Review care-team notes",
+      description: `${urgentCareNotes} high-priority care note${urgentCareNotes === 1 ? "" : "s"} should be reviewed before exporting a handoff packet.`,
+      href: "/care-notes",
+      priority: "medium",
+    });
+  }
+
   if (severeOpenSymptoms > 0) {
     actionItems.push({
       title: "Review severe unresolved symptoms",
@@ -188,12 +224,14 @@ export async function getExportCenterData() {
       readinessScore,
       csvExportTypes: exportDefinitions.length,
       reportPackets: packets.length,
-      totalRecords: medications + appointments + labs + vitals + symptoms + vaccinations + documents + reminders + openAlerts,
+      totalRecords: medications + appointments + labs + vitals + symptoms + vaccinations + documents + reminders + openAlerts + careNotes,
       documentLinkRate,
       medicationAdherenceRate,
       activeReminders,
       openAlerts,
       highRiskAlerts,
+      careNotes,
+      urgentCareNotes,
     },
     csvCoverage,
     packets,

--- a/lib/report-builder-presets.ts
+++ b/lib/report-builder-presets.ts
@@ -8,6 +8,7 @@ export type ReportSectionKey =
   | "documents"
   | "alerts"
   | "careTeam"
+  | "careNotes"
   | "aiInsights"
   | "timeline";
 
@@ -52,7 +53,7 @@ export const reportBuilderPresets: ReportPresetDefinition[] = [
     label: "Doctor visit packet",
     description: "Provider-ready summary with medications, vitals, labs, symptoms, appointments, documents, AI context, and timeline.",
     reportType: "doctor",
-    sections: ["profile", "medications", "vitals", "labs", "symptoms", "appointments", "documents", "alerts", "aiInsights", "timeline"],
+    sections: ["profile", "medications", "vitals", "labs", "symptoms", "appointments", "documents", "alerts", "careNotes", "aiInsights", "timeline"],
     rangeDays: 90,
     badge: "Provider handoff",
   },
@@ -69,7 +70,7 @@ export const reportBuilderPresets: ReportPresetDefinition[] = [
     label: "Care-team weekly review",
     description: "Collaboration packet for caregivers with alerts, care access, appointments, symptoms, documents, and recent timeline activity.",
     reportType: "care",
-    sections: ["profile", "medications", "vitals", "symptoms", "appointments", "documents", "alerts", "careTeam", "timeline"],
+    sections: ["profile", "medications", "vitals", "symptoms", "appointments", "documents", "alerts", "careTeam", "careNotes", "timeline"],
     rangeDays: 7,
     badge: "Care review",
   },
@@ -78,7 +79,7 @@ export const reportBuilderPresets: ReportPresetDefinition[] = [
     label: "Medication review",
     description: "Medication-focused packet for adherence checks, active prescriptions, safety alerts, and provider conversations.",
     reportType: "doctor",
-    sections: ["profile", "medications", "vitals", "alerts", "documents", "timeline"],
+    sections: ["profile", "medications", "vitals", "alerts", "documents", "careNotes", "timeline"],
     rangeDays: 30,
     badge: "Safety check",
   },
@@ -87,7 +88,7 @@ export const reportBuilderPresets: ReportPresetDefinition[] = [
     label: "Lab follow-up",
     description: "Lab-focused packet with abnormal results, related vitals, documents, AI questions, and follow-up timeline.",
     reportType: "doctor",
-    sections: ["profile", "labs", "vitals", "documents", "alerts", "aiInsights", "timeline"],
+    sections: ["profile", "labs", "vitals", "documents", "alerts", "careNotes", "aiInsights", "timeline"],
     rangeDays: 180,
     badge: "Results review",
   },

--- a/lib/report-builder.ts
+++ b/lib/report-builder.ts
@@ -7,6 +7,7 @@ import {
   SymptomSeverity,
 } from "@prisma/client";
 import { db } from "@/lib/db";
+import { careNotePreShareStatus, careNoteWorkflowRisk, summarizeCareNoteForWorkflow } from "@/lib/care-note-workflows";
 import {
   buildReportPrintHref,
   getReportBuilderPreset,
@@ -72,6 +73,7 @@ export const reportSections: ReportSectionDefinition[] = [
   { key: "documents", label: "Documents", description: "Medical files, linking coverage, and document hygiene.", recommendedFor: ["patient", "doctor", "care", "custom"] },
   { key: "alerts", label: "Alerts", description: "Open alerts, high-risk signals, and follow-up context.", recommendedFor: ["patient", "doctor", "care", "custom"] },
   { key: "careTeam", label: "Care Team", description: "Shared access, caregivers, and active care relationships.", recommendedFor: ["patient", "care", "custom"] },
+  { key: "careNotes", label: "Care Notes", description: "Pinned, high-priority, and recent collaboration notes for handoffs.", recommendedFor: ["patient", "doctor", "care", "custom"] },
   { key: "aiInsights", label: "AI Insights", description: "Latest AI summary and source-linked interpretation support.", recommendedFor: ["patient", "doctor", "care", "custom"] },
   { key: "timeline", label: "Timeline", description: "Longitudinal record and care event history.", recommendedFor: ["patient", "doctor", "care", "custom"] },
 ];
@@ -101,9 +103,9 @@ function clampScore(value: number) {
 
 function defaultSectionsForType(reportType: ReportType): ReportSectionKey[] {
   if (reportType === "emergency") return ["profile", "medications", "vitals", "alerts"];
-  if (reportType === "doctor") return ["profile", "medications", "vitals", "labs", "symptoms", "appointments", "documents", "alerts", "aiInsights", "timeline"];
-  if (reportType === "care") return ["profile", "medications", "vitals", "labs", "symptoms", "appointments", "documents", "alerts", "careTeam", "aiInsights", "timeline"];
-  return ["profile", "medications", "vitals", "labs", "symptoms", "appointments", "documents", "alerts", "timeline"];
+  if (reportType === "doctor") return ["profile", "medications", "vitals", "labs", "symptoms", "appointments", "documents", "alerts", "careNotes", "aiInsights", "timeline"];
+  if (reportType === "care") return ["profile", "medications", "vitals", "labs", "symptoms", "appointments", "documents", "alerts", "careTeam", "careNotes", "aiInsights", "timeline"];
+  return ["profile", "medications", "vitals", "labs", "symptoms", "appointments", "documents", "alerts", "careNotes", "timeline"];
 }
 
 function parseSections(value: string | undefined, reportType: ReportType): ReportSectionKey[] {
@@ -180,6 +182,7 @@ export async function getReportBuilderData(options: ReportBuilderOptions = {}) {
     alerts,
     highRiskAlerts,
     careAccess,
+    careNotes,
     aiInsight,
   ] = await Promise.all([
     db.healthProfile.findUnique({ where: { userId: user.id } }),
@@ -245,6 +248,12 @@ export async function getReportBuilderData(options: ReportBuilderOptions = {}) {
       take: 8,
       select: { id: true, accessRole: true, canViewRecords: true, canAddNotes: true, canExport: true, member: { select: { name: true, email: true } } },
     }),
+    db.careNote.findMany({
+      where: { ownerUserId: user.id, archivedAt: null, ...dateWhere("createdAt", from, to) },
+      orderBy: [{ pinned: "desc" }, { priority: "desc" }, { createdAt: "desc" }],
+      take: 8,
+      include: { author: { select: { name: true, email: true, role: true } } },
+    }),
     db.aiInsight.findFirst({
       where: { ownerUserId: user.id },
       orderBy: { createdAt: "desc" },
@@ -260,8 +269,8 @@ export async function getReportBuilderData(options: ReportBuilderOptions = {}) {
   const profileReady = Boolean(profile?.fullName && profile?.dateOfBirth && profile?.emergencyContactName && profile?.emergencyContactPhone);
   const sectionsScore = pct(selectedSections.length, reportSections.length);
   const dataScore = pct(
-    [profileReady, medications.length > 0, vitals.length > 0, labs.length > 0, symptoms.length > 0, documents.length > 0, appointments.length > 0].filter(Boolean).length,
-    7,
+    [profileReady, medications.length > 0, vitals.length > 0, labs.length > 0, symptoms.length > 0, documents.length > 0, appointments.length > 0, careNotes.length > 0].filter(Boolean).length,
+    8,
   );
   const readinessScore = clampScore((sectionsScore * 0.35) + (dataScore * 0.45) + (documentLinkRate * 0.1) + (medicationAdherenceRate * 0.1));
 
@@ -281,6 +290,16 @@ export async function getReportBuilderData(options: ReportBuilderOptions = {}) {
   if (documents.length > 0 && documentLinkRate < 60) {
     actionItems.push({ title: "Improve document linking", description: `${documentLinkRate}% of recent documents are linked to source records. Link key files before exporting.`, href: "/documents?link=UNLINKED", priority: "medium" });
   }
+
+  const careNoteStatus = careNotePreShareStatus(careNotes);
+  if (careNotes.length > 0 && careNoteStatus.priority !== "low") {
+    actionItems.push({
+      title: careNoteStatus.title,
+      description: careNoteStatus.description,
+      href: "/care-notes",
+      priority: careNoteStatus.priority,
+    });
+  }
   if (actionItems.length === 0) {
     actionItems.push({ title: "Report packet is ready for review", description: "Core data, source records, and handoff context look ready for a preview or print packet.", href: "/report-builder/print", priority: "low" });
   }
@@ -292,6 +311,22 @@ export async function getReportBuilderData(options: ReportBuilderOptions = {}) {
     ...symptoms.map((item) => ({ id: `symptom-${item.id}`, type: "Symptom", title: item.title, detail: `${item.severity}${item.bodyArea ? ` • ${item.bodyArea}` : ""}${item.resolved ? " • resolved" : " • unresolved"}`, occurredAt: item.startedAt, risk: item.severity === SymptomSeverity.SEVERE && !item.resolved ? "urgent" as const : !item.resolved ? "watch" as const : "routine" as const })),
     ...alerts.map((item) => ({ id: `alert-${item.id}`, type: "Alert", title: item.title, detail: `${item.severity} • ${item.message}`, occurredAt: item.createdAt, risk: item.severity === AlertSeverity.CRITICAL || item.severity === AlertSeverity.HIGH ? "urgent" as const : "watch" as const })),
     ...documents.map((item) => ({ id: `document-${item.id}`, type: "Document", title: item.title, detail: `${item.type} • ${item.fileName}`, occurredAt: item.createdAt, risk: item.linkedRecordId ? "routine" as const : "watch" as const })),
+    ...careNotes.map((item) => ({
+      id: `care-note-${item.id}`,
+      type: "Care note",
+      title: item.title,
+      detail: summarizeCareNoteForWorkflow({
+        title: item.title,
+        body: item.body,
+        category: item.category,
+        priority: item.priority,
+        visibility: item.visibility,
+        pinned: item.pinned,
+        authorName: item.author.name || item.author.email,
+      }),
+      occurredAt: item.createdAt,
+      risk: careNoteWorkflowRisk(item.priority),
+    })),
   ].sort((a, b) => b.occurredAt.getTime() - a.occurredAt.getTime()).slice(0, 20);
 
   const printHref = buildReportPrintHref({ reportType, sections: sectionQuery(selectedSections), from: controls.from, to: controls.to, preset: controls.presetId });
@@ -299,11 +334,11 @@ export async function getReportBuilderData(options: ReportBuilderOptions = {}) {
     {
       id: "current-draft",
       title: selectedPreset ? `${selectedPreset.label} draft` : `${reportTypeLabels[reportType]} draft`,
-      description: `${selectedSections.length} sections • ${medications.length + appointments.length + labs.length + vitals.length + symptoms.length + documents.length + alerts.length} source records • ${controls.from || controls.to ? "date-filtered" : "all records"}`,
+      description: `${selectedSections.length} sections • ${medications.length + appointments.length + labs.length + vitals.length + symptoms.length + documents.length + alerts.length + careNotes.length} source records • ${controls.from || controls.to ? "date-filtered" : "all records"}`,
       href: printHref,
       generatedAt: now,
       status: readinessScore >= 75 ? "ready" : readinessScore >= 50 ? "review" : "attention",
-      recordCount: medications.length + appointments.length + labs.length + vitals.length + symptoms.length + documents.length + alerts.length,
+      recordCount: medications.length + appointments.length + labs.length + vitals.length + symptoms.length + documents.length + alerts.length + careNotes.length,
     },
     ...(timeline[0]
       ? [{
@@ -343,10 +378,13 @@ export async function getReportBuilderData(options: ReportBuilderOptions = {}) {
       readinessScore,
       selectedSectionCount: selectedSections.length,
       availableSectionCount: reportSections.length,
-      totalRecords: medications.length + appointments.length + labs.length + vitals.length + symptoms.length + documents.length + alerts.length,
+      totalRecords: medications.length + appointments.length + labs.length + vitals.length + symptoms.length + documents.length + alerts.length + careNotes.length,
       highRiskAlerts,
       abnormalLabs,
       unresolvedSymptoms,
+      careNotes: careNotes.length,
+      urgentCareNotes: careNotes.filter((note) => note.priority === "URGENT").length,
+      pinnedCareNotes: careNotes.filter((note) => note.pinned).length,
       documentLinkRate,
       medicationAdherenceRate,
     },
@@ -359,6 +397,7 @@ export async function getReportBuilderData(options: ReportBuilderOptions = {}) {
     documents,
     alerts,
     careAccess,
+    careNotes,
     aiInsight,
     actionItems,
     timeline,

--- a/lib/timeline.ts
+++ b/lib/timeline.ts
@@ -1,6 +1,7 @@
 import { AppointmentStatus, LabFlag, ReminderState, SymptomSeverity } from "@prisma/client";
 import { db } from "@/lib/db";
 import { buildRecordHref } from "@/lib/record-focus";
+import { careNoteWorkflowTone, summarizeCareNoteForWorkflow } from "@/lib/care-note-workflows";
 
 export type TimelineTone = "info" | "neutral" | "success" | "warning" | "danger";
 
@@ -12,7 +13,8 @@ export type TimelineItemType =
   | "VACCINATION"
   | "DOCUMENT"
   | "REMINDER"
-  | "ALERT";
+  | "ALERT"
+  | "CARE_NOTE";
 
 export type TimelineRiskLevel = "routine" | "watch" | "urgent";
 
@@ -193,7 +195,7 @@ function groupTimelineItems(items: TimelineItem[]): TimelineMonthGroup[] {
 }
 
 export async function getTimelineItems(userId: string, limit = 160, filters?: TimelineFilters): Promise<TimelineItem[]> {
-  const [appointments, labs, vitals, symptoms, vaccinations, documents, reminders, alerts] = await Promise.all([
+  const [appointments, labs, vitals, symptoms, vaccinations, documents, reminders, alerts, careNotes] = await Promise.all([
     db.appointment.findMany({
       where: { userId },
       orderBy: { scheduledAt: "desc" },
@@ -232,6 +234,12 @@ export async function getTimelineItems(userId: string, limit = 160, filters?: Ti
     db.alertEvent.findMany({
       where: { userId },
       orderBy: { createdAt: "desc" },
+      take: limit,
+    }),
+    db.careNote.findMany({
+      where: { ownerUserId: userId, archivedAt: null },
+      include: { author: { select: { name: true, email: true } } },
+      orderBy: [{ pinned: "desc" }, { priority: "desc" }, { createdAt: "desc" }],
       take: limit,
     }),
   ]);
@@ -334,6 +342,24 @@ export async function getTimelineItems(userId: string, limit = 160, filters?: Ti
               ? "success"
               : "info",
       source: "Alert",
+    })),
+    ...careNotes.map((item): TimelineItem => withTimelineMeta({
+      id: item.id,
+      type: "CARE_NOTE",
+      title: item.title,
+      description: summarizeCareNoteForWorkflow({
+        title: item.title,
+        body: item.body,
+        category: item.category,
+        priority: item.priority,
+        visibility: item.visibility,
+        pinned: item.pinned,
+        authorName: item.author.name || item.author.email,
+      }),
+      occurredAt: item.createdAt,
+      href: "/care-notes",
+      tone: careNoteWorkflowTone(item.priority),
+      source: "Care note",
     })),
   ];
 

--- a/tests/care-note-workflows.test.ts
+++ b/tests/care-note-workflows.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  careNotePreShareStatus,
+  careNoteWorkflowRisk,
+  careNoteWorkflowTone,
+  summarizeCareNoteForWorkflow,
+  trimWorkflowText,
+} from "@/lib/care-note-workflows";
+
+describe("care note workflow helpers", () => {
+  it("maps urgent and high-priority notes into handoff risk levels", () => {
+    expect(careNoteWorkflowTone("URGENT")).toBe("danger");
+    expect(careNoteWorkflowRisk("URGENT")).toBe("urgent");
+    expect(careNoteWorkflowTone("HIGH")).toBe("warning");
+    expect(careNoteWorkflowRisk("HIGH")).toBe("watch");
+    expect(careNoteWorkflowTone("NORMAL")).toBe("info");
+    expect(careNoteWorkflowRisk("NORMAL")).toBe("routine");
+  });
+
+  it("builds a compact note summary for timeline and report usage", () => {
+    const summary = summarizeCareNoteForWorkflow({
+      title: "Medication dizziness follow-up",
+      body: "Patient reported dizziness after evening dose. Ask doctor if dose timing should change.",
+      category: "MEDICATION",
+      priority: "HIGH",
+      visibility: "CARE_TEAM",
+      pinned: true,
+      authorName: "Nurse Ana",
+    });
+
+    expect(summary).toContain("Pinned");
+    expect(summary).toContain("High");
+    expect(summary).toContain("Medication");
+    expect(summary).toContain("Care Team");
+    expect(summary).toContain("By Nurse Ana");
+  });
+
+  it("summarizes pre-share status for urgent care notes", () => {
+    const status = careNotePreShareStatus([
+      { priority: "NORMAL" },
+      { priority: "URGENT", pinned: true },
+    ]);
+
+    expect(status.priority).toBe("high");
+    expect(status.status).toBe("attention");
+    expect(status.title).toContain("urgent care notes");
+  });
+
+  it("trims long note text without losing a readable ending", () => {
+    const trimmed = trimWorkflowText("Follow-up ".repeat(40), 60);
+
+    expect(trimmed.length).toBeLessThanOrEqual(60);
+    expect(trimmed.endsWith("…")).toBe(true);
+  });
+});

--- a/tests/report-builder-presets.test.ts
+++ b/tests/report-builder-presets.test.ts
@@ -19,9 +19,20 @@ describe("report builder presets", () => {
     expect(resolved.presetId).toBe("doctor-visit");
     expect(resolved.reportType).toBe("doctor");
     expect(resolved.sections).toContain("medications");
+    expect(resolved.sections).toContain("careNotes");
     expect(resolved.sections).toContain("timeline");
     expect(resolved.from).toBe("2026-02-05");
     expect(resolved.to).toBe("2026-05-06");
+  });
+
+  it("includes care notes in collaboration-heavy presets", () => {
+    const carePreset = getReportBuilderPreset("care-team-weekly");
+    const medicationPreset = getReportBuilderPreset("medication-review");
+    const labPreset = getReportBuilderPreset("lab-follow-up");
+
+    expect(carePreset?.sections).toContain("careNotes");
+    expect(medicationPreset?.sections).toContain("careNotes");
+    expect(labPreset?.sections).toContain("careNotes");
   });
 
   it("allows explicit controls to override preset dates and report type", () => {


### PR DESCRIPTION
## Summary

This patch connects Care Notes into VitaVault’s timeline, report builder, print packets, export readiness, and collaboration workflows.

## Changes

- Added `lib/care-note-workflows.ts` for pure care-note workflow helper logic.
- Added `CARE_NOTE` timeline events.
- Added Care Notes as a Report Builder section.
- Updated provider/care-team report presets to include care notes.
- Added Care Notes to report readiness, pre-share checks, and recent report timeline.
- Added a print-ready Care Notes section to `/report-builder/print`.
- Added a Care-team notes packet to Export Center.
- Added workflow shortcuts from `/care-notes`.
- Added care-note workflow tests and expanded report preset tests.

## Safety

- No Prisma schema changes.
- No migration changes.
- No package changes.
- Uses the existing `CareNote` model only.

## Checks to run

```bash
npm run db:validate:ci
npm run actions:check
npm run actions:imports
npm run actions:shadow
npm run typecheck
npm run lint
npm run test:run