### PR TITLE
Strengthen mobile API contract consistency tests

### DIFF
--- a/docs/PATCH_57_MOBILE_API_CONTRACT_CONSISTENCY_TESTS.md
+++ b/docs/PATCH_57_MOBILE_API_CONTRACT_CONSISTENCY_TESTS.md
@@ -1,0 +1,52 @@
+# Patch 57 — Mobile API Contract Consistency Tests
+
+## Summary
+
+This patch strengthens VitaVault's mobile API test coverage by checking that the published SDK examples, OpenAPI export, Postman collection, and server-side Prisma-backed enum values stay aligned.
+
+## Files changed
+
+- `examples/mobile-api/vitavault-mobile-client.ts`
+- `tests/mobile-api-sdk-examples.test.ts`
+- `tests/mobile-api-contract-export.test.ts`
+
+## Files added
+
+- `docs/PATCH_57_MOBILE_API_CONTRACT_CONSISTENCY_TESTS.md`
+
+## What changed
+
+- Added runtime-safe SDK constants for supported reading types, reading sources, device platforms, and connection statuses.
+- Kept SDK platform values limited to the server-backed device platform contract: `ANDROID`, `IOS`, `WEB`, and `OTHER`.
+- Added SDK regression coverage to compare exported SDK constants against Prisma enums.
+- Added OpenAPI regression coverage to compare schema enum values against Prisma enums and SDK constants.
+- Added Postman regression coverage to verify the sync request example only uses valid enum values.
+- Updated the contract summary test so endpoint and reading counts are checked against source-of-truth constants instead of hard-coded counts.
+
+## Safety
+
+- No Prisma migration.
+- No package changes.
+- No README changes.
+- No API route changes.
+- No app UI changes.
+- The patch only strengthens examples and tests around the existing mobile API contract.
+
+## Suggested checks
+
+```powershell
+npm install
+npm run db:validate:ci
+npm run actions:check
+npm run actions:imports
+npm run actions:shadow
+npm run typecheck
+npm run lint
+npm run test:run
+```
+
+Targeted checks:
+
+```powershell
+npm run test:run -- tests/mobile-api-sdk-examples.test.ts tests/mobile-api-contract-export.test.ts
+```

--- a/examples/mobile-api/vitavault-mobile-client.ts
+++ b/examples/mobile-api/vitavault-mobile-client.ts
@@ -1,25 +1,33 @@
-export type VitaVaultReadingType =
-  | "HEART_RATE"
-  | "BLOOD_PRESSURE"
-  | "OXYGEN_SATURATION"
-  | "WEIGHT"
-  | "BLOOD_GLUCOSE"
-  | "TEMPERATURE"
-  | "STEPS";
+export const VITAVAULT_READING_TYPES = [
+  "HEART_RATE",
+  "BLOOD_PRESSURE",
+  "OXYGEN_SATURATION",
+  "WEIGHT",
+  "BLOOD_GLUCOSE",
+  "TEMPERATURE",
+  "STEPS",
+] as const;
 
-export type VitaVaultReadingSource =
-  | "MANUAL"
-  | "ANDROID_HEALTH_CONNECT"
-  | "APPLE_HEALTH"
-  | "FITBIT"
-  | "SMART_BP_MONITOR"
-  | "SMART_SCALE"
-  | "PULSE_OXIMETER"
-  | "OTHER";
+export type VitaVaultReadingType = (typeof VITAVAULT_READING_TYPES)[number];
+
+export const VITAVAULT_READING_SOURCES = [
+  "MANUAL",
+  "ANDROID_HEALTH_CONNECT",
+  "APPLE_HEALTH",
+  "FITBIT",
+  "SMART_BP_MONITOR",
+  "SMART_SCALE",
+  "PULSE_OXIMETER",
+  "OTHER",
+] as const;
+
+export type VitaVaultReadingSource = (typeof VITAVAULT_READING_SOURCES)[number];
 
 export const VITAVAULT_DEVICE_PLATFORMS = ["ANDROID", "IOS", "WEB", "OTHER"] as const;
 export type VitaVaultDevicePlatform = (typeof VITAVAULT_DEVICE_PLATFORMS)[number];
