### PR TITLE
Fix mobile SDK platform contract alignment

### DIFF
--- a/docs/PATCH_55_SDK_CONTRACT_ALIGNMENT.md
+++ b/docs/PATCH_55_SDK_CONTRACT_ALIGNMENT.md
@@ -1,0 +1,30 @@
+# Patch 55 — Mobile SDK Contract Alignment
+
+## Summary
+
+Patch 55 keeps the published mobile API SDK examples aligned with the current VitaVault Prisma-backed API contract.
+
+## Changes
+
+- Removed unsupported `WEARABLE` and `BLUETOOTH` values from the public `VitaVaultDevicePlatform` SDK type.
+- Added `VITAVAULT_DEVICE_PLATFORMS` as a runtime-safe exported platform list for SDK consumers and tests.
+- Added a regression test to prevent SDK platform values from drifting away from the server contract.
+
+## Why this matters
+
+The current Prisma `DevicePlatform` enum supports only:
+
+- `ANDROID`
+- `IOS`
+- `WEB`
+- `OTHER`
+
+The SDK example now matches that contract exactly, so mobile developers will not submit platform values rejected by the `/api/mobile/device-readings` endpoint.
+
+## Safety
+
+- No Prisma migration added.
+- No package dependency changes.
+- No README changes.
+- No route or API behavior changes.
+- Existing sample payload behavior is preserved.

--- a/examples/mobile-api/vitavault-mobile-client.ts
+++ b/examples/mobile-api/vitavault-mobile-client.ts
@@ -17,7 +17,8 @@ export type VitaVaultReadingSource =
   | "PULSE_OXIMETER"
   | "OTHER";
 
-export type VitaVaultDevicePlatform = "ANDROID" | "IOS" | "WEB" | "WEARABLE" | "BLUETOOTH" | "OTHER";
+export const VITAVAULT_DEVICE_PLATFORMS = ["ANDROID", "IOS", "WEB", "OTHER"] as const;
+export type VitaVaultDevicePlatform = (typeof VITAVAULT_DEVICE_PLATFORMS)[number];
 export type VitaVaultConnectionStatus = "ACTIVE" | "ERROR" | "REVOKED" | "DISCONNECTED";
 
 export type VitaVaultUser = { id: string; email: string; name: string | null };

--- a/tests/mobile-api-sdk-examples.test.ts
+++ b/tests/mobile-api-sdk-examples.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { MOBILE_API_SDK_EXAMPLES, getMobileApiSdkCoveredCapabilities, getMobileApiSdkExampleCount } from "@/lib/mobile-api-sdk-examples";
-import { buildAndroidHealthConnectSamplePayload } from "@/examples/mobile-api/vitavault-mobile-client";
+import { VITAVAULT_DEVICE_PLATFORMS, buildAndroidHealthConnectSamplePayload } from "@/examples/mobile-api/vitavault-mobile-client";
 import { buildReactNativeSyncPayload, mapDraftToVitaVaultReading } from "@/examples/mobile-api/react-native-sync";
 
 describe("mobile API SDK examples", () => {
@@ -17,6 +17,12 @@ describe("mobile API SDK examples", () => {
 
   it("documents expected client capabilities", () => {
     expect(getMobileApiSdkCoveredCapabilities()).toEqual(expect.arrayContaining(["login", "session", "logout", "connections", "device reading sync"]));
+  });
+
+  it("keeps SDK device platforms aligned to the Prisma-backed mobile API contract", () => {
+    expect(VITAVAULT_DEVICE_PLATFORMS).toEqual(["ANDROID", "IOS", "WEB", "OTHER"]);
+    expect(VITAVAULT_DEVICE_PLATFORMS).not.toContain("WEARABLE");
+    expect(VITAVAULT_DEVICE_PLATFORMS).not.toContain("BLUETOOTH");
   });
 
   it("builds a schema-backed Android Health Connect sample payload", () => {


### PR DESCRIPTION
## Summary

This patch aligns the published mobile API SDK example with the current VitaVault server-side device platform contract.

## Changes

- Removed unsupported `WEARABLE` and `BLUETOOTH` values from the SDK platform type
- Added `VITAVAULT_DEVICE_PLATFORMS` as a runtime-safe exported platform list
- Added a regression test to prevent SDK platform drift
- Added Patch 55 documentation under `docs/`

## Safety

- No Prisma migration
- No dependency changes
- No README changes
- No API route changes
- Existing Android Health Connect sample payload behavior is preserved

## Checks

Run locally:

```powershell
npm install
npm run db:validate:ci
npm run actions:check
npm run actions:imports
npm run actions:shadow
npm run typecheck
npm run lint
npm run test:run