### PR TITLE
Patch 51: README Screenshot Restoration + Visual Portfolio Polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,21 +223,76 @@ This gives the project enough depth to support future upgrades without constantl
 
 ## Screenshots
 
-### Core experience
+The original screenshot set is stored in [`.mkdir/`](.mkdir/) and is intentionally kept in the repo so reviewers can preview the product quickly from GitHub.
+
+### Reviewer entry points
+
+| Landing Page | Login Page |
+|---|---|
+| <img src=".mkdir/Landing-Page.jpg" alt="VitaVault landing page" width="100%"> | <img src=".mkdir/Login-Page.jpg" alt="VitaVault login page" width="100%"> |
+
+### Core patient workspace
 
 | Dashboard | Health Profile |
 |---|---|
-| <img src=".mkdir/Dashboard.jpg" alt="Dashboard" width="100%"> | <img src=".mkdir/Health-Profile.jpg" alt="Health Profile" width="100%"> |
+| <img src=".mkdir/Dashboard.jpg" alt="VitaVault dashboard" width="100%"> | <img src=".mkdir/Health-Profile.jpg" alt="Health profile workspace" width="100%"> |
 
-| Medications | Documents |
+| Medications | Appointments |
 |---|---|
-| <img src=".mkdir/Medications.jpg" alt="Medications" width="100%"> | <img src=".mkdir/Documents.jpg" alt="Documents" width="100%"> |
+| <img src=".mkdir/Medications.jpg" alt="Medication management" width="100%"> | <img src=".mkdir/Appointments.jpg" alt="Appointment management" width="100%"> |
 
-| Lab Review | Vitals Monitor |
+| Doctors | Documents |
 |---|---|
-| <img src=".mkdir/Lab-Review.jpg" alt="Lab Review" width="100%"> | <img src=".mkdir/Vitals-Monitor.jpg" alt="Vitals Monitor" width="100%"> |
+| <img src=".mkdir/Doctors.jpg" alt="Doctor directory" width="100%"> | <img src=".mkdir/Documents.jpg" alt="Document intelligence hub" width="100%"> |
 
-> Screenshot filenames may be updated as the public demo is refreshed. The app routes and docs are the source of truth for current functionality.
+### Clinical review and record coverage
+
+| Lab Results | Vitals |
+|---|---|
+| <img src=".mkdir/Lab-Results.jpg" alt="Lab results review" width="100%"> | <img src=".mkdir/Vitals.jpg" alt="Vitals monitoring" width="100%"> |
+
+| Symptoms | Vaccinations |
+|---|---|
+| <img src=".mkdir/Symptoms.jpg" alt="Symptom tracking" width="100%"> | <img src=".mkdir/Vaccinations.jpg" alt="Vaccination records" width="100%"> |
+
+### Collaboration, intelligence, and handoff
+
+| Care Team | AI Insights |
+|---|---|
+| <img src=".mkdir/Care-Team.jpg" alt="Care team workspace" width="100%"> | <img src=".mkdir/AI-Insights.jpg" alt="AI insights workspace" width="100%"> |
+
+| Alert Center | Summary |
+|---|---|
+| <img src=".mkdir/Alert-Center.jpg" alt="Alert center" width="100%"> | <img src=".mkdir/Summary.jpg" alt="Patient summary" width="100%"> |
+
+| Device Connections | Exports Page |
+|---|---|
+| <img src=".mkdir/Device-Connections.jpg" alt="Device connection dashboard" width="100%"> | <img src=".mkdir/Exports-Page.jpg" alt="Export center" width="100%"> |
+
+### Screenshot inventory
+
+| File | Represents |
+|---|---|
+| `.mkdir/Landing-Page.jpg` | Public landing and product entry point |
+| `.mkdir/Login-Page.jpg` | Authentication entry point |
+| `.mkdir/Dashboard.jpg` | Main patient command center |
+| `.mkdir/Health-Profile.jpg` | Baseline profile and emergency context |
+| `.mkdir/Medications.jpg` | Medication records and safety workflow entry |
+| `.mkdir/Appointments.jpg` | Visit and appointment tracking |
+| `.mkdir/Doctors.jpg` | Provider directory |
+| `.mkdir/Documents.jpg` | Document records and document-readiness surface |
+| `.mkdir/Lab-Results.jpg` | Lab record coverage |
+| `.mkdir/Vitals.jpg` | Vital-sign record coverage |
+| `.mkdir/Symptoms.jpg` | Symptom tracking |
+| `.mkdir/Vaccinations.jpg` | Preventive-care records |
+| `.mkdir/Care-Team.jpg` | Care-team collaboration |
+| `.mkdir/AI-Insights.jpg` | AI insight workspace |
+| `.mkdir/Alert-Center.jpg` | Alert and review workflow |
+| `.mkdir/Summary.jpg` | Patient summary handoff |
+| `.mkdir/Device-Connections.jpg` | Connected-device readiness |
+| `.mkdir/Exports-Page.jpg` | Export and packet generation |
+
+> Patch 51 restores the screenshot gallery to use the actual files present in `.mkdir/`, including `Lab-Results.jpg` and `Vitals.jpg`. Avoid renaming screenshot files unless the README is updated in the same PR.
 
 ---
 

