### PR TITLE
Patch 47: Background Jobs v2 Admin Tools

### DIFF
--- a/app/api/jobs/dispatch/route.ts
+++ b/app/api/jobs/dispatch/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { AppRole } from "@prisma/client";
 import { requireUser } from "@/lib/session";
 import { hasRedisConfig, shouldSkipRedisDuringBuild } from "@/lib/jobs/connection";
 import {
@@ -65,6 +66,11 @@ export async function POST(request: Request) {
     }
 
     const currentUser = await requireUser();
+
+    if (currentUser.role !== AppRole.ADMIN) {
+      return NextResponse.json({ error: "Only admins can dispatch background jobs." }, { status: 403 });
+    }
+
     const body = (await request.json()) as DispatchBody;
 
     const userId = body.userId || currentUser.id!;

--- a/app/jobs/actions.ts
+++ b/app/jobs/actions.ts
@@ -1,0 +1,238 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { AppRole } from "@prisma/client";
+import { db } from "@/lib/db";
+import { requireUser } from "@/lib/session";
+import {
+  buildRetryDispatchPayload,
+  isCancellableJobRunStatus,
+  isRetryableJobRunStatus,
+} from "@/lib/jobs/admin-tools";
+import {
+  enqueueAlertEvaluationJob,
+  enqueueDailyHealthSummaryJob,
+  enqueueDeviceSyncProcessingJob,
+  enqueueReminderGenerationJob,
+  enqueueReminderOverdueEvaluationJob,
+} from "@/lib/jobs/enqueue";
+
+function formString(formData: FormData, name: string) {
+  return String(formData.get(name) ?? "").trim();
+}
+
+async function requireAdminUser() {
+  const user = await requireUser();
+  if (user.role !== AppRole.ADMIN) {
+    throw new Error("Only admins can manage background jobs.");
+  }
+  return user;
+}
+
+async function logJobAdminAction(args: {
+  ownerUserId: string;
+  actorUserId: string;
+  action: string;
+  jobRunId: string;
+  metadata?: Record<string, unknown>;
+}) {
+  await db.accessAuditLog.create({
+    data: {
+      ownerUserId: args.ownerUserId,
+      actorUserId: args.actorUserId,
+      action: args.action,
+      targetType: "JOB_RUN",
+      targetId: args.jobRunId,
+      metadataJson: args.metadata ? JSON.stringify(args.metadata) : null,
+    },
+  });
+}
+
+function revalidateJobSurfaces() {
+  revalidatePath("/jobs");
+  revalidatePath("/admin");
+  revalidatePath("/audit-log");
+  revalidatePath("/ops");
+}
+
+async function dispatchRetryPayload(payload: ReturnType<typeof buildRetryDispatchPayload>) {
+  switch (payload.jobType) {
+    case "alert-evaluation":
+      return enqueueAlertEvaluationJob(payload);
+    case "reminder-generation":
+      return enqueueReminderGenerationJob(payload);
+    case "reminder-overdue-evaluation":
+      return enqueueReminderOverdueEvaluationJob(payload);
+    case "daily-health-summary":
+      return enqueueDailyHealthSummaryJob(payload);
+    case "device-sync-processing":
+      return enqueueDeviceSyncProcessingJob(payload);
+  }
+}
+
+export async function retryJobRunAction(formData: FormData) {
+  const admin = await requireAdminUser();
+  const jobRunId = formString(formData, "jobRunId");
+
+  if (!jobRunId) {
+    throw new Error("Job run id is required.");
+  }
+
+  const run = await db.jobRun.findUnique({
+    where: { id: jobRunId },
+    select: {
+      id: true,
+      jobName: true,
+      status: true,
+      userId: true,
+      connectionId: true,
+      syncJobId: true,
+      inputJson: true,
+    },
+  });
+
+  if (!run) {
+    throw new Error("Job run not found.");
+  }
+
+  if (!isRetryableJobRunStatus(run.status)) {
+    throw new Error("Only failed, retrying, or cancelled job runs can be retried from this panel.");
+  }
+
+  const retryPayload = buildRetryDispatchPayload(run);
+  const queued = await dispatchRetryPayload(retryPayload);
+
+  await db.jobRunLog.create({
+    data: {
+      jobRunId: run.id,
+      level: "INFO",
+      message: "Admin queued a retry from the jobs dashboard.",
+      contextJson: JSON.stringify({
+        retryJobRunId: queued.jobRunId,
+        retryBullmqJobId: queued.bullmqJobId,
+        actorUserId: admin.id,
+      }),
+    },
+  });
+
+  await logJobAdminAction({
+    ownerUserId: run.userId ?? admin.id!,
+    actorUserId: admin.id!,
+    action: "JOB_RUN_RETRY_QUEUED",
+    jobRunId: run.id,
+    metadata: {
+      retryJobRunId: queued.jobRunId,
+      retryBullmqJobId: queued.bullmqJobId,
+      jobName: run.jobName,
+    },
+  });
+
+  revalidateJobSurfaces();
+}
+
+export async function cancelJobRunAction(formData: FormData) {
+  const admin = await requireAdminUser();
+  const jobRunId = formString(formData, "jobRunId");
+
+  if (!jobRunId) {
+    throw new Error("Job run id is required.");
+  }
+
+  const run = await db.jobRun.findUnique({
+    where: { id: jobRunId },
+    select: {
+      id: true,
+      status: true,
+      userId: true,
+      jobName: true,
+      bullmqJobId: true,
+    },
+  });
+
+  if (!run) {
+    throw new Error("Job run not found.");
+  }
+
+  if (!isCancellableJobRunStatus(run.status)) {
+    throw new Error("Only queued, active, or retrying job runs can be marked cancelled.");
+  }
+
+  await db.jobRun.update({
+    where: { id: run.id },
+    data: {
+      status: "CANCELLED",
+      finishedAt: new Date(),
+      errorMessage: "Marked cancelled by an admin from the Jobs dashboard.",
+    },
+  });
+
+  await db.jobRunLog.create({
+    data: {
+      jobRunId: run.id,
+      level: "WARN",
+      message: "Admin marked this persisted job run as cancelled.",
+      contextJson: JSON.stringify({ actorUserId: admin.id, bullmqJobId: run.bullmqJobId }),
+    },
+  });
+
+  await logJobAdminAction({
+    ownerUserId: run.userId ?? admin.id!,
+    actorUserId: admin.id!,
+    action: "JOB_RUN_CANCELLED",
+    jobRunId: run.id,
+    metadata: {
+      jobName: run.jobName,
+      previousStatus: run.status,
+      bullmqJobId: run.bullmqJobId,
+    },
+  });
+
+  revalidateJobSurfaces();
+}
+
+export async function acknowledgeJobRunAction(formData: FormData) {
+  const admin = await requireAdminUser();
+  const jobRunId = formString(formData, "jobRunId");
+
+  if (!jobRunId) {
+    throw new Error("Job run id is required.");
+  }
+
+  const run = await db.jobRun.findUnique({
+    where: { id: jobRunId },
+    select: {
+      id: true,
+      userId: true,
+      status: true,
+      jobName: true,
+      errorMessage: true,
+    },
+  });
+
+  if (!run) {
+    throw new Error("Job run not found.");
+  }
+
+  await db.jobRunLog.create({
+    data: {
+      jobRunId: run.id,
+      level: run.status === "FAILED" ? "WARN" : "INFO",
+      message: "Admin acknowledged this job run for operational review.",
+      contextJson: JSON.stringify({ actorUserId: admin.id, status: run.status, errorMessage: run.errorMessage }),
+    },
+  });
+
+  await logJobAdminAction({
+    ownerUserId: run.userId ?? admin.id!,
+    actorUserId: admin.id!,
+    action: "JOB_RUN_ACKNOWLEDGED",
+    jobRunId: run.id,
+    metadata: {
+      jobName: run.jobName,
+      status: run.status,
+      errorMessage: run.errorMessage,
+    },
+  });
+
+  revalidateJobSurfaces();
+}

--- a/app/jobs/page.tsx
+++ b/app/jobs/page.tsx
@@ -1,11 +1,53 @@
-import { Activity, Cpu, RefreshCcw } from "lucide-react";
+import type { ReactNode } from "react";
+import Link from "next/link";
+import {
+  Activity,
+  Cpu,
+  Filter,
+  RotateCcw,
+  ShieldCheck,
+  XCircle,
+} from "lucide-react";
 import { AppShell } from "@/components/app-shell";
-import { PageHeader, StatusPill } from "@/components/common";
+import { EmptyState, PageHeader, StatusPill } from "@/components/common";
 import { JobDispatchPanel } from "@/components/job-dispatch-panel";
-import { Badge, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
+import { Badge, Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
 import { db } from "@/lib/db";
 import { getJobsDashboardData } from "@/lib/jobs/dashboard";
+import {
+  buildJobRunDeepLink,
+  isCancellableJobRunStatus,
+  isRetryableJobRunStatus,
+  jobRunTone,
+  parseJobRunJson,
+  parseJobRunOpsFilter,
+  type JobRunFilterKind,
+  type JobRunFilterStatus,
+} from "@/lib/jobs/admin-tools";
 import { requireRoutePolicy } from "@/lib/route-policy";
+import {
+  acknowledgeJobRunAction,
+  cancelJobRunAction,
+  retryJobRunAction,
+} from "./actions";
+
+const STATUS_FILTERS: { label: string; value: JobRunFilterStatus }[] = [
+  { label: "All", value: "all" },
+  { label: "Queued", value: "QUEUED" },
+  { label: "Active", value: "ACTIVE" },
+  { label: "Retrying", value: "RETRYING" },
+  { label: "Failed", value: "FAILED" },
+  { label: "Completed", value: "COMPLETED" },
+  { label: "Cancelled", value: "CANCELLED" },
+];
+
+const KIND_FILTERS: { label: string; value: JobRunFilterKind }[] = [
+  { label: "All kinds", value: "all" },
+  { label: "Alerts", value: "ALERT_EVALUATION" },
+  { label: "Reminders", value: "REMINDER_GENERATION" },
+  { label: "Daily summary", value: "DAILY_HEALTH_SUMMARY" },
+  { label: "Device sync", value: "DEVICE_SYNC_PROCESSING" },
+];
 
 function formatDateTime(value: Date | null | undefined) {
   if (!value) return "—";
@@ -15,19 +57,67 @@ function formatDateTime(value: Date | null | undefined) {
   }).format(value);
 }
 
-function runTone(status: string) {
-  if (status === "COMPLETED") return "success";
-  if (status === "FAILED") return "danger";
-  if (status === "RETRYING") return "warning";
-  if (status === "ACTIVE") return "info";
-  return "neutral";
+function compactId(value: string | null | undefined) {
+  if (!value) return "—";
+  if (value.length <= 14) return value;
+  return `${value.slice(0, 8)}…${value.slice(-4)}`;
 }
 
-export default async function JobsDashboardPage() {
+function filterHref(params: Record<string, string>) {
+  const search = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value && value !== "all") search.set(key, value);
+  });
+  const query = search.toString();
+  return query ? `/jobs?${query}` : "/jobs";
+}
+
+function JsonPreview({ title, value }: { title: string; value: string | null }) {
+  const parsed = parseJobRunJson(value);
+  if (!parsed) return null;
+  return (
+    <details className="rounded-2xl border border-border/60 bg-muted/30 p-3 text-xs text-muted-foreground">
+      <summary className="cursor-pointer font-medium text-foreground">{title}</summary>
+      <pre className="mt-2 max-h-44 overflow-auto whitespace-pre-wrap">{JSON.stringify(parsed, null, 2)}</pre>
+    </details>
+  );
+}
+
+function JobActionForm({
+  action,
+  jobRunId,
+  label,
+  variant = "outline",
+  icon,
+}: {
+  action: (formData: FormData) => Promise<void>;
+  jobRunId: string;
+  label: string;
+  variant?: "outline" | "secondary" | "destructive";
+  icon?: ReactNode;
+}) {
+  return (
+    <form action={action}>
+      <input type="hidden" name="jobRunId" value={jobRunId} />
+      <Button type="submit" variant={variant} size="sm">
+        {icon}
+        {label}
+      </Button>
+    </form>
+  );
+}
+
+export default async function JobsDashboardPage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
   await requireRoutePolicy("jobs");
+  const params = (await searchParams) ?? {};
+  const filters = parseJobRunOpsFilter(params);
 
   const [dashboard, deviceConnections] = await Promise.all([
-    getJobsDashboardData(),
+    getJobsDashboardData({ filters }),
     db.deviceConnection.findMany({
       select: {
         id: true,
@@ -48,7 +138,17 @@ export default async function JobsDashboardPage() {
       <div className="mx-auto max-w-7xl space-y-6 p-6">
         <PageHeader
           title="Background Jobs"
-          description="Redis + BullMQ operational layer for alert checks, reminder generation, daily summaries, and device sync processing."
+          description="Admin control center for Redis/BullMQ queues, persisted job runs, retry/rerun workflows, device sync processing, and operational review."
+          action={
+            <div className="flex flex-wrap gap-2">
+              <Link href="/ops" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium hover:bg-muted/50">
+                Ops dashboard
+              </Link>
+              <Link href="/audit-log?source=job" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium hover:bg-muted/50">
+                Job audit
+              </Link>
+            </div>
+          }
         />
 
         {!dashboard.jobsAvailable ? (
@@ -67,6 +167,36 @@ export default async function JobsDashboardPage() {
           </Card>
         ) : null}
 
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Persisted runs</CardDescription>
+              <CardTitle>{dashboard.summary.totalRuns}</CardTitle>
+            </CardHeader>
+            <CardContent className="text-sm text-muted-foreground">All saved job-run records in the database.</CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Needs review</CardDescription>
+              <CardTitle>{dashboard.summary.failedRuns}</CardTitle>
+            </CardHeader>
+            <CardContent className="text-sm text-muted-foreground">Failed or retrying runs that need admin attention.</CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>In flight</CardDescription>
+              <CardTitle>{dashboard.summary.activeRuns}</CardTitle>
+            </CardHeader>
+            <CardContent className="text-sm text-muted-foreground">Queued or active persisted runs.</CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Recent failure rate</CardDescription>
+              <CardTitle>{dashboard.summary.failureRate}%</CardTitle>
+            </CardHeader>
+            <CardContent className="text-sm text-muted-foreground">Failed/retrying share across the latest 100 runs.</CardContent>
+          </Card>
+        </div>
 
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
           {dashboard.queueCounts.map((queue) => (
@@ -111,21 +241,21 @@ export default async function JobsDashboardPage() {
 
           <Card>
             <CardHeader>
-              <CardTitle>Operational notes</CardTitle>
-              <CardDescription>What this iteration proves inside the repo.</CardDescription>
+              <CardTitle>Admin operations added in v2</CardTitle>
+              <CardDescription>What Patch 47 proves inside the product.</CardDescription>
             </CardHeader>
             <CardContent className="space-y-3 text-sm text-muted-foreground">
               <div className="flex items-start gap-3 rounded-2xl border border-border/60 p-3">
-                <Cpu className="mt-0.5 h-4 w-4 text-primary" />
-                <div>Separate worker runtime inside the same app repo.</div>
+                <ShieldCheck className="mt-0.5 h-4 w-4 text-primary" />
+                <div>Manual job dispatch and job admin routes are admin-gated instead of authenticated-only.</div>
               </div>
               <div className="flex items-start gap-3 rounded-2xl border border-border/60 p-3">
-                <RefreshCcw className="mt-0.5 h-4 w-4 text-primary" />
-                <div>Retry-aware BullMQ queues with persisted database job-run records.</div>
+                <RotateCcw className="mt-0.5 h-4 w-4 text-primary" />
+                <div>Failed, retrying, or cancelled job runs can be re-queued from persisted input payloads.</div>
               </div>
               <div className="flex items-start gap-3 rounded-2xl border border-border/60 p-3">
                 <Activity className="mt-0.5 h-4 w-4 text-primary" />
-                <div>Device sync jobs mirror supported readings into vitals in an idempotent way.</div>
+                <div>Device sync jobs now retain connection and sync-job links for traceability.</div>
               </div>
             </CardContent>
           </Card>
@@ -133,74 +263,138 @@ export default async function JobsDashboardPage() {
 
         <Card>
           <CardHeader>
+            <CardTitle>Job filters</CardTitle>
+            <CardDescription>Review failed runs, device-sync runs, statuses, kinds, and exact ids.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <form action="/jobs" className="grid gap-3 lg:grid-cols-[1fr_180px_180px_auto]">
+              <input
+                name="q"
+                defaultValue={filters.q}
+                placeholder="Search job name, id, BullMQ id, connection id, sync job id, or error"
+                className="h-10 rounded-2xl border border-border/70 bg-background/60 px-4 text-sm outline-none focus:border-primary/60"
+              />
+              <select name="status" defaultValue={filters.status} className="h-10 rounded-2xl border border-border/70 bg-background/60 px-3 text-sm">
+                {STATUS_FILTERS.map((status) => (
+                  <option key={status.value} value={status.value}>{status.label}</option>
+                ))}
+              </select>
+              <select name="kind" defaultValue={filters.kind} className="h-10 rounded-2xl border border-border/70 bg-background/60 px-3 text-sm">
+                {KIND_FILTERS.map((kind) => (
+                  <option key={kind.value} value={kind.value}>{kind.label}</option>
+                ))}
+              </select>
+              <Button type="submit">
+                <Filter className="h-4 w-4" />
+                Apply
+              </Button>
+            </form>
+
+            <div className="flex flex-wrap gap-2 text-sm">
+              <Link href={filterHref({ review: "failed" })} className="rounded-full border border-border/60 px-3 py-1.5 hover:bg-muted/50">Needs review</Link>
+              <Link href={filterHref({ review: "device" })} className="rounded-full border border-border/60 px-3 py-1.5 hover:bg-muted/50">Device sync only</Link>
+              <Link href={filterHref({ status: "ACTIVE" })} className="rounded-full border border-border/60 px-3 py-1.5 hover:bg-muted/50">Active</Link>
+              <Link href={filterHref({ status: "FAILED" })} className="rounded-full border border-border/60 px-3 py-1.5 hover:bg-muted/50">Failed</Link>
+              <Link href="/jobs" className="rounded-full border border-border/60 px-3 py-1.5 hover:bg-muted/50">Clear filters</Link>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
             <CardTitle>Recent job runs</CardTitle>
             <CardDescription>
-              Most recent persisted queue runs, attempts, results, and worker logs.
+              Persisted queue runs with attempts, payload previews, retry controls, cancellation, and worker logs.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             {dashboard.recentRuns.length ? (
-              dashboard.recentRuns.map((run) => (
-                <div key={run.id} className="rounded-3xl border border-border/60 p-4">
-                  <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-                    <div className="space-y-2">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <Badge>{run.jobKind.replaceAll("_", " ")}</Badge>
-                        <StatusPill tone={runTone(run.status)}>{run.status}</StatusPill>
-                      </div>
+              dashboard.recentRuns.map((run) => {
+                const retryable = isRetryableJobRunStatus(run.status);
+                const cancellable = isCancellableJobRunStatus(run.status);
+                const deepLink = buildJobRunDeepLink(run);
 
-                      <div>
-                        <div className="font-medium">{run.jobName}</div>
-                        <div className="text-sm text-muted-foreground">Queue: {run.queueName}</div>
-                      </div>
-
-                      <div className="grid gap-1 text-sm text-muted-foreground">
-                        <div>Attempts: {run.attemptsMade} / {run.maxAttempts}</div>
-                        <div>Created: {formatDateTime(run.createdAt)}</div>
-                        <div>Started: {formatDateTime(run.startedAt)}</div>
-                        <div>Finished: {formatDateTime(run.finishedAt)}</div>
-                        {run.user ? <div>User: {run.user.name || run.user.email || run.user.id}</div> : null}
-                        <div>Connection ID: {run.connectionId ?? "—"}</div>
-                        <div>Sync Job ID: {run.syncJobId ?? "—"}</div>
-                      </div>
-
-                      {run.errorMessage ? (
-                        <div className="rounded-2xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700 dark:border-rose-900/40 dark:bg-rose-950/30 dark:text-rose-200">
-                          {run.errorMessage}
+                return (
+                  <div key={run.id} className="rounded-3xl border border-border/60 p-4">
+                    <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+                      <div className="min-w-0 flex-1 space-y-3">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Badge>{run.jobKind.replaceAll("_", " ")}</Badge>
+                          <StatusPill tone={jobRunTone(run.status)}>{run.status}</StatusPill>
+                          {run.attemptsMade >= run.maxAttempts && run.maxAttempts > 0 ? <StatusPill tone="warning">Max attempts</StatusPill> : null}
                         </div>
-                      ) : null}
-                    </div>
 
-                    <div className="w-full max-w-xl space-y-2">
-                      <div className="text-sm font-medium">Recent logs</div>
-                      {run.logs.length ? (
-                        run.logs.map((log) => (
-                          <div key={log.id} className="rounded-2xl border border-border/60 px-3 py-2 text-sm">
-                            <div className="flex items-center justify-between gap-3">
-                              <span className="font-medium">{log.level}</span>
-                              <span className="text-xs text-muted-foreground">{formatDateTime(log.createdAt)}</span>
-                            </div>
-                            <div className="mt-1 text-muted-foreground">{log.message}</div>
-                            {log.contextJson ? (
-                              <pre className="mt-2 overflow-x-auto rounded-xl bg-muted/50 p-2 text-xs text-muted-foreground">
-                                {log.contextJson}
-                              </pre>
-                            ) : null}
+                        <div>
+                          <div className="font-medium">{run.jobName}</div>
+                          <div className="text-sm text-muted-foreground">Queue: {run.queueName}</div>
+                        </div>
+
+                        <div className="grid gap-1 text-sm text-muted-foreground md:grid-cols-2">
+                          <div>Run ID: {compactId(run.id)}</div>
+                          <div>BullMQ ID: {compactId(run.bullmqJobId)}</div>
+                          <div>Attempts: {run.attemptsMade} / {run.maxAttempts}</div>
+                          <div>Created: {formatDateTime(run.createdAt)}</div>
+                          <div>Started: {formatDateTime(run.startedAt)}</div>
+                          <div>Finished: {formatDateTime(run.finishedAt)}</div>
+                          {run.user ? <div>User: {run.user.name || run.user.email || run.user.id}</div> : null}
+                          <div>Connection: {run.connection ? run.connection.deviceLabel || run.connection.clientDeviceId : compactId(run.connectionId)}</div>
+                          <div>Sync Job ID: {compactId(run.syncJobId)}</div>
+                        </div>
+
+                        {run.errorMessage ? (
+                          <div className="rounded-2xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700 dark:border-rose-900/40 dark:bg-rose-950/30 dark:text-rose-200">
+                            {run.errorMessage}
                           </div>
-                        ))
-                      ) : (
-                        <div className="rounded-2xl border border-border/60 px-3 py-2 text-sm text-muted-foreground">
-                          No logs for this run yet.
+                        ) : null}
+
+                        <div className="grid gap-2 lg:grid-cols-2">
+                          <JsonPreview title="Input payload" value={run.inputJson} />
+                          <JsonPreview title="Result payload" value={run.resultJson} />
                         </div>
-                      )}
+                      </div>
+
+                      <div className="w-full space-y-3 xl:max-w-md">
+                        <div className="flex flex-wrap gap-2">
+                          {retryable ? (
+                            <JobActionForm action={retryJobRunAction} jobRunId={run.id} label="Retry" icon={<RotateCcw className="h-4 w-4" />} />
+                          ) : null}
+                          {cancellable ? (
+                            <JobActionForm action={cancelJobRunAction} jobRunId={run.id} label="Cancel" variant="destructive" icon={<XCircle className="h-4 w-4" />} />
+                          ) : null}
+                          <JobActionForm action={acknowledgeJobRunAction} jobRunId={run.id} label="Acknowledge" variant="secondary" icon={<ShieldCheck className="h-4 w-4" />} />
+                          <Link href={deepLink} className="inline-flex h-9 items-center justify-center rounded-xl border border-border/70 bg-background/60 px-3 text-sm font-medium hover:bg-muted/50">
+                            Open trace
+                          </Link>
+                        </div>
+
+                        <div className="text-sm font-medium">Recent logs</div>
+                        {run.logs.length ? (
+                          run.logs.map((log) => (
+                            <div key={log.id} className="rounded-2xl border border-border/60 px-3 py-2 text-sm">
+                              <div className="flex items-center justify-between gap-3">
+                                <span className="font-medium">{log.level}</span>
+                                <span className="text-xs text-muted-foreground">{formatDateTime(log.createdAt)}</span>
+                              </div>
+                              <div className="mt-1 text-muted-foreground">{log.message}</div>
+                              {log.contextJson ? (
+                                <pre className="mt-2 max-h-28 overflow-x-auto rounded-xl bg-muted/50 p-2 text-xs text-muted-foreground">
+                                  {log.contextJson}
+                                </pre>
+                              ) : null}
+                            </div>
+                          ))
+                        ) : (
+                          <div className="rounded-2xl border border-border/60 px-3 py-2 text-sm text-muted-foreground">
+                            No logs for this run yet.
+                          </div>
+                        )}
+                      </div>
                     </div>
                   </div>
-                </div>
-              ))
+                );
+              })
             ) : (
-              <div className="rounded-2xl border border-border/60 px-4 py-3 text-sm text-muted-foreground">
-                No job runs found yet.
-              </div>
+              <EmptyState title="No job runs found" description="Try clearing filters or dispatching a sample job from the manual dispatch panel." />
             )}
           </CardContent>
         </Card>

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -30,7 +30,7 @@ This document keeps the current limitations honest so reviewers can understand w
 | Mobile API | Mobile auth, sessions, connections, and device readings have schema-backed foundations. | Add OpenAPI output, SDK examples, rate limits, and request signing for production use. |
 | Sleep readings | Sleep tracking is not currently part of the Prisma `DeviceReadingType` enum. | Add sleep support only through a deliberate Prisma enum migration and matching docs/tests. |
 | Device ingestion | Device readings can be validated, ingested, reviewed in the Device Integration dashboard, opened in per-device detail pages, and mirrored into vitals. Provider integrations are still simulated/foundational. | Add provider-specific connectors and reconciliation logic for Apple Health, Health Connect, Fitbit, and smart devices. |
-| Background sync | BullMQ/Redis foundations exist, but production worker deployment depends on environment setup. | Add queue dashboards, retry/rerun controls, dead-letter handling, and alerting. |
+| Background sync | BullMQ/Redis foundations exist, and the Jobs dashboard now supports admin filtering, retry, acknowledgement, and persisted cancellation. Production worker deployment still depends on environment setup. | Add true BullMQ dead-letter queues, Redis job removal from the UI, alerting, and hosted worker runbooks. |
 
 ## Demo limitations
 
@@ -76,3 +76,4 @@ Recommended future coverage:
 - Care Notes were connected across timeline, report, print, and export workflows in Patch 44.
 - Portfolio-facing README, feature matrix, known limitations, metadata, and demo wording were refreshed in Patch 45.
 - Device Integration v2 was added in Patch 46 with real connection management, detail pages, QA payloads, and traceable sync history.
+- Background Jobs v2 Admin Tools were added in Patch 47 with admin-only dispatch, filters, retry, acknowledge, and persisted cancellation workflows.

--- a/docs/PATCH_47_BACKGROUND_JOBS_V2_ADMIN_TOOLS.md
+++ b/docs/PATCH_47_BACKGROUND_JOBS_V2_ADMIN_TOOLS.md
@@ -1,0 +1,38 @@
+# Patch 47: Background Jobs v2 Admin Tools
+
+## Summary
+
+Patch 47 upgrades VitaVault's Background Jobs area from a mostly observational dashboard into an admin operations surface for reviewing persisted job runs, filtering failures, retrying failed work, acknowledging operational review, and marking queued/active/retrying persisted runs as cancelled.
+
+## What changed
+
+- Added admin-only job-run retry, acknowledge, and cancel server actions.
+- Added filtered job-run review by status, job kind, failure review, device-sync review, and free-text query.
+- Added job-run input/result JSON previews for operational debugging.
+- Added persisted job-run links back to device connections or sync jobs when available.
+- Added summary KPIs for total persisted runs, failed/retrying runs, in-flight runs, and recent failure rate.
+- Hardened `/api/jobs/dispatch` so manual job dispatch is admin-only.
+- Preserved `connectionId` and `syncJobId` on newly queued device-sync job runs.
+- Added pure helper tests for job admin filter parsing, retry payload construction, retry/cancel eligibility, summaries, and deep links.
+
+## Safety notes
+
+- No Prisma schema changes.
+- No migration changes.
+- No package changes.
+- Cancelling a job run marks the persisted VitaVault `JobRun` record as `CANCELLED`; it does not remove a live BullMQ job from Redis.
+- Retrying uses the original persisted input payload and queues a new job run when Redis is configured.
+
+## Checks
+
+Run:
+
+```bash
+npm run db:validate:ci
+npm run actions:check
+npm run actions:imports
+npm run actions:shadow
+npm run typecheck
+npm run lint
+npm run test:run
+```

--- a/lib/jobs/admin-tools.ts
+++ b/lib/jobs/admin-tools.ts
@@ -1,0 +1,245 @@
+import { JOB_NAMES } from "@/lib/jobs/contracts";
+
+type JsonRecord = Record<string, unknown>;
+
+export type JobRunFilterStatus =
+  | "all"
+  | "QUEUED"
+  | "ACTIVE"
+  | "RETRYING"
+  | "FAILED"
+  | "COMPLETED"
+  | "CANCELLED";
+
+export type JobRunFilterKind =
+  | "all"
+  | "ALERT_EVALUATION"
+  | "REMINDER_GENERATION"
+  | "DAILY_HEALTH_SUMMARY"
+  | "DEVICE_SYNC_PROCESSING";
+
+export type JobRunOpsFilter = {
+  status: JobRunFilterStatus;
+  kind: JobRunFilterKind;
+  q: string;
+  review: "all" | "failed" | "device";
+};
+
+export type JobRunSummaryInput = {
+  status: string;
+  jobKind: string;
+  attemptsMade: number;
+  maxAttempts: number;
+  errorMessage?: string | null;
+  connectionId?: string | null;
+  syncJobId?: string | null;
+};
+
+export type RetryableJobRunInput = {
+  id: string;
+  jobName: string;
+  userId?: string | null;
+  connectionId?: string | null;
+  syncJobId?: string | null;
+  inputJson?: string | null;
+};
+
+export type RetryDispatchPayload =
+  | {
+      jobType: "alert-evaluation";
+      userId: string;
+      sourceType?: "VITAL_RECORD" | "MEDICATION_LOG" | "SYMPTOM_ENTRY" | "SYNC_JOB" | "DEVICE_READING" | "SCHEDULED_SCAN" | null;
+      sourceId?: string | null;
+      sourceRecordedAt?: string | null;
+      initiatedBy?: "record_create" | "scheduled_scan" | "manual_scan" | "sync_finish";
+    }
+  | {
+      jobType: "reminder-generation";
+      userId: string;
+      timezone?: string | null;
+      targetDate?: string | null;
+    }
+  | {
+      jobType: "reminder-overdue-evaluation";
+      userId: string;
+      timezone?: string | null;
+    }
+  | {
+      jobType: "daily-health-summary";
+      userId: string;
+      targetDate?: string | null;
+    }
+  | {
+      jobType: "device-sync-processing";
+      userId: string;
+      connectionId?: string | null;
+      syncJobId?: string | null;
+    };
+
+const STATUS_VALUES: JobRunFilterStatus[] = [
+  "all",
+  "QUEUED",
+  "ACTIVE",
+  "RETRYING",
+  "FAILED",
+  "COMPLETED",
+  "CANCELLED",
+];
+
+const KIND_VALUES: JobRunFilterKind[] = [
+  "all",
+  "ALERT_EVALUATION",
+  "REMINDER_GENERATION",
+  "DAILY_HEALTH_SUMMARY",
+  "DEVICE_SYNC_PROCESSING",
+];
+
+function stringValue(value: unknown) {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value) && typeof value[0] === "string") return value[0];
+  return "";
+}
+
+function isAlertSourceType(value: unknown): value is "VITAL_RECORD" | "MEDICATION_LOG" | "SYMPTOM_ENTRY" | "SYNC_JOB" | "DEVICE_READING" | "SCHEDULED_SCAN" {
+  return (
+    value === "VITAL_RECORD" ||
+    value === "MEDICATION_LOG" ||
+    value === "SYMPTOM_ENTRY" ||
+    value === "SYNC_JOB" ||
+    value === "DEVICE_READING" ||
+    value === "SCHEDULED_SCAN"
+  );
+}
+
+function isAlertInitiatedBy(value: unknown): value is "record_create" | "scheduled_scan" | "manual_scan" | "sync_finish" {
+  return value === "record_create" || value === "scheduled_scan" || value === "manual_scan" || value === "sync_finish";
+}
+
+function asNullableString(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+export function parseJobRunOpsFilter(params: Record<string, string | string[] | undefined>): JobRunOpsFilter {
+  const status = stringValue(params.status);
+  const kind = stringValue(params.kind);
+  const review = stringValue(params.review);
+
+  return {
+    status: STATUS_VALUES.includes(status as JobRunFilterStatus) ? (status as JobRunFilterStatus) : "all",
+    kind: KIND_VALUES.includes(kind as JobRunFilterKind) ? (kind as JobRunFilterKind) : "all",
+    q: stringValue(params.q).trim(),
+    review: review === "failed" || review === "device" ? review : "all",
+  };
+}
+
+export function parseJobRunJson(value: string | null | undefined): JsonRecord | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed as JsonRecord;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function isRetryableJobRunStatus(status: string) {
+  return status === "FAILED" || status === "RETRYING" || status === "CANCELLED";
+}
+
+export function isCancellableJobRunStatus(status: string) {
+  return status === "QUEUED" || status === "ACTIVE" || status === "RETRYING";
+}
+
+export function jobRunTone(status: string): "neutral" | "info" | "success" | "warning" | "danger" {
+  if (status === "COMPLETED") return "success";
+  if (status === "FAILED") return "danger";
+  if (status === "RETRYING" || status === "CANCELLED") return "warning";
+  if (status === "ACTIVE") return "info";
+  return "neutral";
+}
+
+export function buildJobRunOpsSummary(runs: JobRunSummaryInput[]) {
+  const failed = runs.filter((run) => run.status === "FAILED").length;
+  const retrying = runs.filter((run) => run.status === "RETRYING").length;
+  const active = runs.filter((run) => run.status === "ACTIVE").length;
+  const queued = runs.filter((run) => run.status === "QUEUED").length;
+  const completed = runs.filter((run) => run.status === "COMPLETED").length;
+  const cancellable = runs.filter((run) => isCancellableJobRunStatus(run.status)).length;
+  const retryable = runs.filter((run) => isRetryableJobRunStatus(run.status)).length;
+  const deviceRuns = runs.filter((run) => run.jobKind === "DEVICE_SYNC_PROCESSING" || run.connectionId || run.syncJobId).length;
+
+  return {
+    total: runs.length,
+    failed,
+    retrying,
+    active,
+    queued,
+    completed,
+    cancellable,
+    retryable,
+    deviceRuns,
+    failureRate: runs.length ? Math.round(((failed + retrying) / runs.length) * 100) : 0,
+  };
+}
+
+export function buildRetryDispatchPayload(run: RetryableJobRunInput): RetryDispatchPayload {
+  const input = parseJobRunJson(run.inputJson) ?? {};
+  const userId = asNullableString(input.userId) ?? run.userId;
+
+  if (!userId) {
+    throw new Error("This job run cannot be retried because it does not have a user id.");
+  }
+
+  switch (run.jobName) {
+    case JOB_NAMES.alertEvaluation:
+    case JOB_NAMES.alertScheduledScan:
+      return {
+        jobType: "alert-evaluation",
+        userId,
+        sourceType: isAlertSourceType(input.sourceType) ? input.sourceType : null,
+        sourceId: asNullableString(input.sourceId),
+        sourceRecordedAt: asNullableString(input.sourceRecordedAt) ?? new Date().toISOString(),
+        initiatedBy: isAlertInitiatedBy(input.initiatedBy) ? input.initiatedBy : "manual_scan",
+      };
+
+    case JOB_NAMES.reminderGeneration:
+      return {
+        jobType: "reminder-generation",
+        userId,
+        timezone: asNullableString(input.timezone),
+        targetDate: asNullableString(input.targetDate),
+      };
+
+    case JOB_NAMES.reminderOverdueEvaluation:
+      return {
+        jobType: "reminder-overdue-evaluation",
+        userId,
+        timezone: asNullableString(input.timezone),
+      };
+
+    case JOB_NAMES.dailyHealthSummary:
+      return {
+        jobType: "daily-health-summary",
+        userId,
+        targetDate: asNullableString(input.targetDate),
+      };
+
+    case JOB_NAMES.deviceSyncProcessing:
+      return {
+        jobType: "device-sync-processing",
+        userId,
+        connectionId: asNullableString(input.connectionId) ?? run.connectionId ?? null,
+        syncJobId: asNullableString(input.syncJobId) ?? run.syncJobId ?? null,
+      };
+
+    default:
+      throw new Error(`Unsupported retry job name: ${run.jobName}`);
+  }
+}
+
+export function buildJobRunDeepLink(run: { id: string; connectionId?: string | null; syncJobId?: string | null }) {
+  if (run.connectionId) return `/device-connection/${run.connectionId}`;
+  if (run.syncJobId) return `/jobs?review=device&q=${encodeURIComponent(run.syncJobId)}`;
+  return `/jobs?q=${encodeURIComponent(run.id)}`;
+}

--- a/lib/jobs/dashboard.ts
+++ b/lib/jobs/dashboard.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from "@prisma/client";
 import { JobType, Queue } from "bullmq";
 import { db } from "@/lib/db";
 import { DEFAULT_JOB_DASHBOARD_LIMIT } from "@/lib/jobs/constants";
@@ -8,8 +9,16 @@ import {
   getDeviceSyncQueue,
   getRemindersQueue,
 } from "@/lib/jobs/queues";
+import {
+  buildJobRunOpsSummary,
+  type JobRunOpsFilter,
+} from "@/lib/jobs/admin-tools";
 
 type SafeQueue = Queue;
+
+type JobsDashboardOptions = {
+  filters?: JobRunOpsFilter;
+};
 
 const EMPTY_COUNTS = {
   active: 0,
@@ -56,9 +65,60 @@ function getEmptyQueueCounts() {
   ];
 }
 
-export async function getJobsDashboardData() {
+function buildJobRunWhere(filters?: JobRunOpsFilter): Prisma.JobRunWhereInput {
+  const where: Prisma.JobRunWhereInput = {};
+
+  if (!filters) return where;
+
+  if (filters.status !== "all") {
+    where.status = filters.status;
+  }
+
+  if (filters.kind !== "all") {
+    where.jobKind = filters.kind;
+  }
+
+  if (filters.review === "failed") {
+    where.status = { in: ["FAILED", "RETRYING"] };
+  }
+
+  if (filters.review === "device") {
+    where.OR = [
+      { jobKind: "DEVICE_SYNC_PROCESSING" },
+      { connectionId: { not: null } },
+      { syncJobId: { not: null } },
+    ];
+  }
+
+  if (filters.q) {
+    const queryFilter: Prisma.JobRunWhereInput = {
+      OR: [
+        { id: { contains: filters.q, mode: "insensitive" } },
+        { jobName: { contains: filters.q, mode: "insensitive" } },
+        { queueName: { contains: filters.q, mode: "insensitive" } },
+        { errorMessage: { contains: filters.q, mode: "insensitive" } },
+        { bullmqJobId: { contains: filters.q, mode: "insensitive" } },
+        { connectionId: { contains: filters.q, mode: "insensitive" } },
+        { syncJobId: { contains: filters.q, mode: "insensitive" } },
+      ],
+    };
+
+    if (where.OR) {
+      where.AND = [{ OR: where.OR }, queryFilter];
+      where.OR = undefined;
+    } else {
+      where.OR = queryFilter.OR;
+    }
+  }
+
+  return where;
+}
+
+export async function getJobsDashboardData(options: JobsDashboardOptions = {}) {
   const skipRedis = shouldSkipRedisDuringBuild();
   const redisConfigured = hasRedisConfig();
+  const filters = options.filters;
+  const jobRunWhere = buildJobRunWhere(filters);
 
   const queueCountsPromise =
     !redisConfigured || skipRedis
@@ -71,6 +131,7 @@ export async function getJobsDashboardData() {
         ]);
 
   const recentRunsPromise = db.jobRun.findMany({
+    where: jobRunWhere,
     orderBy: { createdAt: "desc" },
     take: DEFAULT_JOB_DASHBOARD_LIMIT,
     include: {
@@ -85,10 +146,40 @@ export async function getJobsDashboardData() {
           email: true,
         },
       },
+      connection: {
+        select: {
+          id: true,
+          source: true,
+          status: true,
+          deviceLabel: true,
+          clientDeviceId: true,
+        },
+      },
     },
   });
 
-  const [queueCounts, recentRuns] = await Promise.all([queueCountsPromise, recentRunsPromise]);
+  const recentForSummaryPromise = db.jobRun.findMany({
+    orderBy: { createdAt: "desc" },
+    take: 100,
+    select: {
+      status: true,
+      jobKind: true,
+      attemptsMade: true,
+      maxAttempts: true,
+      errorMessage: true,
+      connectionId: true,
+      syncJobId: true,
+    },
+  });
+
+  const [queueCounts, recentRuns, recentForSummary, totalRuns, failedRuns, activeRuns] = await Promise.all([
+    queueCountsPromise,
+    recentRunsPromise,
+    recentForSummaryPromise,
+    db.jobRun.count(),
+    db.jobRun.count({ where: { status: { in: ["FAILED", "RETRYING"] } } }),
+    db.jobRun.count({ where: { status: { in: ["QUEUED", "ACTIVE"] } } }),
+  ]);
 
   let unavailableReason: string | null = null;
   if (!redisConfigured) {
@@ -102,5 +193,12 @@ export async function getJobsDashboardData() {
     unavailableReason,
     queueCounts,
     recentRuns,
+    filters,
+    summary: {
+      ...buildJobRunOpsSummary(recentForSummary),
+      totalRuns,
+      failedRuns,
+      activeRuns,
+    },
   };
 }

--- a/lib/jobs/enqueue.ts
+++ b/lib/jobs/enqueue.ts
@@ -130,6 +130,8 @@ export async function enqueueDeviceSyncProcessingJob(payload: DeviceSyncProcessi
     queueName: QUEUE_NAMES.deviceSync,
     jobName: JOB_NAMES.deviceSyncProcessing,
     userId: payload.userId,
+    connectionId: payload.connectionId ?? null,
+    syncJobId: payload.syncJobId ?? null,
     input: payload as Record<string, unknown>,
     maxAttempts: 3,
   });

--- a/lib/jobs/job-run.ts
+++ b/lib/jobs/job-run.ts
@@ -6,6 +6,8 @@ export async function createJobRun(args: {
   jobName: string;
   bullmqJobId?: string | null;
   userId?: string | null;
+  connectionId?: string | null;
+  syncJobId?: string | null;
   input?: Record<string, unknown> | null;
   maxAttempts?: number;
 }) {
@@ -17,6 +19,8 @@ export async function createJobRun(args: {
       bullmqJobId: args.bullmqJobId ?? null,
       status: "QUEUED",
       userId: args.userId ?? null,
+      connectionId: args.connectionId ?? null,
+      syncJobId: args.syncJobId ?? null,
       inputJson: args.input ? JSON.stringify(args.input) : null,
       maxAttempts: args.maxAttempts ?? 0,
     },

--- a/tests/job-admin-tools.test.ts
+++ b/tests/job-admin-tools.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildJobRunDeepLink,
+  buildJobRunOpsSummary,
+  buildRetryDispatchPayload,
+  isCancellableJobRunStatus,
+  isRetryableJobRunStatus,
+  parseJobRunJson,
+  parseJobRunOpsFilter,
+} from "@/lib/jobs/admin-tools";
+
+describe("job admin tools", () => {
+  it("parses safe dashboard filters", () => {
+    expect(parseJobRunOpsFilter({ status: "FAILED", kind: "DEVICE_SYNC_PROCESSING", review: "device", q: "sync" })).toEqual({
+      status: "FAILED",
+      kind: "DEVICE_SYNC_PROCESSING",
+      review: "device",
+      q: "sync",
+    });
+
+    expect(parseJobRunOpsFilter({ status: "BROKEN", kind: "NOPE", review: "weird" })).toEqual({
+      status: "all",
+      kind: "all",
+      review: "all",
+      q: "",
+    });
+  });
+
+  it("summarizes operational state from recent job runs", () => {
+    const summary = buildJobRunOpsSummary([
+      { status: "FAILED", jobKind: "DEVICE_SYNC_PROCESSING", attemptsMade: 3, maxAttempts: 3, connectionId: "conn_1" },
+      { status: "RETRYING", jobKind: "ALERT_EVALUATION", attemptsMade: 1, maxAttempts: 3 },
+      { status: "COMPLETED", jobKind: "DAILY_HEALTH_SUMMARY", attemptsMade: 1, maxAttempts: 3 },
+      { status: "ACTIVE", jobKind: "REMINDER_GENERATION", attemptsMade: 0, maxAttempts: 3 },
+    ]);
+
+    expect(summary.failed).toBe(1);
+    expect(summary.retrying).toBe(1);
+    expect(summary.active).toBe(1);
+    expect(summary.retryable).toBe(2);
+    expect(summary.cancellable).toBe(2);
+    expect(summary.deviceRuns).toBe(1);
+    expect(summary.failureRate).toBe(50);
+  });
+
+  it("builds retry payloads from persisted job input", () => {
+    const payload = buildRetryDispatchPayload({
+      id: "run_1",
+      jobName: "device-sync-processing",
+      userId: "user_1",
+      connectionId: "fallback_connection",
+      syncJobId: "fallback_sync",
+      inputJson: JSON.stringify({ userId: "user_1", connectionId: "conn_1", syncJobId: "sync_1" }),
+    });
+
+    expect(payload).toEqual({
+      jobType: "device-sync-processing",
+      userId: "user_1",
+      connectionId: "conn_1",
+      syncJobId: "sync_1",
+    });
+  });
+
+  it("understands retryable and cancellable states", () => {
+    expect(isRetryableJobRunStatus("FAILED")).toBe(true);
+    expect(isRetryableJobRunStatus("COMPLETED")).toBe(false);
+    expect(isCancellableJobRunStatus("QUEUED")).toBe(true);
+    expect(isCancellableJobRunStatus("CANCELLED")).toBe(false);
+  });
+
+  it("parses json safely and builds useful deep links", () => {
+    expect(parseJobRunJson('{"ok":true}')).toEqual({ ok: true });
+    expect(parseJobRunJson("not-json")).toBeNull();
+    expect(buildJobRunDeepLink({ id: "run_1", connectionId: "conn_1" })).toBe("/device-connection/conn_1");
+    expect(buildJobRunDeepLink({ id: "run_2" })).toBe("/jobs?q=run_2");
+  });
+});


### PR DESCRIPTION
## Summary

This patch upgrades VitaVault’s Background Jobs area into a stronger admin operations surface with job filtering, retry tools, cancellation, acknowledgement, device-sync traceability, and persisted job run debugging.

## Changes

- Added admin-only retry, acknowledge, and cancel server actions for job runs.
- Added filtered job review by status, job kind, failure state, device-sync state, and search query.
- Added job operational KPIs for failed, retrying, active, retryable, cancellable, and device-sync runs.
- Added JSON previews for job input, result, and error payloads.
- Added deep links from job runs to device connection detail pages.
- Hardened `/api/jobs/dispatch` so manual dispatch is admin-only.
- Preserved `connectionId` and `syncJobId` on newly queued device-sync job runs.
- Added reusable admin job helper functions.
- Added job admin helper tests.
- Updated known limitations and added Patch 47 documentation.

## Safety

- No Prisma schema changes.
- No migration changes.
- No package changes.
- Cancelling a job run only marks the persisted VitaVault `JobRun` record as `CANCELLED`.
- Retrying creates a new dispatch from the existing persisted job input.

## Checks to run

```bash
npm install
npm run db:validate:ci
npm run actions:check
npm run actions:imports
npm run actions:shadow
npm run typecheck
npm run lint
npm run test:run