### PR TITLE
Polish public demo route coverage

### DIFF
--- a/app/demo/care-notes/page.tsx
+++ b/app/demo/care-notes/page.tsx
@@ -1,0 +1,48 @@
+import { BulletList, DemoHeader, DemoSection, MetricGrid, SimpleTable, StatCards } from "@/components/demo-primitives";
+import { demoCareNotesHub } from "@/lib/demo-data";
+
+export default function DemoCareNotesPage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader
+        eyebrow="Collaboration layer"
+        title="Care Notes"
+        description="Shared handoff notes show how VitaVault connects caregivers, clinicians, admins, and patient records without turning collaboration into scattered comments."
+      />
+
+      <MetricGrid items={demoCareNotesHub.metrics} />
+
+      <DemoSection title="Shared handoff board" description="Representative notes from the real care-note workflow, including status, author context, and the record areas they support.">
+        <SimpleTable
+          headers={["Note", "Category", "Author", "Status", "Detail"]}
+          rows={demoCareNotesHub.notes.map((note) => ({
+            key: `${note.title}-${note.author}`,
+            cells: [note.title, note.category, note.author, note.status, note.detail],
+          }))}
+        />
+      </DemoSection>
+
+      <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
+        <DemoSection title="Why this matters in the product">
+          <BulletList items={demoCareNotesHub.workflow} />
+        </DemoSection>
+        <DemoSection title="Reviewer signal">
+          <StatCards
+            items={[
+              {
+                title: "Permission-aware collaboration",
+                body: "Care notes are designed to respect shared-access scopes instead of exposing the entire patient workspace to every collaborator.",
+                status: "Secure",
+              },
+              {
+                title: "Workflow-connected notes",
+                body: "Notes are most useful when they connect to alerts, reminders, reports, labs, symptoms, documents, and upcoming appointments.",
+                status: "Workflow",
+              },
+            ]}
+          />
+        </DemoSection>
+      </div>
+    </div>
+  );
+}

--- a/app/demo/report-builder/page.tsx
+++ b/app/demo/report-builder/page.tsx
@@ -1,0 +1,56 @@
+import { DemoHeader, DemoSection, KeyValueList, SimpleTable, StatCards } from "@/components/demo-primitives";
+import { demoReportBuilderHub } from "@/lib/demo-data";
+
+export default function DemoReportBuilderPage() {
+  return (
+    <div className="space-y-6">
+      <DemoHeader
+        eyebrow="Export workflow"
+        title="Report Builder"
+        description="A read-only preview of VitaVault's custom report packet workflow for doctor visits, emergency summaries, care-team handoffs, and device review exports."
+      />
+
+      <div className="grid gap-6 xl:grid-cols-[1fr_0.9fr]">
+        <DemoSection title="Packet readiness checks" description="The real report builder uses record availability and safety context to make report exports more useful.">
+          <KeyValueList items={demoReportBuilderHub.checks} />
+        </DemoSection>
+        <DemoSection title="Reviewer signal">
+          <StatCards
+            items={[
+              {
+                title: "Saved report history",
+                body: "Generated packets can be tracked as saved report records instead of disappearing after export.",
+                status: "Persisted",
+              },
+              {
+                title: "Multiple audiences",
+                body: "The same health record can produce clinician, caregiver, emergency, and operations-oriented packets.",
+                status: "Flexible",
+              },
+            ]}
+          />
+        </DemoSection>
+      </div>
+
+      <DemoSection title="Report presets">
+        <SimpleTable
+          headers={["Preset", "Audience", "Sections", "Status"]}
+          rows={demoReportBuilderHub.presets.map((preset) => ({
+            key: preset.name,
+            cells: [preset.name, preset.audience, preset.sections, preset.status],
+          }))}
+        />
+      </DemoSection>
+
+      <DemoSection title="Saved report history">
+        <SimpleTable
+          headers={["Report", "Generated", "Format", "Status"]}
+          rows={demoReportBuilderHub.history.map((report) => ({
+            key: `${report.title}-${report.generatedAt}`,
+            cells: [report.title, report.generatedAt, report.format, report.status],
+          }))}
+        />
+      </DemoSection>
+    </div>
+  );
+}