--- a/docs/FEATURE_MATRIX.md
+++ b/docs/FEATURE_MATRIX.md
@@ -109,12 +109,19 @@ This matrix summarizes the current VitaVault product surface after the latest po
 ## Recommended next improvements
 
 1. Persistent report-builder history stored in the database
-2. Optional care-note links to a specific lab, appointment, medication, symptom, document, or alert
-3. Production document storage provider hardening
-4. Background jobs v2 with admin retry and rerun tools
-5. Data quality center for missing/old/contradictory health records
-6. Expanded tests around route access, report printing, and shared patient permissions
+2. Device provider connector abstraction for Apple Health, Android Health Connect, Fitbit, and smart devices
+3. Mobile API SDK examples for JavaScript, React Native, and cURL
+4. Data quality snapshots and cleanup trend history
+5. Field-level care-team permissions
+6. AI insights review and approval workflow
+7. Worker heartbeat and queue health dashboard
+8. Security hardening v3 with persistent abuse tracking
+9. Playwright smoke tests for the public demo path
+10. Final screenshot refresh after the next visual UI pass
 
-## Patch 48 addition
+## Recent portfolio polish additions
 
-- **Data Quality Center**: computes profile, record, safety, device, export, and collaboration cleanup signals from existing records without adding a new database table.
+- **Patch 48: Data Quality Center** computes profile, record, safety, device, export, and collaboration cleanup signals from existing records without adding a new database table.
+- **Patch 49: Mobile API Security Hardening** adds mobile API rate limits, no-store headers, payload-size protection, and mobile session audit events.
+- **Patch 50: OpenAPI/Postman Export** adds machine-readable mobile API exports for reviewers and client-integration testing.
+- **Patch 51: README Screenshot Restoration** fixes broken screenshot references and restores the original screenshot gallery for GitHub review.

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -38,7 +38,12 @@ This document keeps the current limitations honest so reviewers can understand w
 |---|---|---|
 | Public demo | `/demo` routes are read-only and use sample data for portfolio review. | Keep demo pages aligned whenever authenticated features change. |
 | Live deployment | The Vercel demo may not have the database and secrets required for all authenticated flows. | Use the no-login demo for review and configure production env vars for full app testing. |
