### PR TITLE
Harden sensitive route policy guards

### DIFF
--- a/app/api/jobs/dispatch/route.ts
+++ b/app/api/jobs/dispatch/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
-import { AppRole } from "@prisma/client";
-import { requireUser } from "@/lib/session";
 import { hasRedisConfig, shouldSkipRedisDuringBuild } from "@/lib/jobs/connection";
+import { requireApiRoutePolicy } from "@/lib/route-policy";
 import {
   enqueueAlertEvaluationJob,
   enqueueDailyHealthSummaryJob,
@@ -65,15 +64,17 @@ export async function POST(request: Request) {
       );
     }
 
-    const currentUser = await requireUser();
+    const guard = await requireApiRoutePolicy("jobDispatchApi");
 
-    if (currentUser.role !== AppRole.ADMIN) {
-      return NextResponse.json({ error: "Only admins can dispatch background jobs." }, { status: 403 });
+    if (!guard.ok) {
+      return guard.response;
     }
+
+    const currentUser = guard.user;
 
     const body = (await request.json()) as DispatchBody;
 
-    const userId = body.userId || currentUser.id!;
+    const userId = body.userId || currentUser.id;
     if (!userId) {
       return NextResponse.json({ error: "Missing user id." }, { status: 400 });
     }
@@ -96,7 +97,7 @@ export async function POST(request: Request) {
           userId,
           timezone: body.timezone ?? null,
           targetDate: body.targetDate ?? null,
-          requestedByUserId: currentUser.id!,
+          requestedByUserId: currentUser.id,
         });
 
         return NextResponse.json({ ok: true, jobType: body.jobType, ...result });
