### PR TITLE
Patch 49: Mobile API Security Hardening

### DIFF
--- a/app/api-docs/page.tsx
+++ b/app/api-docs/page.tsx
@@ -26,6 +26,7 @@ import {
   THead,
   TR,
 } from "@/components/ui";
+import { getMobileSecurityChecklist } from "@/lib/mobile-api-security";
 
 const baseUrl = "https://your-vitavault-domain.com";
 
@@ -533,7 +534,7 @@ export default function ApiDocsPage() {
                 "Treat mobile tokens separately from browser sessions.",
                 "Rotate/revoke tokens from the security center when a device is lost.",
                 "Keep reading payloads minimal and avoid sending unnecessary PHI.",
-                "Add rate limiting before exposing the endpoints publicly at scale.",
+                ...getMobileSecurityChecklist(),
               ].map((note) => (
                 <div key={note} className="rounded-3xl border border-border/60 bg-background/55 p-4 text-sm leading-6">
                   {note}

--- a/app/api/mobile/auth/login/route.ts
+++ b/app/api/mobile/auth/login/route.ts
@@ -1,7 +1,18 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { logAccessAudit } from "@/lib/access";
 import { authenticateMobileCredentials, createMobileSessionToken } from "@/lib/mobile-auth";
-import { consumeRateLimit, getClientRateLimitKey } from "@/lib/security/rate-limit";
+import {
+  consumeMobileApiRateLimit,
+  getMobileAuditMetadata,
+  getMobileNoStoreHeaders,
+  getMobilePayloadTooLargeBody,
+  getMobileRateLimitErrorBody,
+  getMobileRateLimitHeaders,
+  getMobileSecurityPolicy,
+  getRetryAfterHeaders,
+  isMobileRequestTooLarge,
+} from "@/lib/mobile-api-security";
 
 const loginSchema = z.object({
   email: z.string().trim().email(),
@@ -10,32 +21,31 @@ const loginSchema = z.object({
 });
 
 export async function POST(request: Request) {
+  const endpoint = "auth:login" as const;
+  const policy = getMobileSecurityPolicy(endpoint);
+
+  if (isMobileRequestTooLarge(request, endpoint)) {
+    return NextResponse.json(getMobilePayloadTooLargeBody(endpoint), {
+      status: 413,
+      headers: getMobileNoStoreHeaders(),
+    });
+  }
+
   try {
     const body = await request.json();
     const parsed = loginSchema.safeParse(body);
     const emailScope = typeof body?.email === "string" ? body.email.trim().toLowerCase() : "unknown";
-    const rateLimit = consumeRateLimit({
-      key: getClientRateLimitKey(request, `mobile-login:${emailScope}`),
-      limit: 10,
-      windowMs: 15 * 60 * 1000,
+    const rateLimit = consumeMobileApiRateLimit({
+      request,
+      endpoint,
+      discriminator: emailScope,
     });
 
     if (!rateLimit.allowed) {
-      return NextResponse.json(
-        {
-          error: "Too many mobile login attempts. Try again later.",
-          retryAfterSeconds: rateLimit.retryAfterSeconds,
-        },
-        {
-          status: 429,
-          headers: {
-            "Retry-After": String(rateLimit.retryAfterSeconds),
-            "X-RateLimit-Limit": String(rateLimit.limit),
-            "X-RateLimit-Remaining": String(rateLimit.remaining),
-            "X-RateLimit-Reset": rateLimit.resetAt.toISOString(),
-          },
-        }
-      );
+      return NextResponse.json(getMobileRateLimitErrorBody(rateLimit, policy.label.toLowerCase()), {
+        status: 429,
+        headers: getMobileNoStoreHeaders(getRetryAfterHeaders(rateLimit)),
+      });
     }
 
     if (!parsed.success) {
@@ -44,7 +54,7 @@ export async function POST(request: Request) {
           error: "Invalid login payload.",
           details: parsed.error.flatten(),
         },
-        { status: 400 }
+        { status: 400, headers: getMobileNoStoreHeaders(getMobileRateLimitHeaders(rateLimit)) }
       );
     }
 
@@ -56,7 +66,7 @@ export async function POST(request: Request) {
     if (!user) {
       return NextResponse.json(
         { error: "Invalid email or password." },
-        { status: 401 }
+        { status: 401, headers: getMobileNoStoreHeaders(getMobileRateLimitHeaders(rateLimit)) }
       );
     }
 
@@ -65,19 +75,33 @@ export async function POST(request: Request) {
       name: parsed.data.deviceName ?? "Android device",
     });
 
-    return NextResponse.json({
-      token: sessionToken.token,
-      expiresAt: sessionToken.expiresAt.toISOString(),
-      user: {
-        id: user.id,
-        email: user.email,
-        name: user.name,
-      },
+    await logAccessAudit({
+      ownerUserId: user.id,
+      actorUserId: user.id,
+      action: "mobile_session.created",
+      targetType: "MOBILE_SESSION",
+      metadata: getMobileAuditMetadata(request, {
+        deviceName: parsed.data.deviceName ?? "Android device",
+        expiresAt: sessionToken.expiresAt.toISOString(),
+      }),
     });
+
+    return NextResponse.json(
+      {
+        token: sessionToken.token,
+        expiresAt: sessionToken.expiresAt.toISOString(),
+        user: {
+          id: user.id,
+          email: user.email,
+          name: user.name,
+        },
+      },
+      { headers: getMobileNoStoreHeaders(getMobileRateLimitHeaders(rateLimit)) }
+    );
   } catch {
     return NextResponse.json(
       { error: "Unable to complete mobile login." },
-      { status: 500 }
+      { status: 500, headers: getMobileNoStoreHeaders() }
     );
   }
 }

--- a/app/api/mobile/auth/logout/route.ts
+++ b/app/api/mobile/auth/logout/route.ts
@@ -1,19 +1,61 @@
 import { NextResponse } from "next/server";
-import { getBearerTokenFromRequest, revokeMobileToken } from "@/lib/mobile-auth";
+import { logAccessAudit } from "@/lib/access";
+import { getBearerTokenFromRequest, requireMobileUser, revokeMobileToken } from "@/lib/mobile-auth";
+import {
+  consumeMobileApiRateLimit,
+  fingerprintBearerToken,
+  getMobileAuditMetadata,
+  getMobileNoStoreHeaders,
+  getMobileRateLimitErrorBody,
+  getMobileRateLimitHeaders,
+  getMobileSecurityPolicy,
+  getRetryAfterHeaders,
+} from "@/lib/mobile-api-security";
 
 export async function POST(request: Request) {
+  const endpoint = "auth:logout" as const;
+  const policy = getMobileSecurityPolicy(endpoint);
+  const rateLimit = consumeMobileApiRateLimit({ request, endpoint });
+
+  if (!rateLimit.allowed) {
+    return NextResponse.json(getMobileRateLimitErrorBody(rateLimit, policy.label.toLowerCase()), {
+      status: 429,
+      headers: getMobileNoStoreHeaders(getRetryAfterHeaders(rateLimit)),
+    });
+  }
+
   try {
     const token = getBearerTokenFromRequest(request);
+    const user = await requireMobileUser(request);
 
-    if (token) {
-      await revokeMobileToken(token);
+    if (!token || !user) {
+      return NextResponse.json(
+        { error: "Unauthorized mobile session." },
+        { status: 401, headers: getMobileNoStoreHeaders(getMobileRateLimitHeaders(rateLimit)) }
+      );
     }
 
-    return NextResponse.json({ success: true });
+    await revokeMobileToken(token);
+
+    await logAccessAudit({
+      ownerUserId: user.id,
+      actorUserId: user.id,
+      action: "mobile_session.revoked",
+      targetType: "MOBILE_SESSION",
+      metadata: getMobileAuditMetadata(request, {
+        tokenFingerprint: fingerprintBearerToken(token),
+        source: "mobile_logout",
+      }),
+    });
+
+    return NextResponse.json(
+      { success: true },
+      { headers: getMobileNoStoreHeaders(getMobileRateLimitHeaders(rateLimit)) }
+    );
   } catch {
     return NextResponse.json(
       { error: "Unable to revoke mobile session." },
-      { status: 500 }
+      { status: 500, headers: getMobileNoStoreHeaders(getMobileRateLimitHeaders(rateLimit)) }
     );
   }
 }

--- a/app/api/mobile/auth/me/route.ts
+++ b/app/api/mobile/auth/me/route.ts
@@ -1,21 +1,43 @@
 import { NextResponse } from "next/server";
 import { requireMobileUser } from "@/lib/mobile-auth";
+import {
+  consumeMobileApiRateLimit,
+  getMobileNoStoreHeaders,
+  getMobileRateLimitErrorBody,
+  getMobileRateLimitHeaders,
+  getMobileSecurityPolicy,
+  getRetryAfterHeaders,
+} from "@/lib/mobile-api-security";
 
 export async function GET(request: Request) {
+  const endpoint = "auth:me" as const;
+  const policy = getMobileSecurityPolicy(endpoint);
+  const rateLimit = consumeMobileApiRateLimit({ request, endpoint });
+
+  if (!rateLimit.allowed) {
+    return NextResponse.json(getMobileRateLimitErrorBody(rateLimit, policy.label.toLowerCase()), {
+      status: 429,
+      headers: getMobileNoStoreHeaders(getRetryAfterHeaders(rateLimit)),
+    });
+  }
+
   const user = await requireMobileUser(request);
 
   if (!user) {
     return NextResponse.json(
       { error: "Unauthorized mobile session." },
-      { status: 401 }
+      { status: 401, headers: getMobileNoStoreHeaders(getMobileRateLimitHeaders(rateLimit)) }
     );
   }
 
-  return NextResponse.json({
-    user: {
-      id: user.id,
-      email: user.email,
-      name: user.name,
+  return NextResponse.json(
+    {
+      user: {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+      },
     },
-  });
+    { headers: getMobileNoStoreHeaders(getMobileRateLimitHeaders(rateLimit)) }
+  );
 }

--- a/app/api/mobile/connections/route.ts
+++ b/app/api/mobile/connections/route.ts
@@ -1,14 +1,33 @@
 import { NextResponse } from "next/server";
 import { requireMobileUser } from "@/lib/mobile-auth";
 import { db } from "@/lib/db";
+import {
+  consumeMobileApiRateLimit,
+  getMobileNoStoreHeaders,
+  getMobileRateLimitErrorBody,
+  getMobileRateLimitHeaders,
+  getMobileSecurityPolicy,
+  getRetryAfterHeaders,
+} from "@/lib/mobile-api-security";
 
 export async function GET(request: Request) {
+  const endpoint = "connections:list" as const;
+  const policy = getMobileSecurityPolicy(endpoint);
+  const rateLimit = consumeMobileApiRateLimit({ request, endpoint });
+
+  if (!rateLimit.allowed) {
+    return NextResponse.json(getMobileRateLimitErrorBody(rateLimit, policy.label.toLowerCase()), {
+      status: 429,
+      headers: getMobileNoStoreHeaders(getRetryAfterHeaders(rateLimit)),
+    });
+  }
+
   const user = await requireMobileUser(request);
 
   if (!user) {
     return NextResponse.json(
       { error: "Unauthorized mobile session." },
-      { status: 401 }
+      { status: 401, headers: getMobileNoStoreHeaders(getMobileRateLimitHeaders(rateLimit)) }
     );
   }
 
@@ -30,5 +49,8 @@ export async function GET(request: Request) {
     },
   });
 
-  return NextResponse.json({ connections });
+  return NextResponse.json(
+    { connections },
+    { headers: getMobileNoStoreHeaders(getMobileRateLimitHeaders(rateLimit)) }
+  );
 }

--- a/app/api/mobile/device-readings/route.ts
+++ b/app/api/mobile/device-readings/route.ts
@@ -1,5 +1,15 @@
 import { NextResponse } from "next/server";
 import { requireMobileUser } from "@/lib/mobile-auth";
+import {
+  consumeMobileApiRateLimit,
+  getMobileNoStoreHeaders,
+  getMobilePayloadTooLargeBody,
+  getMobileRateLimitErrorBody,
+  getMobileRateLimitHeaders,
+  getMobileSecurityPolicy,
+  getRetryAfterHeaders,
+  isMobileRequestTooLarge,
+} from "@/lib/mobile-api-security";
 import { mobileDeviceSyncSchema } from "@/lib/mobile-device-api";
 import {
   ingestDeviceReadings,
@@ -8,12 +18,30 @@ import {
 } from "@/lib/mobile-readings";
 
 export async function POST(request: Request) {
+  const endpoint = "readings:sync" as const;
+  const policy = getMobileSecurityPolicy(endpoint);
+  const rateLimit = consumeMobileApiRateLimit({ request, endpoint });
+
+  if (!rateLimit.allowed) {
+    return NextResponse.json(getMobileRateLimitErrorBody(rateLimit, policy.label.toLowerCase()), {
+      status: 429,
+      headers: getMobileNoStoreHeaders(getRetryAfterHeaders(rateLimit)),
+    });
+  }
+
+  if (isMobileRequestTooLarge(request, endpoint)) {
+    return NextResponse.json(getMobilePayloadTooLargeBody(endpoint), {
+      status: 413,
+      headers: getMobileNoStoreHeaders(getMobileRateLimitHeaders(rateLimit)),
+    });
+  }
+
   const user = await requireMobileUser(request);
 
   if (!user) {
     return NextResponse.json(
       { error: "Unauthorized mobile session." },
-      { status: 401 }
+      { status: 401, headers: getMobileNoStoreHeaders(getMobileRateLimitHeaders(rateLimit)) }
     );
   }
 
@@ -27,7 +55,7 @@ export async function POST(request: Request) {
           error: "Invalid device reading payload.",
           details: parsed.error.flatten(),
         },
-        { status: 400 }
+        { status: 400, headers: getMobileNoStoreHeaders(getMobileRateLimitHeaders(rateLimit)) }
       );
     }
 
@@ -75,22 +103,28 @@ export async function POST(request: Request) {
       syncMetadata,
     });
 
-    return NextResponse.json({
-      success: true,
-      connection: {
-        id: connection.id,
-        source: connection.source,
-        platform: connection.platform,
-        clientDeviceId: connection.clientDeviceId,
-        deviceLabel: connection.deviceLabel,
-        status: connection.status,
+    return NextResponse.json(
+      {
+        success: true,
+        connection: {
+          id: connection.id,
+          source: connection.source,
+          platform: connection.platform,
+          clientDeviceId: connection.clientDeviceId,
+          deviceLabel: connection.deviceLabel,
+          status: connection.status,
+        },
+        sync: result,
       },
-      sync: result,
-    });
+      { headers: getMobileNoStoreHeaders(getMobileRateLimitHeaders(rateLimit)) }
+    );
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Unable to ingest device readings.";
 
-    return NextResponse.json({ error: message }, { status: 500 });
+    return NextResponse.json(
+      { error: message },
+      { status: 500, headers: getMobileNoStoreHeaders(getMobileRateLimitHeaders(rateLimit)) }
+    );
   }
 }

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -81,3 +81,8 @@ Recommended future coverage:
 ## Patch 48 note: Data Quality Center
 
 The Data Quality Center computes quality and readiness at request time from existing VitaVault records. It does not yet persist historical data-quality snapshots, so trend-over-time cleanup analytics remain a future enhancement.
+
+## Mobile API security scale
+
+Patch 49 adds endpoint-specific in-memory rate limits, no-store headers, oversized payload checks, and audit events for mobile session creation/revocation. This is suitable for local demo and portfolio review. For production-scale multi-instance hosting, move rate-limit buckets to Redis, database-backed counters, or an edge rate-limit provider so limits are shared across deployments.
+

--- a/docs/MOBILE_DEVICE_API.md
+++ b/docs/MOBILE_DEVICE_API.md
@@ -258,12 +258,18 @@ Lifecycle actions are user-owned and audited. Revoking a connection does not del
 
 ## Security notes
 
+Patch 49 hardens the mobile API surface without changing the Prisma schema or mobile contract.
+
 - Use HTTPS only in production.
 - Store the mobile token in secure device storage, not plaintext storage.
 - Treat mobile API tokens separately from browser sessions.
 - Revoke mobile tokens from the Security page when a device is lost.
 - Keep reading payloads minimal and avoid sending unnecessary PHI.
-- Add rate limiting before exposing these endpoints publicly at scale.
+- Credential login is rate limited by email and client IP.
+- Bearer-token endpoints are rate limited by endpoint and client IP.
+- Device reading sync rejects oversized payloads before JSON parsing when `Content-Length` is available.
+- Mobile API responses use `Cache-Control: no-store` and `X-Content-Type-Options: nosniff`.
+- Mobile session creation and revocation are written to the access audit timeline.
 
 ## Implementation notes
 

--- a/docs/PATCH_49_MOBILE_API_SECURITY_HARDENING.md
+++ b/docs/PATCH_49_MOBILE_API_SECURITY_HARDENING.md
@@ -1,0 +1,40 @@
+# Patch 49: Mobile API Security Hardening
+
+Patch 49 strengthens VitaVault's mobile/device API foundation without changing the Prisma schema, migrations, packages, or the public reading contract.
+
+## What changed
+
+- Added `lib/mobile-api-security.ts` for reusable mobile endpoint hardening helpers.
+- Added endpoint-specific rate limits for:
+  - mobile login
+  - mobile session check
+  - mobile logout
+  - device connection listing
+  - device reading sync
+- Added `Cache-Control: no-store` and `X-Content-Type-Options: nosniff` headers to mobile API responses.
+- Added Content-Length based payload-size protection for mobile login and device reading sync.
+- Added access audit events for mobile session creation and revocation.
+- Updated mobile logout so invalid/expired tokens return an unauthorized response instead of silently succeeding.
+- Updated API docs and Device Integration QA checklist to reflect the now-implemented security controls.
+- Added `tests/mobile-api-security.test.ts` for the new security helper layer.
+
+## Safety notes
+
+- No Prisma schema changes.
+- No migration changes.
+- No package changes.
+- No Redis/BullMQ dependency added.
+- Rate limiting still uses the existing in-memory helper, so production-scale deployments should move this to Redis or managed edge storage later.
+- Reading validation remains schema-backed through `mobileDeviceSyncSchema`.
+
+## Checks to run
+
+```bash
+npm run db:validate:ci
+npm run actions:check
+npm run actions:imports
+npm run actions:shadow
+npm run typecheck
+npm run lint
+npm run test:run
+```

--- a/lib/device-integrations.ts
+++ b/lib/device-integrations.ts
@@ -6,6 +6,7 @@ import {
   SyncJobStatus,
 } from "@prisma/client";
 import { db } from "@/lib/db";
+import { getMobileSecurityChecklist } from "@/lib/mobile-api-security";
 import { SUPPORTED_DEVICE_READINGS } from "@/lib/mobile-device-api";
 
 export type DeviceConnectionHealthTone = "neutral" | "info" | "success" | "warning" | "danger";
@@ -110,6 +111,7 @@ export function buildDeviceQaChecklist() {
     "Confirm a DeviceConnection appears as ACTIVE.",
     "Confirm a SyncJob records requested, accepted, and mirrored counts.",
     "Confirm supported readings mirror into Vitals Monitor and Trends.",
+    ...getMobileSecurityChecklist().slice(0, 4),
   ];
 }
 

--- a/lib/mobile-api-security.ts
+++ b/lib/mobile-api-security.ts
@@ -1,0 +1,173 @@
+import crypto from "node:crypto";
+import { consumeRateLimit, getClientRateLimitKey, type RateLimitResult } from "@/lib/security/rate-limit";
+
+export type MobileEndpointKey =
+  | "auth:login"
+  | "auth:me"
+  | "auth:logout"
+  | "connections:list"
+  | "readings:sync";
+
+export type MobileEndpointSecurityPolicy = {
+  endpoint: MobileEndpointKey;
+  label: string;
+  limit: number;
+  windowMs: number;
+  maxContentLengthBytes?: number;
+};
+
+export const MOBILE_API_SECURITY_POLICIES: Record<MobileEndpointKey, MobileEndpointSecurityPolicy> = {
+  "auth:login": {
+    endpoint: "auth:login",
+    label: "Mobile login",
+    limit: 10,
+    windowMs: 15 * 60 * 1000,
+    maxContentLengthBytes: 16 * 1024,
+  },
+  "auth:me": {
+    endpoint: "auth:me",
+    label: "Mobile session check",
+    limit: 120,
+    windowMs: 15 * 60 * 1000,
+  },
+  "auth:logout": {
+    endpoint: "auth:logout",
+    label: "Mobile logout",
+    limit: 30,
+    windowMs: 15 * 60 * 1000,
+  },
+  "connections:list": {
+    endpoint: "connections:list",
+    label: "Device connection list",
+    limit: 120,
+    windowMs: 15 * 60 * 1000,
+  },
+  "readings:sync": {
+    endpoint: "readings:sync",
+    label: "Device reading sync",
+    limit: 60,
+    windowMs: 15 * 60 * 1000,
+    maxContentLengthBytes: 256 * 1024,
+  },
+};
+
+export function getMobileSecurityPolicy(endpoint: MobileEndpointKey) {
+  return MOBILE_API_SECURITY_POLICIES[endpoint];
+}
+
+export function getMobileRateLimitScope(endpoint: MobileEndpointKey, discriminator?: string | null) {
+  const cleanDiscriminator = discriminator?.trim().toLowerCase() || "anonymous";
+  return `mobile-api:${endpoint}:${cleanDiscriminator}`;
+}
+
+export function consumeMobileApiRateLimit(params: {
+  request: Request;
+  endpoint: MobileEndpointKey;
+  discriminator?: string | null;
+  now?: Date;
+}) {
+  const policy = getMobileSecurityPolicy(params.endpoint);
+  const key = getClientRateLimitKey(
+    params.request,
+    getMobileRateLimitScope(params.endpoint, params.discriminator)
+  );
+
+  return consumeRateLimit({
+    key,
+    limit: policy.limit,
+    windowMs: policy.windowMs,
+    now: params.now,
+  });
+}
+
+export function getMobileRateLimitHeaders(result: RateLimitResult) {
+  return {
+    "X-RateLimit-Limit": String(result.limit),
+    "X-RateLimit-Remaining": String(result.remaining),
+    "X-RateLimit-Reset": result.resetAt.toISOString(),
+  };
+}
+
+export function getMobileRateLimitErrorBody(result: RateLimitResult, label = "mobile API") {
+  return {
+    error: `Too many ${label} requests. Try again later.`,
+    retryAfterSeconds: result.retryAfterSeconds,
+  };
+}
+
+export function getRetryAfterHeaders(result: RateLimitResult) {
+  return {
+    ...getMobileRateLimitHeaders(result),
+    "Retry-After": String(result.retryAfterSeconds),
+  };
+}
+
+export function getMobileNoStoreHeaders(extra?: Record<string, string>) {
+  return {
+    "Cache-Control": "no-store",
+    "X-Content-Type-Options": "nosniff",
+    ...extra,
+  };
+}
+
+export function getMobileRequestContentLength(request: Request) {
+  const raw = request.headers.get("content-length");
+  if (!raw) {
+    return null;
+  }
+
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+export function isMobileRequestTooLarge(request: Request, endpoint: MobileEndpointKey) {
+  const policy = getMobileSecurityPolicy(endpoint);
+  const contentLength = getMobileRequestContentLength(request);
+
+  if (!policy.maxContentLengthBytes || contentLength == null) {
+    return false;
+  }
+
+  return contentLength > policy.maxContentLengthBytes;
+}
+
+export function getMobilePayloadTooLargeBody(endpoint: MobileEndpointKey) {
+  const policy = getMobileSecurityPolicy(endpoint);
+  return {
+    error: "Mobile API payload is too large.",
+    maxContentLengthBytes: policy.maxContentLengthBytes ?? null,
+  };
+}
+
+export function fingerprintBearerToken(token: string | null | undefined) {
+  if (!token?.trim()) {
+    return null;
+  }
+
+  return crypto.createHash("sha256").update(token.trim()).digest("hex").slice(0, 16);
+}
+
+export function getMobileAuditMetadata(request: Request, extra?: Record<string, unknown>) {
+  const userAgent = request.headers.get("user-agent") ?? null;
+  const forwardedFor = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? null;
+  const realIp = request.headers.get("x-real-ip")?.trim() ?? null;
+  const cfIp = request.headers.get("cf-connecting-ip")?.trim() ?? null;
+
+  return {
+    channel: "mobile_api",
+    userAgent,
+    ipHint: forwardedFor || realIp || cfIp || null,
+    ...extra,
+  };
+}
+
+export function getMobileSecurityChecklist() {
+  return [
+    "Credential login is rate limited by email and client IP.",
+    "Bearer-token endpoints are rate limited by endpoint and client IP.",
+    "Large sync payloads are rejected before JSON parsing when Content-Length is available.",
+    "Mobile responses include no-store and nosniff headers.",
+    "Mobile session creation and revocation are written to the audit timeline.",
+    "Device reading payloads still validate against the schema-backed reading contract.",
+  ];
+}

--- a/tests/mobile-api-security.test.ts
+++ b/tests/mobile-api-security.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  consumeMobileApiRateLimit,
+  fingerprintBearerToken,
+  getMobileNoStoreHeaders,
+  getMobileRateLimitScope,
+  getMobileRequestContentLength,
+  getMobileSecurityChecklist,
+  getMobileSecurityPolicy,
+  isMobileRequestTooLarge,
+} from "@/lib/mobile-api-security";
+import { resetRateLimitBucketsForTests } from "@/lib/security/rate-limit";
+
+function makeRequest(headers?: Record<string, string>) {
+  return new Request("https://vitavault.test/api/mobile/device-readings", {
+    method: "POST",
+    headers,
+  });
+}
+
+describe("mobile API security helpers", () => {
+  it("defines endpoint-specific policies for mobile auth and reading sync", () => {
+    expect(getMobileSecurityPolicy("auth:login").limit).toBe(10);
+    expect(getMobileSecurityPolicy("readings:sync").limit).toBe(60);
+    expect(getMobileSecurityPolicy("readings:sync").maxContentLengthBytes).toBe(256 * 1024);
+  });
+
+  it("builds stable rate limit scopes with endpoint and discriminator", () => {
+    expect(getMobileRateLimitScope("auth:login", "Patient@Example.com")).toBe(
+      "mobile-api:auth:login:patient@example.com"
+    );
+    expect(getMobileRateLimitScope("auth:me")).toBe("mobile-api:auth:me:anonymous");
+  });
+
+  it("blocks mobile requests after the endpoint limit", () => {
+    resetRateLimitBucketsForTests();
+    const now = new Date("2026-05-07T00:00:00.000Z");
+    const request = makeRequest({ "x-forwarded-for": "203.0.113.10" });
+
+    const first = consumeMobileApiRateLimit({ request, endpoint: "auth:logout", now });
+    for (let index = 0; index < 29; index += 1) {
+      consumeMobileApiRateLimit({ request, endpoint: "auth:logout", now });
+    }
+    const blocked = consumeMobileApiRateLimit({ request, endpoint: "auth:logout", now });
+
+    expect(first.allowed).toBe(true);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.retryAfterSeconds).toBe(900);
+  });
+
+  it("detects oversized reading sync payloads from Content-Length", () => {
+    const request = makeRequest({ "content-length": String(300 * 1024) });
+
+    expect(getMobileRequestContentLength(request)).toBe(300 * 1024);
+    expect(isMobileRequestTooLarge(request, "readings:sync")).toBe(true);
+    expect(isMobileRequestTooLarge(request, "auth:me")).toBe(false);
+  });
+
+  it("returns no-store response headers and safe token fingerprints", () => {
+    expect(getMobileNoStoreHeaders()).toMatchObject({
+      "Cache-Control": "no-store",
+      "X-Content-Type-Options": "nosniff",
+    });
+    expect(fingerprintBearerToken("vvm_secret_token")).toHaveLength(16);
+    expect(fingerprintBearerToken("vvm_secret_token")).toBe(fingerprintBearerToken("vvm_secret_token"));
+  });
+
+  it("documents the mobile endpoint security checklist", () => {
+    expect(getMobileSecurityChecklist()).toEqual(
+      expect.arrayContaining([
+        "Credential login is rate limited by email and client IP.",
+        "Device reading payloads still validate against the schema-backed reading contract.",
+      ])
+    );
+  });
+});


### PR DESCRIPTION
## Summary

This patch hardens VitaVault’s mobile/device API surface with endpoint-specific rate limiting, no-store response headers, payload-size protection, and mobile session audit events.

## Changes

- Added `lib/mobile-api-security.ts` for reusable mobile API hardening helpers.
- Added endpoint-specific rate limits for mobile login, session checks, logout, device connection listing, and reading sync.
- Added `Cache-Control: no-store` and `X-Content-Type-Options: nosniff` to mobile API responses.
- Added rate-limit response headers and `Retry-After` for blocked requests.
- Added Content-Length payload-size checks for mobile login and device reading sync.
- Added audit events for mobile session creation and revocation.
- Hardened mobile logout so invalid/expired tokens return unauthorized instead of silently succeeding.
- Updated API docs, mobile API docs, device QA checklist, and known limitations.
- Added mobile API security helper tests.

## Safety

- No Prisma schema changes.
- No migration changes.
- No package changes.
- No mobile reading contract changes.
- Uses the existing in-memory rate-limit helper.

## Checks to run

```bash
npm install
npm run db:validate:ci
npm run actions:check
npm run actions:imports
npm run actions:shadow
npm run typecheck
npm run lint
npm run test:run