-| Screenshots | README screenshots may lag behind fast-moving UI patches. | Refresh screenshots after major visual updates and keep filenames stable. |
+| Screenshots | Patch 51 restores the original `.mkdir/` screenshot gallery and fixes the missing README image paths. Screenshots can still become visually outdated after large UI changes. | Keep filenames stable and refresh images after major visual redesigns. |
+
+
+## Screenshot gallery status
+
+Patch 51 fixes the README screenshot references and restores the original screenshot set from `.mkdir/`. The README now uses the actual repository filenames, including `Lab-Results.jpg` and `Vitals.jpg`, instead of the missing `Lab-Review.jpg` and `Vitals-Monitor.jpg` paths.
 
 ## Testing limitations
 
@@ -89,3 +94,8 @@ Patch 49 adds endpoint-specific in-memory rate limits, no-store headers, oversiz
 ## API contract exports
 
 Patch 50 adds generated OpenAPI and Postman JSON exports for the mobile/device API. These are intentionally scoped to the existing mobile endpoints only. The exports do not yet cover the full web app/server-action surface because most authenticated web workflows are rendered through App Router pages and server actions rather than public REST endpoints.
+
+
+## Patch 51 note: README Screenshot Restoration
+
+Patch 51 is a docs-only portfolio polish patch. It fixes broken README screenshot paths, restores the original screenshot grid, updates the reviewer guide, and records the screenshot inventory so future UI/image refreshes do not break GitHub previews.

--- a/docs/PATCH_51_README_SCREENSHOT_RESTORATION.md
+++ b/docs/PATCH_51_README_SCREENSHOT_RESTORATION.md
@@ -1,0 +1,65 @@
+# Patch 51: README Screenshot Restoration + Visual Portfolio Polish
+
+## Summary
+
+Patch 51 restores VitaVault's GitHub-facing screenshot gallery and fixes broken README image references.
+
+## Why this patch exists
+
+The latest README referenced two screenshot files that were not present in the repository:
+
+- `.mkdir/Lab-Review.jpg`
+- `.mkdir/Vitals-Monitor.jpg`
+
+The actual screenshot files are:
+
+- `.mkdir/Lab-Results.jpg`
+- `.mkdir/Vitals.jpg`
+
+This created broken image previews in the most important reviewer-facing file in the repo.
+
+## Changes
+
+- Rebuilt the README screenshot section into a fuller visual gallery.
+- Fixed broken image paths for labs and vitals.
+- Restored the original screenshot set from `.mkdir/` into the README.
+- Added screenshot categories for:
+  - reviewer entry points
+  - core patient workspace
+  - clinical review and record coverage
+  - collaboration, intelligence, and handoff
+- Added a screenshot inventory table so filenames stay clear.
+- Updated `docs/PORTFOLIO_REVIEW_GUIDE.md` with a screenshot-based reviewer flow.
+- Updated `docs/FEATURE_MATRIX.md` with current next-patch recommendations.
+- Updated `docs/KNOWN_LIMITATIONS.md` to document screenshot gallery status.
+
+## Files changed
+
+- `README.md`
+- `docs/PORTFOLIO_REVIEW_GUIDE.md`
+- `docs/FEATURE_MATRIX.md`
+- `docs/KNOWN_LIMITATIONS.md`
+- `docs/PATCH_51_README_SCREENSHOT_RESTORATION.md`
+
+## Safety
+
+- No Prisma schema changes.
+- No migration changes.
+- No package changes.
+- No app runtime logic changes.
+- Documentation and README polish only.
+
+## Verification
+
+Recommended checks:
+
+```bash
+npm run actions:check
+npm run actions:imports
+npm run actions:shadow
+npm run typecheck
+npm run lint
+npm run test:run
+```
+
+Also verify README image paths by checking every `.mkdir/*.jpg` reference exists in the repository.

--- a/docs/PORTFOLIO_REVIEW_GUIDE.md
+++ b/docs/PORTFOLIO_REVIEW_GUIDE.md
@@ -82,12 +82,47 @@ A strong walkthrough can be explained like this:
 - Persistent report history and record-attached care notes are future work.
 - Production document storage, compliance controls, and provider-specific device integrations need hardening.
 