@@ -106,7 +107,7 @@ export async function POST(request: Request) {
         const result = await enqueueReminderOverdueEvaluationJob({
           userId,
           timezone: body.timezone ?? null,
-          requestedByUserId: currentUser.id!,
+          requestedByUserId: currentUser.id,
         });
 
         return NextResponse.json({ ok: true, jobType: body.jobType, ...result });
@@ -116,7 +117,7 @@ export async function POST(request: Request) {
         const result = await enqueueDailyHealthSummaryJob({
           userId,
           targetDate: body.targetDate ?? null,
-          requestedByUserId: currentUser.id!,
+          requestedByUserId: currentUser.id,
         });
 
         return NextResponse.json({ ok: true, jobType: body.jobType, ...result });
@@ -127,7 +128,7 @@ export async function POST(request: Request) {
           userId,
           connectionId: body.connectionId ?? null,
           syncJobId: body.syncJobId ?? null,
-          triggeredBy: currentUser.id!,
+          triggeredBy: currentUser.id,
         });
 
         return NextResponse.json({ ok: true, jobType: body.jobType, ...result });

--- a/docs/PATCH_56_SERVER_SIDE_ROUTE_GUARD_AUDIT.md
+++ b/docs/PATCH_56_SERVER_SIDE_ROUTE_GUARD_AUDIT.md
@@ -1,0 +1,58 @@
+# Patch 56 — Server-Side Route Guard Audit
+
+## Summary
+
+Patch 56 strengthens VitaVault's sensitive-route guard layer by extending the route policy registry beyond sidebar-only page routes and into high-risk API surfaces.
+
+The patch keeps the change focused and low risk: it does not add database migrations, does not change public README content, and does not modify the user-facing route layout.
+
+## What changed
+
+- Added API route policies for:
+  - `/api/jobs/dispatch`
+  - `/api/internal/alerts/scan`
+  - `/api/internal/alerts/evaluate`
+- Added a sensitive-route audit list covering admin pages and privileged APIs.
+- Added route-policy lookup helpers for exact and nested route checks.
+- Added an API-safe route guard that returns JSON `401` / `403` responses instead of relying on page redirects.
+- Updated `/api/jobs/dispatch` to use the centralized API route policy guard.
+- Expanded route-policy tests to verify:
+  - admin sidebar routes are backed by admin route policies
+  - sensitive page/API routes are tracked in one audit list
+  - admin-only API policies reject non-admin roles
+  - nested and query-string route paths map back to their owning policies
+
+## Files changed
+
+- `lib/route-policy.ts`
+- `app/api/jobs/dispatch/route.ts`
+- `tests/route-policy.test.ts`
+- `docs/PATCH_56_SERVER_SIDE_ROUTE_GUARD_AUDIT.md`
+
+## Safety notes
+
+- No Prisma migration is required.
+- No package changes are required.
+- No README changes were made.
+- Existing admin page guards remain intact.
+- Existing internal alert API token behavior remains intact.
+- The job dispatch API now returns a proper JSON `401` response for unauthenticated requests and a JSON `403` response for non-admin sessions.
+
+## Recommended checks
+
+```powershell
+npm install
+npm run db:validate:ci
+npm run actions:check
+npm run actions:imports
+npm run actions:shadow
+npm run typecheck
+npm run lint
+npm run test:run
+```
+
+Targeted test:
+
+```powershell
+npm run test:run -- tests/route-policy.test.ts
+```

--- a/lib/route-policy.ts
+++ b/lib/route-policy.ts
@@ -7,48 +7,107 @@ export type RoutePolicy = {
   href: string;
   access: RouteAccessLevel;
   description: string;
+  surface: "page" | "api";
 };
+
+export type ApiRoutePolicyUser = {
+  id: string;
+  name: string | null;
+  email: string | null;
+  image: string | null;
+  role: AppRole;
+};
+
+export type ApiRoutePolicyResult =
+  | {
+      ok: true;
+      user: ApiRoutePolicyUser;
+    }
+  | {
+      ok: false;
+      response: Response;
+    };
 
 export const routePolicies = {
   admin: {
     title: "Admin Command Center",
     href: "/admin",
     access: "admin",
+    surface: "page",
     description: "Admin-only account lifecycle, audit, and system visibility.",
   },
   jobs: {
     title: "Background Jobs",
     href: "/jobs",
     access: "admin",
+    surface: "page",
     description: "Admin-only worker queue, retry, and job-run operations.",
   },
   ops: {
     title: "Operations",
     href: "/ops",
     access: "admin",
+    surface: "page",
     description: "Admin-only deployment readiness, workload risk, and operational runbooks.",
   },
   auditLog: {
     title: "Audit Log",
     href: "/audit-log",
     access: "authenticated",
+    surface: "page",
     description: "Scoped audit visibility for regular users and system-wide visibility for admins.",
   },
   apiDocs: {
     title: "API Docs",
     href: "/api-docs",
     access: "authenticated",
+    surface: "page",
     description: "Authenticated reviewer-facing mobile and device API reference.",
   },
   deviceConnection: {
     title: "Device Connections",
     href: "/device-connection",
     access: "authenticated",
+    surface: "page",
     description: "Authenticated roadmap surface for health-device and mobile integration planning.",
+  },
+  jobDispatchApi: {
+    title: "Job Dispatch API",
+    href: "/api/jobs/dispatch",
+    access: "admin",
+    surface: "api",
+    description: "Admin-only API endpoint for manually dispatching background jobs.",
+  },
+  internalAlertScanApi: {
+    title: "Internal Alert Scan API",
+    href: "/api/internal/alerts/scan",
+    access: "admin",
+    surface: "api",
+    description: "Admin or trusted-token endpoint for queueing a full scheduled alert scan.",
+  },
+  internalAlertEvaluateApi: {
+    title: "Internal Alert Evaluation API",
+    href: "/api/internal/alerts/evaluate",
+    access: "authenticated",
+    surface: "api",
+    description: "Authenticated or trusted-token endpoint for queueing scoped alert evaluation.",
   },
 } as const satisfies Record<string, RoutePolicy>;
 
 export type RoutePolicyKey = keyof typeof routePolicies;
+
+export const adminRoutePolicyKeys = Object.entries(routePolicies)
+  .filter(([, policy]) => policy.access === "admin")
+  .map(([key]) => key as RoutePolicyKey);
+
+export const sensitiveRoutePolicyKeys = [
+  "admin",
+  "jobs",
+  "ops",
+  "jobDispatchApi",
+  "internalAlertScanApi",
+  "internalAlertEvaluateApi",
+] as const satisfies readonly RoutePolicyKey[];
 
 export function canAccessRoutePolicy(
   policy: RoutePolicy,
@@ -61,6 +120,19 @@ export function canAccessRoutePolicy(
 
 export function isAdminRole(role: AppRole | null | undefined) {
   return role === AppRole.ADMIN;
+}
+
+export function getRoutePolicyByHref(href: string) {
+  const normalizedHref = href.split("?")[0]?.replace(/\/$/, "") || "/";
+
+  return Object.values(routePolicies).find((policy) => {
+    const policyHref = policy.href.replace(/\/$/, "");
+    return normalizedHref === policyHref || normalizedHref.startsWith(`${policyHref}/`);
+  });
+}
+
+export function getAdminRoutePolicies() {
+  return adminRoutePolicyKeys.map((key) => routePolicies[key]);
 }
 
 export async function requireRoutePolicy(
@@ -84,4 +156,78 @@ export async function requireRoutePolicy(
 
 export async function requireAdminRoute(redirectTo = "/dashboard") {
   return requireRoutePolicy("admin", redirectTo);
+}
+
+export async function requireAdminRoutePolicy(
+  policyKey: Extract<RoutePolicyKey, "admin" | "jobs" | "ops">,
+  redirectTo = "/dashboard"
+) {
+  return requireRoutePolicy(policyKey, redirectTo);
+}
+
+export async function requireApiRoutePolicy(
+  policyKey: RoutePolicyKey
+): Promise<ApiRoutePolicyResult> {
+  const [{ NextResponse }, { auth }, { db }] = await Promise.all([
+    import("next/server"),
+    import("@/lib/auth"),
+    import("@/lib/db"),
+  ]);
+
+  const policy = routePolicies[policyKey];
+  const session = await auth();
+  const sessionUserId = session?.user?.id;
+
+  if (!sessionUserId) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Authentication is required for this route." },
+        { status: 401 }
+      ),
+    };
+  }
+
+  const user = await db.user.findUnique({
+    where: { id: sessionUserId },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      image: true,
+      role: true,
+      deactivatedAt: true,
+    },
+  });
+
+  if (!user || user.deactivatedAt) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Authentication is required for this route." },
+        { status: 401 }
+      ),
+    };
+  }
+
+  if (!canAccessRoutePolicy(policy, user.role)) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: `Only administrators can access ${policy.title}.` },
+        { status: 403 }
+      ),
+    };
+  }
+
+  return {
+    ok: true,
+    user: {
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      image: user.image,
+      role: user.role,
+    },
+  };
 }