--- a/docs/PATCH_59_DEMO_ROUTE_COVERAGE_POLISH.md
+++ b/docs/PATCH_59_DEMO_ROUTE_COVERAGE_POLISH.md
@@ -1,0 +1,44 @@
+# Patch 59 — Demo Route Coverage Polish
+
+## Summary
+
+Patch 59 improves VitaVault's public no-login demo coverage so reviewers can inspect collaboration and report-building workflows without needing a configured database.
+
+## What changed
+
+- Added a public `/demo/care-notes` page for the care-note collaboration layer.
+- Added a public `/demo/report-builder` page for report presets and saved report history.
+- Added both routes to the demo sidebar navigation.
+- Added both routes to the product-hub overview cards.
+- Updated demo copy to reflect care-note collaboration and report-builder coverage.
+- Added `tests/demo-route-coverage.test.ts` to prevent broken demo navigation links.
+
+## Safety
+
+- No Prisma migration.
+- No package changes.
+- No README changes.
+- No authenticated app route behavior changes.
+- No API behavior changes.
+- Public demo routes remain read-only and use static sample data.
+
+## Validation
+
+Recommended checks:
+
+```powershell
+npm install
+npm run db:validate:ci
+npm run actions:check
+npm run actions:imports
+npm run actions:shadow
+npm run typecheck
+npm run lint
+npm run test:run
+```
+
+Targeted test:
+
+```powershell
+npm run test:run -- tests/demo-route-coverage.test.ts
+```

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -41,6 +41,7 @@ export const demoNav: DemoNavItem[] = [
   { href: "/demo/doctors", label: "Doctors", description: "Care provider directory" },
   { href: "/demo/documents", label: "Documents", description: "Protected file index" },
   { href: "/demo/care-team", label: "Care Team", description: "Shared access preview" },
+  { href: "/demo/care-notes", label: "Care Notes", description: "Shared handoff notes" },
   { href: "/demo/ai-insights", label: "AI Insights", description: "AI-assisted summaries" },
   { href: "/demo/alerts", label: "Alerts", description: "Alert events and rules" },
   { href: "/demo/timeline", label: "Timeline", description: "Merged patient activity" },
@@ -48,6 +49,7 @@ export const demoNav: DemoNavItem[] = [
   { href: "/demo/review-queue", label: "Review Queue", description: "Care review workload" },
   { href: "/demo/summary", label: "Summary", description: "Patient handoff summary" },
   { href: "/demo/exports", label: "Exports", description: "Portable reports" },
+  { href: "/demo/report-builder", label: "Report Builder", description: "Custom packet builder" },
   { href: "/demo/device-connection", label: "Device Connections", description: "Connected data readiness" },
   { href: "/demo/device-sync-simulator", label: "Device Sync Simulator", description: "Connected-device sync demo" },
   { href: "/demo/audit-log", label: "Audit Log", description: "Unified audit trail" },
@@ -127,6 +129,25 @@ export const demoCareTeam = {
   ],
 };
 
+export const demoCareNotesHub = {
+  metrics: [
+    { label: "Open notes", value: "7", note: "2 clinical, 3 caregiver, 2 admin follow-ups" },
+    { label: "Linked records", value: "12", note: "Labs, symptoms, reminders, alerts, and documents" },
+    { label: "Unread replies", value: "3", note: "Doctor and caregiver handoff comments" },
+    { label: "Escalations", value: "2", note: "Items needing provider review before export" },
+  ],
+  notes: [
+    { title: "Endocrinology visit prep", category: "Clinical", author: "Dr. Angela Santos", status: "Needs review", detail: "Bring A1C, LDL, medication adherence, and foot tingling timeline into the visit packet." },
+    { title: "Caregiver medication observation", category: "Caregiver", author: "Marco Cruz", status: "Open", detail: "Atorvastatin was skipped twice this week because the evening alarm was missed." },
+    { title: "Lab document handoff", category: "Admin", author: "Admin Support", status: "Done", detail: "A1C lab PDF has been linked to the April 20 result and summary export." },
+  ],
+  workflow: [
+    "Care notes keep family, clinicians, and admin support aligned without exposing unrelated records.",
+    "Notes can be linked to alerts, labs, symptoms, reminders, documents, and report packets.",
+    "The real app uses permission checks so shared users only see notes within their approved scope.",
+  ],
+};
+
 export const demoAiInsights = [
   { title: "Blood sugar stability is improving", severity: "Positive", summary: "Recent fasting glucose and A1C trends suggest better adherence and diet consistency over the last 8 weeks." },
   { title: "Neuropathy watch signal", severity: "Monitor", summary: "Foot tingling has appeared twice this month. Recommend discussing neuropathy screening and vitamin B12 status." },
@@ -181,6 +202,27 @@ export const demoExports = [
   { name: "Document Index CSV", format: "CSV", status: "Ready", note: "Shows protected file access references" },
   { name: "Alerts Snapshot CSV", format: "CSV", status: "Ready", note: "Useful for admin review and handoff" },
 ];
+
+export const demoReportBuilderHub = {
+  presets: [
+    { name: "Doctor Visit Packet", audience: "Clinician", sections: "Profile, labs, vitals, medications, symptoms, notes", status: "Ready" },
+    { name: "Emergency Summary", audience: "Emergency contact", sections: "Allergies, conditions, medications, contacts", status: "Ready" },
+    { name: "Care Team Handoff", audience: "Caregiver", sections: "Tasks, reminders, notes, alerts, upcoming visits", status: "Draft" },
+    { name: "Device Review Export", audience: "Ops / QA", sections: "Connections, readings, sync jobs, stale providers", status: "Preview" },
+  ],
+  history: [
+    { title: "Endocrinology visit packet", generatedAt: "Apr 24, 2026 · 8:15 AM", format: "PDF", status: "Saved" },
+    { title: "Medication adherence CSV", generatedAt: "Apr 23, 2026 · 6:30 PM", format: "CSV", status: "Saved" },
+    { title: "Care team handoff packet", generatedAt: "Apr 22, 2026 · 9:10 AM", format: "PDF", status: "Archived" },
+  ],
+  checks: [
+    { label: "Patient identity", value: "Included" },
+    { label: "Recent labs", value: "Included" },
+    { label: "Open alerts", value: "Included" },
+    { label: "Care notes", value: "Included" },
+    { label: "Device context", value: "Optional" },
+  ],
+};
 
 export const demoDevices = [
   { provider: "Health Connect", status: "Active", lastSync: "15 minutes ago", readings: "Glucose, steps, weight" },
@@ -254,14 +296,14 @@ export const demoTourSteps = [
   {
     step: "02",
     title: "Review the care workflow hubs",
-    route: "/notifications",
+    route: "/demo/notifications",
     status: "Workflow hubs",
     body: "Notification Center, Care Plan, Visit Prep, and Emergency Card show how VitaVault turns records into next actions.",
   },
   {
     step: "03",
     title: "Inspect clinical review depth",
-    route: "/trends",
+    route: "/demo/trends",
     status: "Clinical review",
     body: "Health Trends, Medication Safety, Lab Review, Vitals Monitor, and Symptom Review show interpretation surfaces on top of records.",
   },
@@ -303,7 +345,7 @@ export const demoPersona = {
 };
 
 export const demoShowcaseMetrics = [
-  { label: "Demo modules", value: "25", note: "Public read-only pages plus a guided walkthrough for reviewers" },
+  { label: "Demo modules", value: "40", note: "Public read-only pages plus a guided walkthrough for reviewers" },
   { label: "Clinical records", value: "9", note: "Profile, meds, labs, vitals, symptoms, vaccines, doctors, documents, timeline" },
   { label: "Workflow layers", value: "12+", note: "Notifications, care plan, visit prep, alerts, reminders, review, exports, device sync, jobs" },
   { label: "Ops surfaces", value: "5", note: "Security, audit log, admin, ops, jobs, and reviewer-friendly controls" },
@@ -331,6 +373,7 @@ export const demoProductHubs = [
   { label: "Visit Prep", href: "/demo/visit-prep", layer: "Care workflow", body: "Provider-ready appointment prep with missing context, recent labs, symptoms, vitals, documents, and doctor packet handoff." },
   { label: "Data Quality Center", href: "/demo/data-quality", layer: "Care workflow", body: "Record cleanup command center for profile gaps, stale vitals, device sync health, alerts, report readiness, and care-team handoff quality." },
   { label: "Emergency Card", href: "/demo/emergency-card", layer: "Reports", body: "Printable emergency profile with blood type, allergies, conditions, contacts, active medications, and latest vitals." },
+  { label: "Care Notes", href: "/demo/care-notes", layer: "Care workflow", body: "Shared handoff notes connecting caregivers, clinicians, records, alerts, reminders, and report packets." },
   { label: "Health Trends", href: "/demo/trends", layer: "Clinical review", body: "Trend coverage, risk scoring, vital averages, lab flags, symptom severity, adherence, and merged clinical timeline." },
   { label: "Medication Safety", href: "/demo/medication-safety", layer: "Clinical review", body: "Dose board, adherence signal, missed/skipped rates, medication reminders, safety actions, and provider context." },
   { label: "Lab Review", href: "/demo/lab-review", layer: "Clinical review", body: "Lab readiness, abnormal/borderline action queue, trend cards, document coverage, and provider review guidance." },
@@ -339,13 +382,14 @@ export const demoProductHubs = [
   { label: "Device Sync Simulator", href: "/demo/device-sync-simulator", layer: "Platform", body: "Simulated Apple Health, Health Connect, BP monitor, pulse ox, and smart scale sync flow for reviewer demos." },
   { label: "Audit Log", href: "/demo/audit-log", layer: "Security/Ops", body: "Unified audit feed for care access, alerts, reminders, jobs, and mobile/API session events." },
   { label: "Mobile API Docs", href: "/demo/api-docs", layer: "Platform", body: "Product-facing documentation for mobile login, bearer sessions, device connections, and reading ingestion." },
+  { label: "Report Builder", href: "/demo/report-builder", layer: "Reports", body: "Custom patient, doctor, emergency, device, and care-team packets with saved report history." },
 ];
 
 export const demoFeatureMatrix = [
   { layer: "Patient records", modules: "Profile, medications, appointments, doctors, labs, vitals, symptoms, vaccines, documents", value: "Broad structured health data coverage" },
   { layer: "Care workflows", modules: "Notifications, care plan, visit prep, data quality, reminders, alerts, review queue", value: "Turns stored records into clear next actions" },
   { layer: "Clinical review", modules: "Trends, medication safety, lab review, vitals monitor, symptom review", value: "Adds interpretation surfaces without requiring a new schema" },
-  { layer: "Reports", modules: "Summary packet, emergency card, exports, print views", value: "Supports doctor visits and portable handoffs" },
+  { layer: "Reports", modules: "Summary packet, emergency card, report builder, exports, print views", value: "Supports doctor visits and portable handoffs" },
   { layer: "Platform", modules: "Device sync APIs, jobs, ops, admin, audit, security", value: "Shows production-minded backend and operations work" },
 ];
 

--- a/tests/demo-route-coverage.test.ts
+++ b/tests/demo-route-coverage.test.ts
@@ -1,0 +1,46 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { demoNav, demoProductHubs, demoTourSteps } from "@/lib/demo-data";
+
+function demoPagePathForHref(href: string) {
+  if (href === "/demo") {
+    return join(process.cwd(), "app", "demo", "page.tsx");
+  }
+
+  const demoSegment = href.replace(/^\/demo\/?/, "");
+  return join(process.cwd(), "app", "demo", demoSegment, "page.tsx");
+}
+
+describe("demo route coverage", () => {
+  it("keeps every sidebar demo link backed by a public demo page", () => {
+    const missingPages = demoNav
+      .map((item) => ({ href: item.href, path: demoPagePathForHref(item.href) }))
+      .filter((item) => !existsSync(item.path));
+
+    expect(missingPages).toEqual([]);
+  });
+
+  it("keeps every product hub card linked to a public demo page", () => {
+    const missingHubPages = demoProductHubs
+      .map((item) => ({ href: item.href, path: demoPagePathForHref(item.href) }))
+      .filter((item) => !existsSync(item.path));
+
+    expect(missingHubPages).toEqual([]);
+  });
+
+  it("keeps every guided walkthrough step linked to a public demo page", () => {
+    const missingTourPages = demoTourSteps
+      .map((item) => ({ href: item.route, path: demoPagePathForHref(item.route) }))
+      .filter((item) => !existsSync(item.path));
+
+    expect(missingTourPages).toEqual([]);
+  });
+
+  it("includes collaboration and report-builder surfaces in the no-login demo", () => {
+    const hrefs = new Set(demoNav.map((item) => item.href));
+
+    expect(hrefs.has("/demo/care-notes")).toBe(true);
+    expect(hrefs.has("/demo/report-builder")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

This patch improves VitaVault's public no-login demo coverage by adding missing collaboration and report-building demo surfaces.

## Changes

- Added `/demo/care-notes`
- Added `/demo/report-builder`
- Added both pages to the public demo navigation
- Added both pages to the product hub cards
- Fixed guided walkthrough links that were missing the `/demo` prefix
- Added demo route coverage tests to catch broken demo links
- Added Patch 59 documentation under `docs/`

## Safety

- No Prisma migration
- No package changes
- No README changes
- No authenticated route behavior changes
- No API behavior changes
- Public demo pages remain static and read-only

## Checks

Run locally:

```powershell
npm install
npm run db:validate:ci
npm run actions:check
npm run actions:imports
npm run actions:shadow
npm run typecheck
npm run lint
npm run test:run