### PR TITLE
Patch 50: OpenAPI/Postman Export

### DIFF
--- a/app/api-docs/page.tsx
+++ b/app/api-docs/page.tsx
@@ -27,8 +27,10 @@ import {
   TR,
 } from "@/components/ui";
 import { getMobileSecurityChecklist } from "@/lib/mobile-api-security";
+import { getMobileApiContractSummary } from "@/lib/mobile-api-contract-export";
 
 const baseUrl = "https://your-vitavault-domain.com";
+const contractSummary = getMobileApiContractSummary();
 
 const endpointGroups = [
   {
@@ -274,6 +276,65 @@ export default function ApiDocsPage() {
           </div>
         </header>
 
+        <section className="grid gap-6 lg:grid-cols-[1fr_1fr]">
+          <Card className="border-primary/20 bg-primary/5">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Workflow className="h-5 w-5 text-primary" />
+                Download OpenAPI contract
+              </CardTitle>
+              <CardDescription>
+                Machine-readable OpenAPI 3.1 JSON for Swagger UI, Insomnia, API gateways, and reviewer inspection.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid gap-3 sm:grid-cols-3">
+                <div className="rounded-3xl border border-border/60 bg-background/70 p-4">
+                  <p className="text-2xl font-semibold">{contractSummary.endpointCount}</p>
+                  <p className="text-xs text-muted-foreground">endpoints</p>
+                </div>
+                <div className="rounded-3xl border border-border/60 bg-background/70 p-4">
+                  <p className="text-2xl font-semibold">{contractSummary.readingTypeCount}</p>
+                  <p className="text-xs text-muted-foreground">reading types</p>
+                </div>
+                <div className="rounded-3xl border border-border/60 bg-background/70 p-4">
+                  <p className="text-2xl font-semibold">3.1</p>
+                  <p className="text-xs text-muted-foreground">OpenAPI</p>
+                </div>
+              </div>
+              <Link
+                href="/api/mobile/openapi"
+                className="inline-flex h-11 items-center justify-center rounded-2xl bg-primary px-5 text-sm font-semibold text-primary-foreground shadow-sm transition hover:opacity-95"
+              >
+                Download vitavault-mobile-openapi.json
+              </Link>
+            </CardContent>
+          </Card>
+
+          <Card className="border-primary/20 bg-primary/5">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <DatabaseZap className="h-5 w-5 text-primary" />
+                Download Postman collection
+              </CardTitle>
+              <CardDescription>
+                Import-ready Postman Collection 2.1 JSON with base URL and mobile token variables.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="rounded-3xl border border-border/60 bg-background/70 p-4 text-sm leading-6 text-muted-foreground">
+                Includes grouped requests for mobile login, session validation, logout, device connections, and device reading sync with schema-backed sample payloads.
+              </div>
+              <Link
+                href="/api/mobile/postman"
+                className="inline-flex h-11 items-center justify-center rounded-2xl bg-primary px-5 text-sm font-semibold text-primary-foreground shadow-sm transition hover:opacity-95"
+              >
+                Download vitavault-mobile-postman-collection.json
+              </Link>
+            </CardContent>
+          </Card>
+        </section>
+
         <section className="grid gap-6 lg:grid-cols-3">
           {endpointGroups.map((group) => {
             const Icon = group.icon;
@@ -342,7 +403,7 @@ export default function ApiDocsPage() {
             <CardHeader>
               <CardTitle>Endpoint matrix</CardTitle>
               <CardDescription>
-                Quick implementation map for mobile, QA, and future Postman collection work.
+                Quick implementation map for mobile, QA, and downloadable OpenAPI/Postman contract work.
               </CardDescription>
             </CardHeader>
             <CardContent>
@@ -546,7 +607,7 @@ export default function ApiDocsPage() {
 
         <footer className="rounded-[2rem] border border-border/60 bg-card/80 p-6 text-sm leading-7 text-muted-foreground">
           <p>
-            This page documents the current VitaVault API foundation. It is meant for product review, mobile planning, QA, and future Postman/OpenAPI expansion. The API surface is intentionally small today, but it already supports credential login, revocable mobile sessions, connected-device visibility, and structured reading ingestion.
+            This page documents the current VitaVault API foundation. It is meant for product review, mobile planning, QA, and downloadable OpenAPI/Postman contract review. The API surface is intentionally small today, but it already supports credential login, revocable mobile sessions, connected-device visibility, and structured reading ingestion.
           </p>
         </footer>
       </div>

--- a/app/api/mobile/openapi/route.ts
+++ b/app/api/mobile/openapi/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { buildMobileOpenApiSpec, getMobileApiExportFileName } from "@/lib/mobile-api-contract-export";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const requestUrl = new URL(request.url);
+  const baseUrl = requestUrl.searchParams.get("baseUrl")?.trim() || requestUrl.origin;
+
+  return NextResponse.json(buildMobileOpenApiSpec(baseUrl), {
+    headers: {
+      "Cache-Control": "no-store",
+      "Content-Disposition": `attachment; filename="${getMobileApiExportFileName("openapi")}"`,
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/app/api/mobile/postman/route.ts
+++ b/app/api/mobile/postman/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { buildMobilePostmanCollection, getMobileApiExportFileName } from "@/lib/mobile-api-contract-export";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const requestUrl = new URL(request.url);
+  const baseUrl = requestUrl.searchParams.get("baseUrl")?.trim() || requestUrl.origin;
+
+  return NextResponse.json(buildMobilePostmanCollection(baseUrl), {
+    headers: {
+      "Cache-Control": "no-store",
+      "Content-Disposition": `attachment; filename="${getMobileApiExportFileName("postman")}"`,
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -86,3 +86,6 @@ The Data Quality Center computes quality and readiness at request time from exis
 
 Patch 49 adds endpoint-specific in-memory rate limits, no-store headers, oversized payload checks, and audit events for mobile session creation/revocation. This is suitable for local demo and portfolio review. For production-scale multi-instance hosting, move rate-limit buckets to Redis, database-backed counters, or an edge rate-limit provider so limits are shared across deployments.
 
+## API contract exports
+
+Patch 50 adds generated OpenAPI and Postman JSON exports for the mobile/device API. These are intentionally scoped to the existing mobile endpoints only. The exports do not yet cover the full web app/server-action surface because most authenticated web workflows are rendered through App Router pages and server actions rather than public REST endpoints.

--- a/docs/MOBILE_DEVICE_API.md
+++ b/docs/MOBILE_DEVICE_API.md
@@ -1,6 +1,6 @@
 # VitaVault Mobile and Device API
 
-This document summarizes the current VitaVault mobile/device API foundation for Android, mobile sync, QA, and future Postman/OpenAPI work. It intentionally lists only reading types currently backed by the Prisma `DeviceReadingType` enum.
+This document summarizes the current VitaVault mobile/device API foundation for Android, mobile sync, QA, OpenAPI import, and Postman testing. It intentionally lists only reading types currently backed by the Prisma `DeviceReadingType` enum.
 
 The same information is also available as a product-facing page at:
 
@@ -255,6 +255,25 @@ Patch 46 adds authenticated device integration surfaces on top of the mobile API
 | `/device-sync-simulator` | Safe demo sync runner that creates connections, readings, sync jobs, job runs, and mirrored vitals |
 
 Lifecycle actions are user-owned and audited. Revoking a connection does not delete historical readings; it marks the connection as no longer active while keeping traceability intact.
+
+
+## Machine-readable exports
+
+Patch 50 adds generated API contract downloads for reviewers, QA, and future mobile client work.
+
+| Export | Route | Use |
+|---|---|---|
+| OpenAPI 3.1 JSON | `/api/mobile/openapi` | Import into Swagger UI, Insomnia, API gateways, or client generators. |
+| Postman Collection 2.1 JSON | `/api/mobile/postman` | Import into Postman and set `baseUrl` plus `mobileToken` variables. |
+
+Both exports are generated from VitaVault's existing mobile API contract helpers and include the five supported mobile endpoints, bearer-token security, schema-backed reading types, request examples, response schemas, and rate-limit/security context.
+
+Optional base URL override:
+
+```txt
+/api/mobile/openapi?baseUrl=https://vita-vault-demo.example.com
+/api/mobile/postman?baseUrl=https://vita-vault-demo.example.com
+```
 
 ## Security notes
 

--- a/docs/PATCH_50_OPENAPI_POSTMAN_EXPORT.md
+++ b/docs/PATCH_50_OPENAPI_POSTMAN_EXPORT.md
@@ -1,0 +1,29 @@
+# Patch 50: OpenAPI/Postman Export
+
+Patch 50 adds machine-readable exports for VitaVault's mobile and connected-device API surface.
+
+## Added
+
+- `lib/mobile-api-contract-export.ts`
+  - OpenAPI 3.1 contract builder
+  - Postman Collection 2.1 builder
+  - shared export metadata helpers
+- `/api/mobile/openapi`
+  - downloads `vitavault-mobile-openapi.json`
+- `/api/mobile/postman`
+  - downloads `vitavault-mobile-postman-collection.json`
+- API docs export cards
+- Mobile API documentation for importing generated contracts
+- Tests for OpenAPI/Postman contract generation
+
+## Safety
+
+- No Prisma schema changes.
+- No migrations.
+- No package changes.
+- No mobile endpoint behavior changes.
+- Exports are generated from existing mobile API contract/security metadata.
+
+## Reviewer value
+
+A reviewer can now import the mobile/device API into Postman, Swagger UI, Insomnia, or an API gateway without reverse-engineering route handlers.

--- a/lib/mobile-api-contract-export.ts
+++ b/lib/mobile-api-contract-export.ts
@@ -1,0 +1,317 @@
+import { DevicePlatform, DeviceReadingType, ReadingSource } from "@prisma/client";
+import { MOBILE_DEVICE_ENDPOINTS, SUPPORTED_DEVICE_READINGS, SUPPORTED_DEVICE_READING_TYPES } from "@/lib/mobile-device-api";
+import { MOBILE_API_SECURITY_POLICIES } from "@/lib/mobile-api-security";
+
+export const MOBILE_API_CONTRACT_VERSION = "2026.05.patch50";
+export const MOBILE_API_DEFAULT_BASE_URL = "https://your-vitavault-domain.com";
+export type MobileApiExportFormat = "openapi" | "postman";
+
+const readingTypeValues = Object.values(DeviceReadingType);
+const readingSourceValues = Object.values(ReadingSource);
+const devicePlatformValues = Object.values(DevicePlatform);
+
+function contentForSchema(schema: unknown) {
+  return { "application/json": { schema } };
+}
+function contentForExample(example: unknown) {
+  return { "application/json": { example } };
+}
+function endpointPurpose(path: string) {
+  return MOBILE_DEVICE_ENDPOINTS.find((endpoint) => endpoint.path === path)?.purpose ?? path;
+}
+
+export function getMobileApiContractSummary() {
+  return {
+    version: MOBILE_API_CONTRACT_VERSION,
+    endpointCount: MOBILE_DEVICE_ENDPOINTS.length,
+    readingTypeCount: SUPPORTED_DEVICE_READING_TYPES.length,
+    exportFormats: ["OpenAPI 3.1", "Postman Collection 2.1"],
+    endpoints: MOBILE_DEVICE_ENDPOINTS,
+    supportedReadings: SUPPORTED_DEVICE_READINGS,
+    securityPolicies: Object.values(MOBILE_API_SECURITY_POLICIES).map((policy) => ({
+      endpoint: policy.endpoint,
+      label: policy.label,
+      limit: policy.limit,
+      windowMs: policy.windowMs,
+      maxContentLengthBytes: policy.maxContentLengthBytes ?? null,
+    })),
+  };
+}
+
+const errorResponseSchema = {
+  type: "object",
+  properties: {
+    error: { type: "string" },
+    details: { type: "object", additionalProperties: true },
+    retryAfterSeconds: { type: "number" },
+  },
+  required: ["error"],
+  additionalProperties: true,
+} as const;
+
+const userSchema = {
+  type: "object",
+  properties: {
+    id: { type: "string" },
+    email: { type: "string", format: "email" },
+    name: { type: ["string", "null"] },
+  },
+  required: ["id", "email", "name"],
+  additionalProperties: false,
+} as const;
+
+const connectionSchema = {
+  type: "object",
+  properties: {
+    id: { type: "string" },
+    source: { type: "string", enum: readingSourceValues },
+    platform: { type: "string", enum: devicePlatformValues },
+    clientDeviceId: { type: "string" },
+    deviceLabel: { type: ["string", "null"] },
+    appVersion: { type: ["string", "null"] },
+    status: { type: "string", enum: ["ACTIVE", "ERROR", "REVOKED", "DISCONNECTED"] },
+    lastSyncedAt: { type: ["string", "null"], format: "date-time" },
+    lastError: { type: ["string", "null"] },
+    createdAt: { type: "string", format: "date-time" },
+    updatedAt: { type: "string", format: "date-time" },
+  },
+  required: ["id", "source", "platform", "clientDeviceId", "status", "createdAt", "updatedAt"],
+  additionalProperties: true,
+} as const;
+
+const readingSchema = {
+  type: "object",
+  properties: {
+    readingType: { type: "string", enum: readingTypeValues },
+    capturedAt: { type: "string", format: "date-time" },
+    clientReadingId: { type: "string" },
+    unit: { type: "string" },
+    valueInt: { type: "integer" },
+    valueFloat: { type: "number" },
+    systolic: { type: "integer" },
+    diastolic: { type: "integer" },
+    metadata: { type: "object", additionalProperties: true },
+    rawPayload: { type: "object", additionalProperties: true },
+  },
+  required: ["readingType", "capturedAt"],
+  additionalProperties: false,
+} as const;
+
+const syncRequestSchema = {
+  type: "object",
+  properties: {
+    source: { type: "string", enum: readingSourceValues },
+    platform: { type: "string", enum: devicePlatformValues },
+    clientDeviceId: { type: "string", maxLength: 191 },
+    deviceLabel: { type: "string", maxLength: 191 },
+    appVersion: { type: "string", maxLength: 60 },
+    scopes: { type: "array", items: { type: "string" }, maxItems: 50 },
+    syncMetadata: { type: "object", additionalProperties: true },
+    readings: { type: "array", minItems: 1, maxItems: 500, items: { $ref: "#/components/schemas/DeviceReading" } },
+  },
+  required: ["source", "platform", "clientDeviceId", "readings"],
+  additionalProperties: false,
+} as const;
+
+export function buildMobileOpenApiSpec(baseUrl = MOBILE_API_DEFAULT_BASE_URL) {
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: "VitaVault Mobile and Device API",
+      version: MOBILE_API_CONTRACT_VERSION,
+      description: "OpenAPI contract for VitaVault mobile auth, device connections, and device reading ingestion.",
+    },
+    servers: [{ url: baseUrl, description: "VitaVault deployment URL" }],
+    tags: [
+      { name: "Mobile Authentication", description: "Mobile bearer-token lifecycle." },
+      { name: "Device Connections", description: "Connected device records." },
+      { name: "Device Readings", description: "Device reading ingestion and vitals mirroring." },
+    ],
+    paths: {
+      "/api/mobile/auth/login": {
+        post: {
+          tags: ["Mobile Authentication"],
+          summary: endpointPurpose("/api/mobile/auth/login"),
+          security: [],
+          requestBody: { required: true, content: contentForSchema({ $ref: "#/components/schemas/MobileLoginRequest" }) },
+          responses: {
+            "200": { description: "Mobile token issued.", content: contentForSchema({ $ref: "#/components/schemas/MobileLoginResponse" }) },
+            "400": { description: "Invalid payload.", content: contentForSchema({ $ref: "#/components/schemas/ErrorResponse" }) },
+            "401": { description: "Invalid credentials.", content: contentForSchema({ $ref: "#/components/schemas/ErrorResponse" }) },
+            "413": { description: "Payload too large.", content: contentForSchema({ $ref: "#/components/schemas/ErrorResponse" }) },
+            "429": { description: "Rate limited.", content: contentForSchema({ $ref: "#/components/schemas/ErrorResponse" }) },
+          },
+        },
+      },
+      "/api/mobile/auth/me": {
+        get: {
+          tags: ["Mobile Authentication"],
+          summary: endpointPurpose("/api/mobile/auth/me"),
+          security: [{ bearerAuth: [] }],
+          responses: {
+            "200": { description: "Current mobile session user.", content: contentForSchema({ $ref: "#/components/schemas/MobileMeResponse" }) },
+            "401": { description: "Unauthorized mobile session.", content: contentForSchema({ $ref: "#/components/schemas/ErrorResponse" }) },
+            "429": { description: "Rate limited.", content: contentForSchema({ $ref: "#/components/schemas/ErrorResponse" }) },
+          },
+        },
+      },
+      "/api/mobile/auth/logout": {
+        post: {
+          tags: ["Mobile Authentication"],
+          summary: endpointPurpose("/api/mobile/auth/logout"),
+          security: [{ bearerAuth: [] }],
+          responses: {
+            "200": { description: "Mobile token revoked.", content: contentForExample({ success: true }) },
+            "401": { description: "Unauthorized mobile session.", content: contentForSchema({ $ref: "#/components/schemas/ErrorResponse" }) },
+            "429": { description: "Rate limited.", content: contentForSchema({ $ref: "#/components/schemas/ErrorResponse" }) },
+          },
+        },
+      },
+      "/api/mobile/connections": {
+        get: {
+          tags: ["Device Connections"],
+          summary: endpointPurpose("/api/mobile/connections"),
+          security: [{ bearerAuth: [] }],
+          responses: {
+            "200": { description: "Device connections.", content: contentForSchema({ $ref: "#/components/schemas/DeviceConnectionsResponse" }) },
+            "401": { description: "Unauthorized mobile session.", content: contentForSchema({ $ref: "#/components/schemas/ErrorResponse" }) },
+            "429": { description: "Rate limited.", content: contentForSchema({ $ref: "#/components/schemas/ErrorResponse" }) },
+          },
+        },
+      },
+      "/api/mobile/device-readings": {
+        post: {
+          tags: ["Device Readings"],
+          summary: endpointPurpose("/api/mobile/device-readings"),
+          security: [{ bearerAuth: [] }],
+          requestBody: { required: true, content: contentForSchema({ $ref: "#/components/schemas/DeviceReadingSyncRequest" }) },
+          responses: {
+            "200": { description: "Readings accepted and mirrored where supported.", content: contentForSchema({ $ref: "#/components/schemas/DeviceReadingSyncResponse" }) },
+            "400": { description: "Invalid reading payload.", content: contentForSchema({ $ref: "#/components/schemas/ErrorResponse" }) },
+            "401": { description: "Unauthorized mobile session.", content: contentForSchema({ $ref: "#/components/schemas/ErrorResponse" }) },
+            "413": { description: "Payload too large.", content: contentForSchema({ $ref: "#/components/schemas/ErrorResponse" }) },
+            "429": { description: "Rate limited.", content: contentForSchema({ $ref: "#/components/schemas/ErrorResponse" }) },
+          },
+        },
+      },
+    },
+    components: {
+      securitySchemes: { bearerAuth: { type: "http", scheme: "bearer", bearerFormat: "VitaVault mobile token" } },
+      schemas: {
+        ErrorResponse: errorResponseSchema,
+        MobileUser: userSchema,
+        MobileLoginRequest: {
+          type: "object",
+          properties: { email: { type: "string", format: "email" }, password: { type: "string" }, deviceName: { type: "string", maxLength: 120 } },
+          required: ["email", "password"],
+          additionalProperties: false,
+        },
+        MobileLoginResponse: {
+          type: "object",
+          properties: { token: { type: "string" }, expiresAt: { type: "string", format: "date-time" }, user: { $ref: "#/components/schemas/MobileUser" } },
+          required: ["token", "expiresAt", "user"],
+          additionalProperties: false,
+        },
+        MobileMeResponse: { type: "object", properties: { user: { $ref: "#/components/schemas/MobileUser" } }, required: ["user"], additionalProperties: false },
+        DeviceConnection: connectionSchema,
+        DeviceConnectionsResponse: { type: "object", properties: { connections: { type: "array", items: { $ref: "#/components/schemas/DeviceConnection" } } }, required: ["connections"], additionalProperties: false },
+        DeviceReading: readingSchema,
+        DeviceReadingSyncRequest: syncRequestSchema,
+        DeviceReadingSyncResponse: {
+          type: "object",
+          properties: {
+            success: { type: "boolean" },
+            connection: { $ref: "#/components/schemas/DeviceConnection" },
+            sync: {
+              type: "object",
+              properties: {
+                syncJobId: { type: "string" },
+                requestedCount: { type: "integer" },
+                acceptedCount: { type: "integer" },
+                mirroredCount: { type: "integer" },
+                duplicateCount: { type: "integer" },
+              },
+              required: ["syncJobId", "requestedCount", "acceptedCount", "mirroredCount", "duplicateCount"],
+              additionalProperties: false,
+            },
+          },
+          required: ["success", "connection", "sync"],
+          additionalProperties: false,
+        },
+      },
+    },
+    "x-vitavault": getMobileApiContractSummary(),
+  };
+}
+
+function postmanUrl(path: string) {
+  return { raw: `{{baseUrl}}${path}`, host: ["{{baseUrl}}"], path: path.split("/").filter(Boolean) };
+}
+function postmanAuthHeader() {
+  return { key: "Authorization", value: "Bearer {{mobileToken}}", type: "text" };
+}
+function postmanJsonBody(raw: unknown) {
+  return { mode: "raw", raw: JSON.stringify(raw, null, 2), options: { raw: { language: "json" } } };
+}
+
+export function buildMobilePostmanCollection(baseUrl = MOBILE_API_DEFAULT_BASE_URL) {
+  return {
+    info: {
+      name: "VitaVault Mobile and Device API",
+      description: "Postman collection for VitaVault mobile auth, session checks, device connections, and reading sync.",
+      schema: "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+      version: MOBILE_API_CONTRACT_VERSION,
+    },
+    variable: [
+      { key: "baseUrl", value: baseUrl, type: "string" },
+      { key: "mobileToken", value: "paste-token-from-login-response", type: "string" },
+    ],
+    item: [
+      {
+        name: "Mobile Authentication",
+        item: [
+          { name: "Login and issue mobile token", request: { method: "POST", header: [{ key: "Content-Type", value: "application/json", type: "text" }], url: postmanUrl("/api/mobile/auth/login"), body: postmanJsonBody({ email: "patient@example.com", password: "correct-horse-battery-staple", deviceName: "Rey's Android Phone" }) } },
+          { name: "Get current mobile user", request: { method: "GET", header: [postmanAuthHeader()], url: postmanUrl("/api/mobile/auth/me") } },
+          { name: "Logout and revoke token", request: { method: "POST", header: [postmanAuthHeader()], url: postmanUrl("/api/mobile/auth/logout") } },
+        ],
+      },
+      { name: "Device Connections", item: [{ name: "List device connections", request: { method: "GET", header: [postmanAuthHeader()], url: postmanUrl("/api/mobile/connections") } }] },
+      {
+        name: "Device Readings",
+        item: [
+          {
+            name: "Sync device readings",
+            request: {
+              method: "POST",
+              header: [postmanAuthHeader(), { key: "Content-Type", value: "application/json", type: "text" }],
+              url: postmanUrl("/api/mobile/device-readings"),
+              body: postmanJsonBody({
+                source: ReadingSource.ANDROID_HEALTH_CONNECT,
+                platform: DevicePlatform.ANDROID,
+                clientDeviceId: "android-pixel-8-pro",
+                deviceLabel: "Pixel 8 Pro",
+                appVersion: "1.0.0",
+                scopes: ["vitals:write", "device:sync"],
+                syncMetadata: { batteryLevel: 88, network: "wifi" },
+                readings: [
+                  { readingType: DeviceReadingType.HEART_RATE, capturedAt: "2026-04-29T08:35:00.000Z", clientReadingId: "hr-001", unit: "bpm", valueInt: 78 },
+                  { readingType: DeviceReadingType.BLOOD_PRESSURE, capturedAt: "2026-04-29T08:36:00.000Z", clientReadingId: "bp-001", unit: "mmHg", systolic: 118, diastolic: 76 },
+                ],
+              }),
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export function getMobileApiExportFileName(format: MobileApiExportFormat) {
+  return format === "openapi" ? "vitavault-mobile-openapi.json" : "vitavault-mobile-postman-collection.json";
+}
+
+export function getMobileApiExportDescription(format: MobileApiExportFormat) {
+  return format === "openapi"
+    ? "OpenAPI 3.1 contract for mobile/device API clients."
+    : "Postman Collection 2.1 workspace for mobile/device API testing.";
+}

--- a/tests/mobile-api-contract-export.test.ts
+++ b/tests/mobile-api-contract-export.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMobileOpenApiSpec,
+  buildMobilePostmanCollection,
+  getMobileApiContractSummary,
+  getMobileApiExportFileName,
+} from "@/lib/mobile-api-contract-export";
+
+const mobileEndpoints = [
+  "/api/mobile/auth/login",
+  "/api/mobile/auth/me",
+  "/api/mobile/auth/logout",
+  "/api/mobile/connections",
+  "/api/mobile/device-readings",
+];
+
+describe("mobile API contract export", () => {
+  it("builds an OpenAPI contract for every supported mobile endpoint", () => {
+    const spec = buildMobileOpenApiSpec("https://demo.vitavault.test");
+
+    expect(spec.openapi).toBe("3.1.0");
+    expect(spec.servers[0]?.url).toBe("https://demo.vitavault.test");
+
+    for (const endpoint of mobileEndpoints) {
+      expect(Object.keys(spec.paths)).toContain(endpoint);
+    }
+
+    expect(spec.components.securitySchemes.bearerAuth.scheme).toBe("bearer");
+    expect(spec.components.schemas.DeviceReadingSyncRequest.required).toContain("readings");
+    expect(spec.components.schemas.DeviceReadingSyncRequest.properties.readings.maxItems).toBe(500);
+  });
+
+  it("builds a Postman collection with grouped mobile requests", () => {
+    const collection = buildMobilePostmanCollection("https://demo.vitavault.test");
+
+    expect(collection.info.schema).toContain("collection/v2.1.0");
+    expect(collection.variable).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: "baseUrl", value: "https://demo.vitavault.test" }),
+        expect.objectContaining({ key: "mobileToken" }),
+      ])
+    );
+    expect(collection.item.map((group) => group.name)).toEqual([
+      "Mobile Authentication",
+      "Device Connections",
+      "Device Readings",
+    ]);
+  });
+
+  it("keeps the contract summary aligned with the current mobile surface", () => {
+    const summary = getMobileApiContractSummary();
+
+    expect(summary.endpointCount).toBe(5);
+    expect(summary.readingTypeCount).toBe(7);
+    expect(summary.exportFormats).toContain("OpenAPI 3.1");
+    expect(summary.securityPolicies.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("uses stable downloadable filenames", () => {
+    expect(getMobileApiExportFileName("openapi")).toBe("vitavault-mobile-openapi.json");
+    expect(getMobileApiExportFileName("postman")).toBe("vitavault-mobile-postman-collection.json");
+  });
+});


### PR DESCRIPTION
## Summary

This patch adds machine-readable OpenAPI and Postman exports for VitaVault’s mobile/device API surface.

## Changes

- Added `lib/mobile-api-contract-export.ts`.
- Added `/api/mobile/openapi` to generate and download `vitavault-mobile-openapi.json`.
- Added `/api/mobile/postman` to generate and download `vitavault-mobile-postman-collection.json`.
- Added OpenAPI 3.1 coverage for all current mobile API endpoints.
- Added Postman Collection 2.1 groups for:
  - Mobile Authentication
  - Device Connections
  - Device Readings
- Added `baseUrl` and `mobileToken` Postman variables.
- Updated `/api-docs` with OpenAPI/Postman download cards.
- Updated mobile API docs and known limitations.
- Added tests for contract generation and export metadata.

## Safety

- No Prisma schema changes.
- No migration changes.
- No package changes.
- No mobile endpoint behavior changes.
- Export routes only generate JSON from existing API metadata.

## Checks to run

```bash
npm install
npm run db:validate:ci
npm run actions:check
npm run actions:imports
npm run actions:shadow
npm run typecheck
npm run lint
npm run test:run