--- a/tests/route-policy.test.ts
+++ b/tests/route-policy.test.ts
@@ -2,11 +2,16 @@ import { describe, expect, it } from "vitest";
 import { AppRole } from "@prisma/client";
 
 import {
+  adminRoutePolicyKeys,
   canAccessRoutePolicy,
+  getAdminRoutePolicies,
+  getRoutePolicyByHref,
   isAdminRole,
   routePolicies,
+  sensitiveRoutePolicyKeys,
 } from "../lib/route-policy";
 import {
+  adminOpsRoutes,
   getAllAppRoutesForRole,
   getNavigationSectionsForRole,
 } from "../lib/app-routes";
@@ -51,5 +56,55 @@ describe("role-based route policy", () => {
     expect(canAccessRoutePolicy(routePolicies.apiDocs, AppRole.CAREGIVER)).toBe(true);
     expect(isAdminRole(AppRole.ADMIN)).toBe(true);
     expect(isAdminRole(AppRole.PATIENT)).toBe(false);
+  });
+
+  it("keeps every admin sidebar route backed by an admin route policy", () => {
+    const adminPolicyHrefs = new Set<string>(
+      getAdminRoutePolicies().map((policy) => policy.href)
+    );
+    const adminNavigationHrefs = adminOpsRoutes.map((route) => route.href);
+
+    expect(adminNavigationHrefs).toEqual(["/admin", "/jobs", "/ops"]);
+    expect(adminNavigationHrefs.every((href) => adminPolicyHrefs.has(href))).toBe(true);
+  });
+
+  it("maps nested sensitive routes back to their owning policies", () => {
+    expect(getRoutePolicyByHref("/admin?tab=users")?.title).toBe("Admin Command Center");
+    expect(getRoutePolicyByHref("/jobs/run-123")?.title).toBe("Background Jobs");
+    expect(getRoutePolicyByHref("/ops/")?.title).toBe("Operations");
+    expect(getRoutePolicyByHref("/api/jobs/dispatch")?.title).toBe("Job Dispatch API");
+    expect(getRoutePolicyByHref("/api/internal/alerts/scan")?.title).toBe("Internal Alert Scan API");
+  });
+
+  it("tracks high-risk page and API surfaces in the sensitive policy audit list", () => {
+    expect(sensitiveRoutePolicyKeys).toEqual([
+      "admin",
+      "jobs",
+      "ops",
+      "jobDispatchApi",
+      "internalAlertScanApi",
+      "internalAlertEvaluateApi",
+    ]);
+
+    const sensitivePolicies = sensitiveRoutePolicyKeys.map((key) => routePolicies[key]);
+    const sensitiveHrefs = sensitivePolicies.map((policy) => policy.href);
+
+    expect(sensitiveHrefs).toEqual([
+      "/admin",
+      "/jobs",
+      "/ops",
+      "/api/jobs/dispatch",
+      "/api/internal/alerts/scan",
+      "/api/internal/alerts/evaluate",
+    ]);
+    expect(adminRoutePolicyKeys).toContain("jobDispatchApi");
+    expect(adminRoutePolicyKeys).toContain("internalAlertScanApi");
+  });
+
+  it("requires admin access for admin-only API policies", () => {
+    expect(canAccessRoutePolicy(routePolicies.jobDispatchApi, AppRole.ADMIN)).toBe(true);
+    expect(canAccessRoutePolicy(routePolicies.jobDispatchApi, AppRole.PATIENT)).toBe(false);
+    expect(canAccessRoutePolicy(routePolicies.internalAlertScanApi, AppRole.ADMIN)).toBe(true);
+    expect(canAccessRoutePolicy(routePolicies.internalAlertScanApi, AppRole.DOCTOR)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

This patch strengthens VitaVault's server-side route guard layer for sensitive admin and API surfaces.

## Changes

- Expanded the route policy registry to include high-risk API routes
- Added sensitive route audit coverage for admin pages and privileged APIs
- Added route-policy lookup helpers for nested/query-string paths
- Added an API-safe route guard that returns JSON 401/403 responses
- Updated `/api/jobs/dispatch` to use the centralized admin API policy guard
- Expanded route-policy tests for admin navigation, API policy access, and sensitive route coverage
- Added Patch 56 documentation under `docs/`

## Safety

- No Prisma migration
- No package changes
- No README changes
- Existing admin page guards remain in place
- Existing internal alert token behavior remains unchanged

## Checks

Run locally:

```powershell
npm install
npm run db:validate:ci
npm run actions:check
npm run actions:imports
npm run actions:shadow
npm run typecheck
npm run lint
npm run test:run