-export type VitaVaultConnectionStatus = "ACTIVE" | "ERROR" | "REVOKED" | "DISCONNECTED";
+
+export const VITAVAULT_CONNECTION_STATUSES = ["ACTIVE", "ERROR", "REVOKED", "DISCONNECTED"] as const;
+export type VitaVaultConnectionStatus = (typeof VITAVAULT_CONNECTION_STATUSES)[number];
 
 export type VitaVaultUser = { id: string; email: string; name: string | null };
 export type VitaVaultLoginResponse = { token: string; expiresAt: string; user: VitaVaultUser };

--- a/tests/mobile-api-contract-export.test.ts
+++ b/tests/mobile-api-contract-export.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
+import { DevicePlatform, DeviceReadingType, ReadingSource } from "@prisma/client";
 import {
   buildMobileOpenApiSpec,
   buildMobilePostmanCollection,
   getMobileApiContractSummary,
   getMobileApiExportFileName,
 } from "@/lib/mobile-api-contract-export";
+import { MOBILE_DEVICE_ENDPOINTS, SUPPORTED_DEVICE_READING_TYPES } from "@/lib/mobile-device-api";
+import { VITAVAULT_DEVICE_PLATFORMS, VITAVAULT_READING_SOURCES, VITAVAULT_READING_TYPES } from "@/examples/mobile-api/vitavault-mobile-client";
 
 const mobileEndpoints = [
   "/api/mobile/auth/login",
@@ -13,6 +16,14 @@ const mobileEndpoints = [
   "/api/mobile/connections",
   "/api/mobile/device-readings",
 ];
+
+function getSyncPostmanBody(collection: ReturnType<typeof buildMobilePostmanCollection>) {
+  const deviceReadingsGroup = collection.item.find((group) => group.name === "Device Readings");
+  const syncRequest = deviceReadingsGroup?.item.find((item) => item.name === "Sync device readings");
+  const rawBody = syncRequest?.request.body?.raw;
+  if (!rawBody) throw new Error("Missing Postman sync request body.");
+  return JSON.parse(rawBody) as { source: string; platform: string; readings: Array<{ readingType: string }> };
+}
 
 describe("mobile API contract export", () => {
   it("builds an OpenAPI contract for every supported mobile endpoint", () => {
@@ -28,6 +39,22 @@ describe("mobile API contract export", () => {
     expect(spec.components.securitySchemes.bearerAuth.scheme).toBe("bearer");
     expect(spec.components.schemas.DeviceReadingSyncRequest.required).toContain("readings");
     expect(spec.components.schemas.DeviceReadingSyncRequest.properties.readings.maxItems).toBe(500);
+  });
+
+  it("keeps OpenAPI schema enums aligned with Prisma and SDK constants", () => {
+    const spec = buildMobileOpenApiSpec("https://demo.vitavault.test");
+    const connectionSchema = spec.components.schemas.DeviceConnection;
+    const readingSchema = spec.components.schemas.DeviceReading;
+    const syncRequestSchema = spec.components.schemas.DeviceReadingSyncRequest;
+
+    expect([...connectionSchema.properties.platform.enum].sort()).toEqual(Object.values(DevicePlatform).sort());
+    expect([...connectionSchema.properties.platform.enum].sort()).toEqual([...VITAVAULT_DEVICE_PLATFORMS].sort());
+    expect([...connectionSchema.properties.source.enum].sort()).toEqual(Object.values(ReadingSource).sort());
+    expect([...connectionSchema.properties.source.enum].sort()).toEqual([...VITAVAULT_READING_SOURCES].sort());
+    expect([...readingSchema.properties.readingType.enum].sort()).toEqual(Object.values(DeviceReadingType).sort());
+    expect([...readingSchema.properties.readingType.enum].sort()).toEqual([...VITAVAULT_READING_TYPES].sort());
+    expect([...syncRequestSchema.properties.platform.enum].sort()).toEqual(Object.values(DevicePlatform).sort());
+    expect([...syncRequestSchema.properties.source.enum].sort()).toEqual(Object.values(ReadingSource).sort());
   });
 
   it("builds a Postman collection with grouped mobile requests", () => {
@@ -47,13 +74,26 @@ describe("mobile API contract export", () => {
     ]);
   });
 
+  it("keeps Postman sync examples inside the published mobile contract", () => {
+    const collection = buildMobilePostmanCollection("https://demo.vitavault.test");
+    const body = getSyncPostmanBody(collection);
+
+    expect(Object.values(ReadingSource)).toContain(body.source);
+    expect(Object.values(DevicePlatform)).toContain(body.platform);
+    for (const reading of body.readings) {
+      expect(Object.values(DeviceReadingType)).toContain(reading.readingType);
+    }
+  });
+
   it("keeps the contract summary aligned with the current mobile surface", () => {
     const summary = getMobileApiContractSummary();
 
-    expect(summary.endpointCount).toBe(5);
-    expect(summary.readingTypeCount).toBe(7);
+    expect(summary.endpointCount).toBe(MOBILE_DEVICE_ENDPOINTS.length);
+    expect(summary.endpoints.map((endpoint) => endpoint.path)).toEqual(MOBILE_DEVICE_ENDPOINTS.map((endpoint) => endpoint.path));
+    expect(summary.readingTypeCount).toBe(SUPPORTED_DEVICE_READING_TYPES.length);
+    expect(summary.supportedReadings.map((reading) => reading.type).sort()).toEqual(Object.values(DeviceReadingType).sort());
     expect(summary.exportFormats).toContain("OpenAPI 3.1");
-    expect(summary.securityPolicies.length).toBeGreaterThanOrEqual(5);
+    expect(summary.securityPolicies.length).toBeGreaterThanOrEqual(summary.endpointCount);
   });
 
   it("uses stable downloadable filenames", () => {

--- a/tests/mobile-api-sdk-examples.test.ts
+++ b/tests/mobile-api-sdk-examples.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { DevicePlatform, DeviceReadingType, ReadingSource } from "@prisma/client";
 import { MOBILE_API_SDK_EXAMPLES, getMobileApiSdkCoveredCapabilities, getMobileApiSdkExampleCount } from "@/lib/mobile-api-sdk-examples";
-import { VITAVAULT_DEVICE_PLATFORMS, buildAndroidHealthConnectSamplePayload } from "@/examples/mobile-api/vitavault-mobile-client";
+import {
+  VITAVAULT_DEVICE_PLATFORMS,
+  VITAVAULT_READING_SOURCES,
+  VITAVAULT_READING_TYPES,
+  buildAndroidHealthConnectSamplePayload,
+} from "@/examples/mobile-api/vitavault-mobile-client";
 import { buildReactNativeSyncPayload, mapDraftToVitaVaultReading } from "@/examples/mobile-api/react-native-sync";
 
 describe("mobile API SDK examples", () => {
@@ -19,10 +25,10 @@ describe("mobile API SDK examples", () => {
     expect(getMobileApiSdkCoveredCapabilities()).toEqual(expect.arrayContaining(["login", "session", "logout", "connections", "device reading sync"]));
   });
 
-  it("keeps SDK device platforms aligned to the Prisma-backed mobile API contract", () => {
-    expect(VITAVAULT_DEVICE_PLATFORMS).toEqual(["ANDROID", "IOS", "WEB", "OTHER"]);
-    expect(VITAVAULT_DEVICE_PLATFORMS).not.toContain("WEARABLE");
-    expect(VITAVAULT_DEVICE_PLATFORMS).not.toContain("BLUETOOTH");
+  it("keeps exported SDK contract values aligned with Prisma enums", () => {
+    expect([...VITAVAULT_DEVICE_PLATFORMS].sort()).toEqual(Object.values(DevicePlatform).sort());
+    expect([...VITAVAULT_READING_SOURCES].sort()).toEqual(Object.values(ReadingSource).sort());
+    expect([...VITAVAULT_READING_TYPES].sort()).toEqual(Object.values(DeviceReadingType).sort());
   });
 
   it("builds a schema-backed Android Health Connect sample payload", () => {


### PR DESCRIPTION
## Summary

This patch strengthens VitaVault's mobile API contract coverage across SDK examples, OpenAPI exports, Postman exports, and Prisma-backed enum values.

## Changes

- Added runtime-safe SDK constants for reading types, reading sources, device platforms, and connection statuses
- Kept SDK device platform values aligned with the server-backed contract
- Added SDK regression tests comparing exported SDK constants against Prisma enums
- Added OpenAPI regression tests comparing schema enum values against Prisma enums and SDK constants
- Added Postman regression tests verifying sync request examples only use valid enum values
- Updated mobile contract summary checks to use source-of-truth constants instead of hard-coded counts
- Added Patch 57 documentation under `docs/`

## Safety

- No Prisma migration
- No dependency changes
- No README changes
- No API behavior changes
- No UI changes

## Checks

Run locally:

```powershell
npm install
npm run db:validate:ci
npm run actions:check
npm run actions:imports
npm run actions:shadow
npm run typecheck
npm run lint
npm run test:run