### PR TITLE
Harden saved report history UX

### DIFF
--- a/app/report-builder/actions.ts
+++ b/app/report-builder/actions.ts
@@ -46,7 +46,7 @@ async function getOwnedSavedReport(reportId: string, userId: string) {
   if (!reportId) throw new Error("Saved report id is required.");
   const report = await db.savedReport.findFirst({
     where: { id: reportId, userId },
-    select: { id: true, title: true, status: true, archivedAt: true, reportType: true, presetId: true },
+    select: { id: true, title: true, status: true, archivedAt: true, reportType: true, presetId: true, readinessScore: true },
   });
   if (!report) throw new Error("Saved report not found.");
   return report;
@@ -106,6 +106,15 @@ export async function saveReportPacketAction(formData: FormData) {
   revalidateReportPages();
 }
 
+export async function markSavedReportReviewAction(formData: FormData) {
+  const user = await requireUser();
+  const report = await getOwnedSavedReport(formString(formData, "reportId"), user.id!);
+  if (report.archivedAt) throw new Error("Archived reports cannot be moved back to review until restored.");
+  await db.savedReport.update({ where: { id: report.id }, data: { status: SavedReportStatus.REVIEW } });
+  await writeReportAudit({ ownerUserId: user.id!, actorUserId: user.id!, action: "SAVED_REPORT_MARKED_REVIEW", reportId: report.id, metadata: { previousStatus: report.status } });
+  revalidateReportPages();
+}
+
 export async function markSavedReportSharedAction(formData: FormData) {
   const user = await requireUser();
   const report = await getOwnedSavedReport(formString(formData, "reportId"), user.id!);
@@ -120,5 +129,14 @@ export async function archiveSavedReportAction(formData: FormData) {
   const report = await getOwnedSavedReport(formString(formData, "reportId"), user.id!);
   await db.savedReport.update({ where: { id: report.id }, data: { status: SavedReportStatus.ARCHIVED, archivedAt: new Date() } });
   await writeReportAudit({ ownerUserId: user.id!, actorUserId: user.id!, action: "SAVED_REPORT_ARCHIVED", reportId: report.id, metadata: { previousStatus: report.status } });
+  revalidateReportPages();
+}
+
+export async function restoreSavedReportAction(formData: FormData) {
+  const user = await requireUser();
+  const report = await getOwnedSavedReport(formString(formData, "reportId"), user.id!);
+  const restoredStatus = savedReportStatusFromReadiness(report.readinessScore);
+  await db.savedReport.update({ where: { id: report.id }, data: { status: restoredStatus, archivedAt: null } });
+  await writeReportAudit({ ownerUserId: user.id!, actorUserId: user.id!, action: "SAVED_REPORT_RESTORED", reportId: report.id, metadata: { previousStatus: report.status, restoredStatus } });
   revalidateReportPages();
 }

--- a/app/report-builder/page.tsx
+++ b/app/report-builder/page.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 import { ArrowRight, CalendarDays, CheckCircle2, FileText, Printer, Save, SlidersHorizontal } from "lucide-react";
+import { SavedReportStatus } from "@prisma/client";
 import { AppShell } from "@/components/app-shell";
-import { archiveSavedReportAction, markSavedReportSharedAction, saveReportPacketAction } from "@/app/report-builder/actions";
+import { archiveSavedReportAction, markSavedReportReviewAction, markSavedReportSharedAction, restoreSavedReportAction, saveReportPacketAction } from "@/app/report-builder/actions";
 import { EmptyState, PageHeader, StatusPill } from "@/components/common";
 import { Badge, Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Input, Label, Select } from "@/components/ui";
 import { DataCard, ModuleHero } from "@/components/module-sections";
@@ -16,7 +17,7 @@ import {
   type ReportHistoryItem,
   type ReportType,
 } from "@/lib/report-builder";
-import type { SavedReportHistoryItem } from "@/lib/report-history";
+import type { SavedReportHistoryFilter, SavedReportHistoryItem } from "@/lib/report-history";
 
 const reportTypeOptions: Array<{ value: ReportType; label: string; description: string }> = [
   { value: "patient", label: "Patient summary", description: "Broad personal record packet" },
@@ -40,6 +41,28 @@ function historyTone(status: ReportHistoryItem["status"]) {
 
 function formatDateTime(value: Date) {
   return new Intl.DateTimeFormat("en-PH", { dateStyle: "medium", timeStyle: "short" }).format(value);
+}
+
+
+type ReportBuilderSearchParams = Record<string, string | string[] | undefined>;
+
+function searchParamValue(params: ReportBuilderSearchParams, key: string) {
+  const value = params[key];
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function buildReportBuilderHistoryHref(params: ReportBuilderSearchParams, history: SavedReportHistoryFilter) {
+  const query = new URLSearchParams();
+
+  for (const key of ["preset", "type", "sections", "from", "to"]) {
+    const value = searchParamValue(params, key);
+    if (value) query.set(key, value);
+  }
+
+  if (history !== "active") query.set("history", history);
+
+  const serialized = query.toString();
+  return `/report-builder${serialized ? `?${serialized}` : ""}`;
 }
 
 function ProgressBar({ value }: { value: number }) {
@@ -73,23 +96,46 @@ function SavedReportCard({ item }: { item: SavedReportHistoryItem }) {
   return (
     <div className="rounded-2xl border border-border/60 bg-background/50 p-4">
       <div className="flex items-start justify-between gap-3">
-        <StatusPill tone={item.tone}>{item.statusLabel}</StatusPill>
+        <div className="flex flex-wrap gap-2">
+          <StatusPill tone={item.tone}>{item.statusLabel}</StatusPill>
+          {item.presetLabel ? <Badge>{item.presetLabel}</Badge> : null}
+        </div>
         <Badge>{item.readinessScore}% ready</Badge>
       </div>
       <p className="mt-3 font-medium">{item.title}</p>
       <p className="mt-1 text-sm text-muted-foreground">{item.description}</p>
-      <p className="mt-3 text-xs text-muted-foreground">Saved {formatDateTime(item.createdAt)} • {item.recordCount} item{item.recordCount === 1 ? "" : "s"}</p>
+      <p className="mt-3 text-xs text-muted-foreground">
+        Saved {formatDateTime(item.createdAt)} • {item.recordCount} item{item.recordCount === 1 ? "" : "s"}
+        {item.archivedAt ? ` • Archived ${formatDateTime(item.archivedAt)}` : ""}
+      </p>
       <div className="mt-4 flex flex-wrap gap-2">
         <Link href={item.packetHref} className="inline-flex h-9 items-center justify-center rounded-xl border border-border/70 bg-background/60 px-3 text-xs font-medium transition hover:bg-muted/60">Open</Link>
         <Link href={item.printHref} className="inline-flex h-9 items-center justify-center rounded-xl border border-border/70 bg-background/60 px-3 text-xs font-medium transition hover:bg-muted/60">Print</Link>
-        <form action={markSavedReportSharedAction}>
-          <input type="hidden" name="reportId" value={item.id} />
-          <Button type="submit" variant="ghost" size="sm">Mark shared</Button>
-        </form>
-        <form action={archiveSavedReportAction}>
-          <input type="hidden" name="reportId" value={item.id} />
-          <Button type="submit" variant="ghost" size="sm">Archive</Button>
-        </form>
+        {item.isArchived ? (
+          <form action={restoreSavedReportAction}>
+            <input type="hidden" name="reportId" value={item.id} />
+            <Button type="submit" variant="ghost" size="sm">Restore</Button>
+          </form>
+        ) : (
+          <>
+            {item.status !== SavedReportStatus.REVIEW ? (
+              <form action={markSavedReportReviewAction}>
+                <input type="hidden" name="reportId" value={item.id} />
+                <Button type="submit" variant="ghost" size="sm">Mark review</Button>
+              </form>
+            ) : null}
+            {item.status !== SavedReportStatus.SHARED ? (
+              <form action={markSavedReportSharedAction}>
+                <input type="hidden" name="reportId" value={item.id} />
+                <Button type="submit" variant="ghost" size="sm">Mark shared</Button>
+              </form>
+            ) : null}
+            <form action={archiveSavedReportAction}>
+              <input type="hidden" name="reportId" value={item.id} />
+              <Button type="submit" variant="ghost" size="sm">Archive</Button>
+            </form>
+          </>
+        )}
       </div>
     </div>
   );
@@ -116,7 +162,8 @@ export default async function ReportBuilderPage({ searchParams }: { searchParams
   const sections = Array.isArray(params.sections) ? params.sections.join(",") : typeof params.sections === "string" ? params.sections : undefined;
   const from = typeof params.from === "string" ? params.from : "";
   const to = typeof params.to === "string" ? params.to : "";
-  const data = await getReportBuilderData({ preset, reportType, sections, from, to });
+  const history = typeof params.history === "string" ? params.history : undefined;
+  const data = await getReportBuilderData({ preset, reportType, sections, from, to, history });
   const selectedSectionsQuery = sectionQuery(data.selectedSections);
   const printHref = buildReportPrintHref({ preset: data.selectedPreset?.id, reportType: data.reportType, sections: selectedSectionsQuery, from: data.range.from, to: data.range.to });
 
@@ -338,15 +385,32 @@ export default async function ReportBuilderPage({ searchParams }: { searchParams
           </CardHeader>
           <CardContent className="space-y-5">
             <div className="grid gap-3 sm:grid-cols-5">
-              <DataCard className="rounded-2xl p-4"><p className="text-xs text-muted-foreground">Saved</p><p className="mt-1 text-2xl font-semibold">{data.savedReportStats.total}</p></DataCard>
-              <DataCard className="rounded-2xl p-4"><p className="text-xs text-muted-foreground">Generated</p><p className="mt-1 text-2xl font-semibold">{data.savedReportStats.generated}</p></DataCard>
+              <DataCard className="rounded-2xl p-4"><p className="text-xs text-muted-foreground">Active</p><p className="mt-1 text-2xl font-semibold">{data.savedReportStats.active}</p></DataCard>
               <DataCard className="rounded-2xl p-4"><p className="text-xs text-muted-foreground">Review</p><p className="mt-1 text-2xl font-semibold">{data.savedReportStats.review}</p></DataCard>
               <DataCard className="rounded-2xl p-4"><p className="text-xs text-muted-foreground">Shared</p><p className="mt-1 text-2xl font-semibold">{data.savedReportStats.shared}</p></DataCard>
+              <DataCard className="rounded-2xl p-4"><p className="text-xs text-muted-foreground">Archived</p><p className="mt-1 text-2xl font-semibold">{data.savedReportStats.archived}</p></DataCard>
               <DataCard className="rounded-2xl p-4"><p className="text-xs text-muted-foreground">Avg. readiness</p><p className="mt-1 text-2xl font-semibold">{data.savedReportStats.averageReadiness}%</p></DataCard>
             </div>
+
+            <div className="flex flex-wrap gap-2">
+              {data.savedReportHistoryFilters.map((filter) => {
+                const isActive = data.savedReportHistoryFilter === filter.value;
+                return (
+                  <Link
+                    key={filter.value}
+                    href={buildReportBuilderHistoryHref(params, filter.value)}
+                    className={`inline-flex h-9 items-center justify-center rounded-xl border px-3 text-xs font-medium transition ${isActive ? "border-primary/50 bg-primary/10 text-primary" : "border-border/70 bg-background/60 hover:bg-muted/60"}`}
+                    title={filter.description}
+                  >
+                    {filter.label}
+                  </Link>
+                );
+              })}
+            </div>
+
             <div className="grid gap-3 md:grid-cols-3">
               {data.savedReports.map((item) => <SavedReportCard key={item.id} item={item} />)}
-              {data.savedReports.length === 0 ? <EmptyState title="No saved reports yet" description="Save the current packet to create a real report history record." /> : null}
+              {data.savedReports.length === 0 ? <EmptyState title="No saved reports in this view" description="Save the current packet or switch history filters to review older packets." /> : null}
             </div>
           </CardContent>
         </Card>

--- a/docs/PATCH_60_REPORT_HISTORY_UX_HARDENING.md
+++ b/docs/PATCH_60_REPORT_HISTORY_UX_HARDENING.md
@@ -1,0 +1,53 @@
+# Patch 60 — Report History UX Hardening
+
+## Summary
+
+This patch improves the report builder's saved report history workflow without changing the database schema.
+
+## What changed
+
+- Added saved report history filters for active, review, shared, archived, and all packets.
+- Added archived packet visibility through the report builder history filter.
+- Added restore support for archived saved reports.
+- Added a mark-review action for packets that need another review cycle.
+- Updated report history statistics to count active and archived packets separately.
+- Preserved existing report opening, print preview, mark-shared, and archive workflows.
+- Added helper coverage for saved report filters, status summaries, and history mapping.
+
+## Safety
+
+- No Prisma migration.
+- No package changes.
+- No README changes.
+- No API route changes.
+- Existing `SavedReport` fields are reused.
+- Archived reports remain hidden from the default active view until the archived/all filters are selected.
+
+## Files changed
+
+- `app/report-builder/page.tsx`
+- `app/report-builder/actions.ts`
+- `lib/report-builder.ts`
+- `lib/report-history.ts`
+- `tests/report-history.test.ts`
+
+## Validation
+
+Run the standard local checks after applying the patch:
+
+```powershell
+npm install
+npm run db:validate:ci
+npm run actions:check
+npm run actions:imports
+npm run actions:shadow
+npm run typecheck
+npm run lint
+npm run test:run
+```
+
+Targeted test:
+
+```powershell
+npm run test:run -- tests/report-history.test.ts
+```

--- a/lib/report-builder.ts
+++ b/lib/report-builder.ts
@@ -18,7 +18,7 @@ import {
   type ReportType,
 } from "@/lib/report-builder-presets";
 import { requireUser } from "@/lib/session";
-import { mapSavedReportToHistoryItem, summarizeSavedReportStats } from "@/lib/report-history";
+import { buildSavedReportHistoryWhere, mapSavedReportToHistoryItem, normalizeSavedReportHistoryFilter, savedReportHistoryFilterOptions, summarizeSavedReportStats } from "@/lib/report-history";
 
 export { buildReportBuilderHref, buildReportPrintHref, reportBuilderPresets, sectionQuery } from "@/lib/report-builder-presets";
 export type { ReportPresetDefinition, ReportPresetId, ReportSectionKey, ReportType } from "@/lib/report-builder-presets";
@@ -29,6 +29,7 @@ export type ReportBuilderOptions = {
   sections?: string;
   from?: string;
   to?: string;
+  history?: string;
 };
 
 export type ReportSectionDefinition = {
@@ -166,6 +167,8 @@ export async function getReportBuilderData(options: ReportBuilderOptions = {}) {
   const from = parseDate(controls.from);
   const to = parseDate(controls.to);
   const selectedPreset = getReportBuilderPreset(controls.presetId);
+  const savedReportHistoryFilter = normalizeSavedReportHistoryFilter(options.history);
+  const savedReportHistoryWhere = buildSavedReportHistoryWhere(user.id!, savedReportHistoryFilter);
   const thirtyDaysAgo = new Date(now);
   thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
@@ -185,6 +188,7 @@ export async function getReportBuilderData(options: ReportBuilderOptions = {}) {
     careAccess,
     careNotes,
     savedReports,
+    savedReportStatsSource,
     aiInsight,
   ] = await Promise.all([
     db.healthProfile.findUnique({ where: { userId: user.id } }),
@@ -257,7 +261,7 @@ export async function getReportBuilderData(options: ReportBuilderOptions = {}) {
       include: { author: { select: { name: true, email: true, role: true } } },
     }),
     db.savedReport.findMany({
-      where: { userId: user.id, archivedAt: null },
+      where: savedReportHistoryWhere,
       orderBy: { createdAt: "desc" },
       take: 6,
       select: {
@@ -276,7 +280,12 @@ export async function getReportBuilderData(options: ReportBuilderOptions = {}) {
         printHref: true,
         createdAt: true,
         updatedAt: true,
+        archivedAt: true,
       },
+    }),
+    db.savedReport.findMany({
+      where: { userId: user.id },
+      select: { status: true, readinessScore: true, archivedAt: true },
     }),
     db.aiInsight.findFirst({
       where: { ownerUserId: user.id },
@@ -413,7 +422,9 @@ export async function getReportBuilderData(options: ReportBuilderOptions = {}) {
       medicationAdherenceRate,
     },
     savedReports: savedReports.map(mapSavedReportToHistoryItem),
-    savedReportStats: summarizeSavedReportStats(savedReports),
+    savedReportStats: summarizeSavedReportStats(savedReportStatsSource),
+    savedReportHistoryFilter,
+    savedReportHistoryFilters: savedReportHistoryFilterOptions,
     profile,
     medications,
     appointments,

--- a/lib/report-history.ts
+++ b/lib/report-history.ts
@@ -3,6 +3,14 @@ import { getReportBuilderPreset, type ReportSectionKey, type ReportType } from "
 
 export type SavedReportHistoryTone = "neutral" | "info" | "success" | "warning" | "danger";
 
+export type SavedReportHistoryFilter = "active" | "all" | "draft" | "generated" | "review" | "shared" | "archived";
+
+export type SavedReportHistoryFilterOption = {
+  value: SavedReportHistoryFilter;
+  label: string;
+  description: string;
+};
+
 export type SavedReportHistoryItem = {
   id: string;
   title: string;
@@ -19,16 +27,42 @@ export type SavedReportHistoryItem = {
   rangeLabel: string;
   createdAt: Date;
   updatedAt: Date;
+  archivedAt?: Date | null;
+  isArchived: boolean;
 };
 
 export type SavedReportStats = {
   total: number;
+  active: number;
   generated: number;
   review: number;
   shared: number;
   archived: number;
   averageReadiness: number;
 };
+
+export const savedReportHistoryFilterOptions: SavedReportHistoryFilterOption[] = [
+  { value: "active", label: "Active", description: "Generated, review, shared, and draft packets that are still in use." },
+  { value: "review", label: "Needs review", description: "Packets that should be checked before sharing." },
+  { value: "shared", label: "Shared", description: "Packets already marked as sent or handed off." },
+  { value: "archived", label: "Archived", description: "Older packets hidden from the default working view." },
+  { value: "all", label: "All", description: "Every saved packet, including archived history." },
+];
+
+const savedReportHistoryFilterValues = new Set<SavedReportHistoryFilter>([
+  "active",
+  "all",
+  "draft",
+  "generated",
+  "review",
+  "shared",
+  "archived",
+]);
+
+export function normalizeSavedReportHistoryFilter(value: string | undefined): SavedReportHistoryFilter {
+  const normalized = value?.trim().toLowerCase();
+  return normalized && savedReportHistoryFilterValues.has(normalized as SavedReportHistoryFilter) ? (normalized as SavedReportHistoryFilter) : "active";
+}
 
 export function savedReportStatusLabel(status: SavedReportStatus) {
   if (status === SavedReportStatus.DRAFT) return "Draft";
@@ -48,6 +82,16 @@ export function savedReportStatusTone(status: SavedReportStatus): SavedReportHis
 
 export function savedReportStatusFromReadiness(readinessScore: number) {
   return readinessScore >= 75 ? SavedReportStatus.GENERATED : SavedReportStatus.REVIEW;
+}
+
+export function buildSavedReportHistoryWhere(userId: string, filter: SavedReportHistoryFilter) {
+  if (filter === "all") return { userId };
+  if (filter === "archived") return { userId, archivedAt: { not: null } };
+  if (filter === "draft") return { userId, status: SavedReportStatus.DRAFT, archivedAt: null };
+  if (filter === "generated") return { userId, status: SavedReportStatus.GENERATED, archivedAt: null };
+  if (filter === "review") return { userId, status: SavedReportStatus.REVIEW, archivedAt: null };
+  if (filter === "shared") return { userId, status: SavedReportStatus.SHARED, archivedAt: null };
+  return { userId, archivedAt: null };
 }
 
 export function parseSavedReportSections(value: string | null | undefined): ReportSectionKey[] {
@@ -86,10 +130,12 @@ export function mapSavedReportToHistoryItem(report: {
   printHref: string;
   createdAt: Date;
   updatedAt: Date;
+  archivedAt?: Date | null;
 }): SavedReportHistoryItem {
   const sections = parseSavedReportSections(report.sectionsJson);
   const rangeLabel = formatSavedReportRange(report.fromDate, report.toDate);
   const preset = getReportBuilderPreset(report.presetId || undefined);
+  const isArchived = Boolean(report.archivedAt) || report.status === SavedReportStatus.ARCHIVED;
 
   return {
     id: report.id,
@@ -107,10 +153,12 @@ export function mapSavedReportToHistoryItem(report: {
     rangeLabel,
     createdAt: report.createdAt,
     updatedAt: report.updatedAt,
+    archivedAt: report.archivedAt,
+    isArchived,
   };
 }
 
-export function summarizeSavedReportStats(reports: Array<{ status: SavedReportStatus; readinessScore: number }>): SavedReportStats {
+export function summarizeSavedReportStats(reports: Array<{ status: SavedReportStatus; readinessScore: number; archivedAt?: Date | null }>): SavedReportStats {
   const total = reports.length;
   const byStatus = reports.reduce(
     (acc, report) => {
@@ -120,12 +168,15 @@ export function summarizeSavedReportStats(reports: Array<{ status: SavedReportSt
     {} as Record<SavedReportStatus, number>,
   );
 
+  const archived = reports.filter((report) => report.archivedAt || report.status === SavedReportStatus.ARCHIVED).length;
+
   return {
     total,
+    active: Math.max(0, total - archived),
     generated: byStatus[SavedReportStatus.GENERATED] || 0,
     review: byStatus[SavedReportStatus.REVIEW] || 0,
     shared: byStatus[SavedReportStatus.SHARED] || 0,
-    archived: byStatus[SavedReportStatus.ARCHIVED] || 0,
+    archived,
     averageReadiness: total > 0 ? Math.round(reports.reduce((sum, report) => sum + report.readinessScore, 0) / total) : 0,
   };
 }

--- a/tests/report-history.test.ts
+++ b/tests/report-history.test.ts
@@ -2,13 +2,16 @@ import { describe, expect, it } from "vitest";
 import { SavedReportStatus } from "@prisma/client";
 import {
   buildSavedReportDescription,
+  buildSavedReportHistoryWhere,
   formatSavedReportRange,
   mapSavedReportToHistoryItem,
+  normalizeSavedReportHistoryFilter,
   parseSavedReportSections,
   savedReportStatusFromReadiness,
   savedReportStatusLabel,
   savedReportStatusTone,
   summarizeSavedReportStats,
+  savedReportHistoryFilterOptions,
 } from "@/lib/report-history";
 
 describe("report history helpers", () => {
@@ -30,16 +33,31 @@ describe("report history helpers", () => {
 
   it("summarizes saved report stats", () => {
     const stats = summarizeSavedReportStats([
-      { status: SavedReportStatus.GENERATED, readinessScore: 90 },
-      { status: SavedReportStatus.REVIEW, readinessScore: 60 },
-      { status: SavedReportStatus.SHARED, readinessScore: 80 },
+      { status: SavedReportStatus.GENERATED, readinessScore: 90, archivedAt: null },
+      { status: SavedReportStatus.REVIEW, readinessScore: 60, archivedAt: null },
+      { status: SavedReportStatus.SHARED, readinessScore: 80, archivedAt: null },
+      { status: SavedReportStatus.ARCHIVED, readinessScore: 70, archivedAt: new Date("2026-05-02T00:00:00.000Z") },
     ]);
 
-    expect(stats.total).toBe(3);
+    expect(stats.total).toBe(4);
+    expect(stats.active).toBe(3);
     expect(stats.generated).toBe(1);
     expect(stats.review).toBe(1);
     expect(stats.shared).toBe(1);
-    expect(stats.averageReadiness).toBe(77);
+    expect(stats.archived).toBe(1);
+    expect(stats.averageReadiness).toBe(75);
+  });
+
+
+  it("normalizes and builds saved report history filters", () => {
+    expect(normalizeSavedReportHistoryFilter(undefined)).toBe("active");
+    expect(normalizeSavedReportHistoryFilter("SHARED")).toBe("shared");
+    expect(normalizeSavedReportHistoryFilter("bad-filter")).toBe("active");
+    expect(savedReportHistoryFilterOptions.map((option) => option.value)).toContain("archived");
+
+    expect(buildSavedReportHistoryWhere("user_1", "active")).toEqual({ userId: "user_1", archivedAt: null });
+    expect(buildSavedReportHistoryWhere("user_1", "archived")).toEqual({ userId: "user_1", archivedAt: { not: null } });
+    expect(buildSavedReportHistoryWhere("user_1", "review")).toEqual({ userId: "user_1", status: SavedReportStatus.REVIEW, archivedAt: null });
   });
 
   it("maps database records to history cards", () => {
@@ -60,6 +78,7 @@ describe("report history helpers", () => {
       printHref: "/report-builder/print?type=doctor",
       createdAt,
       updatedAt: createdAt,
+      archivedAt: null,
     });
 
     expect(item.presetLabel).toBe("Doctor visit packet");


### PR DESCRIPTION
## Summary

This patch improves VitaVault's report builder history workflow by making saved packets easier to filter, review, archive, and restore.

## Changes

- Added saved report history filters for active, review, shared, archived, and all packets
- Added archived packet visibility from the report builder history section
- Added restore support for archived saved reports
- Added a mark-review action for active saved reports
- Improved saved report history stats
- Updated saved report cards with preset labels, archived dates, and contextual actions
- Added report-history helper test coverage
- Added Patch 60 documentation under `docs/`

## Safety

- No Prisma migration
- No dependency changes
- No README changes
- No API route changes
- Uses the existing `SavedReport` model only
- Archived reports remain hidden from the default active view until filtered

## Checks

Run locally:

```powershell
npm install
npm run db:validate:ci
npm run actions:check
npm run actions:imports
npm run actions:shadow
npm run typecheck
npm run lint
npm run test:run