+## Screenshot review path
+
+The README now includes the original screenshot set from `.mkdir/`. Use this screenshot path when reviewing the project quickly from GitHub:
+
+1. `Landing-Page.jpg` - public product entry point
+2. `Login-Page.jpg` - auth surface
+3. `Dashboard.jpg` - patient command center
+4. `Health-Profile.jpg` - baseline health profile
+5. `Medications.jpg` - medication record workflow
+6. `Lab-Results.jpg` - lab record coverage
+7. `Vitals.jpg` - vital-sign record coverage
+8. `Care-Team.jpg` - collaboration foundation
+9. `AI-Insights.jpg` - insight workspace
+10. `Device-Connections.jpg` - connected-health foundation
+11. `Exports-Page.jpg` - export and handoff workflow
+12. `Summary.jpg` - patient summary packet
+
+## Reviewer flow using routes and screenshots
+
+| Step | Route or file | What to inspect |
+|---|---|---|
+| 1 | `README.md` screenshots | Visual breadth of the product |
+| 2 | `/demo/walkthrough` | Guided no-login product story |
+| 3 | `/demo/dashboard` | Patient command center |
+| 4 | `/demo/notifications`, `/demo/care-plan`, `/demo/visit-prep` | Workflow layer beyond CRUD |
+| 5 | `/demo/trends`, `/demo/lab-review`, `/demo/vitals-monitor` | Clinical review surfaces |
+| 6 | `/demo/device-connection`, `/demo/api-docs` | Mobile/device readiness and API story |
+| 7 | `/demo/exports`, `/summary`, `/report-builder` | Handoff and reporting story |
+| 8 | `/security`, `/audit-log`, `/jobs`, `/ops`, `/admin` | Production-minded platform layer |
+| 9 | `prisma/schema.prisma` | Domain model depth |
+| 10 | `tests/` | Regression coverage and helper-level testing |
+
 ## Recommended future patch ideas
 
-1. Persistent report history model
-2. Record-attached care notes
-3. Background jobs v2 with admin retry tools
-4. Data Quality Center
-5. Production document storage provider hardening
-6. Playwright demo smoke tests
-7. OpenAPI spec generation for mobile routes
+1. Persistent report-builder history stored in the database
+2. Device provider connector abstraction for Apple Health, Android Health Connect, Fitbit, and smart devices
+3. Mobile API SDK examples for JavaScript, React Native, and cURL
+4. Data quality snapshots and cleanup trend history
+5. Field-level care-team permissions
+6. AI insights review and approval workflow
+7. Worker heartbeat and queue health dashboard
+8. Security hardening v3 with persistent abuse tracking
+9. Final demo screenshot refresh after the next visual UI pass
+10. Playwright smoke tests for the public demo path


### PR DESCRIPTION
## Summary

This patch restores VitaVault’s README screenshot gallery and fixes broken image references in the GitHub-facing project showcase.

## Changes

- Fixed missing README screenshot paths:
  - `.mkdir/Lab-Review.jpg` -> `.mkdir/Lab-Results.jpg`
  - `.mkdir/Vitals-Monitor.jpg` -> `.mkdir/Vitals.jpg`
- Rebuilt the README screenshot section using all 18 original screenshots.
- Added screenshot categories for reviewer entry points, core workspace, clinical review, collaboration, intelligence, devices, and exports.
- Added a screenshot inventory table to keep filenames clear.
- Updated the portfolio review guide with a screenshot-based reviewer flow.
- Updated the feature matrix and known limitations.
- Added Patch 51 documentation.

## Safety

- No Prisma schema changes.
- No migration changes.
- No package changes.
- No app runtime logic changes.
- Documentation and README polish only.

## Checks to run

```bash
npm run actions:check
npm run actions:imports
npm run actions:shadow
npm run typecheck
npm run lint
npm run test:run