### PR TITLE
Enforce care team permission rules

### DIFF
--- a/app/care-team/actions.ts
+++ b/app/care-team/actions.ts
@@ -8,14 +8,24 @@ import { redirect } from "next/navigation";
 import { db } from "@/lib/db";
 import { requireUser } from "@/lib/session";
 import { logAccessAudit } from "@/lib/access";
-import { CareAccessRole } from "@prisma/client";
+import type { CareAccessRole } from "@prisma/client";
 
 import { sendCareInviteEmail } from "@/lib/invite-email";
+import { normalizeCarePermissionInput } from "@/lib/care-permissions";
 
 function boolFromForm(formData: FormData, key: string) {
   return formData.get(key) === "on";
 }
 
+function permissionsFromForm(formData: FormData) {
+  return normalizeCarePermissionInput({
+    canViewRecords: boolFromForm(formData, "canViewRecords"),
+    canEditRecords: boolFromForm(formData, "canEditRecords"),
+    canAddNotes: boolFromForm(formData, "canAddNotes"),
+    canExport: boolFromForm(formData, "canExport"),
+    canGenerateAIInsights: boolFromForm(formData, "canGenerateAIInsights"),
+  });
+}
 
 function getAppOrigin() {
   return (
@@ -68,6 +78,14 @@ async function activateInviteForActor(args: {
     throw new Error("Invite not found or expired.");
   }
 
+  const permissions = normalizeCarePermissionInput({
+    canViewRecords: invite.canViewRecords,
+    canEditRecords: invite.canEditRecords,
+    canAddNotes: invite.canAddNotes,
+    canExport: invite.canExport,
+    canGenerateAIInsights: invite.canGenerateAIInsights,
+  });
+
   const access = await db.careAccess.upsert({
     where: {
       ownerUserId_memberUserId: {
@@ -78,11 +96,7 @@ async function activateInviteForActor(args: {
     update: {
       accessRole: invite.accessRole,
       status: "ACTIVE",
-      canViewRecords: invite.canViewRecords,
-      canEditRecords: invite.canEditRecords,
-      canAddNotes: invite.canAddNotes,
-      canExport: invite.canExport,
-      canGenerateAIInsights: invite.canGenerateAIInsights,
+      ...permissions,
       grantedByUserId: invite.grantedByUserId,
       note: invite.note,
     },
@@ -91,11 +105,7 @@ async function activateInviteForActor(args: {
       memberUserId: args.actorId,
       accessRole: invite.accessRole,
       status: "ACTIVE",
-      canViewRecords: invite.canViewRecords,
-      canEditRecords: invite.canEditRecords,
-      canAddNotes: invite.canAddNotes,
-      canExport: invite.canExport,
-      canGenerateAIInsights: invite.canGenerateAIInsights,
+      ...permissions,
       grantedByUserId: invite.grantedByUserId,
       note: invite.note,
     },
@@ -176,6 +186,7 @@ export async function inviteCareMemberAction(formData: FormData) {
   const email = String(formData.get("email") || "").trim().toLowerCase();
   const accessRole = String(formData.get("accessRole") || "CAREGIVER") as CareAccessRole;
   const note = String(formData.get("note") || "").trim() || null;
+  const permissions = permissionsFromForm(formData);
 
   if (!email) {
     throw new Error("Email is required.");
@@ -197,11 +208,7 @@ export async function inviteCareMemberAction(formData: FormData) {
       status: "PENDING",
       token: randomUUID(),
       grantedByUserId: actor.id,
-      canViewRecords: boolFromForm(formData, "canViewRecords"),
-      canEditRecords: boolFromForm(formData, "canEditRecords"),
-      canAddNotes: boolFromForm(formData, "canAddNotes"),
-      canExport: boolFromForm(formData, "canExport"),
-      canGenerateAIInsights: boolFromForm(formData, "canGenerateAIInsights"),
+      ...permissions,
       note,
       expiresAt: addDays(new Date(), 7),
       acceptedAt: null,
@@ -213,11 +220,7 @@ export async function inviteCareMemberAction(formData: FormData) {
       status: "PENDING",
       token: randomUUID(),
       grantedByUserId: actor.id,
-      canViewRecords: boolFromForm(formData, "canViewRecords"),
-      canEditRecords: boolFromForm(formData, "canEditRecords"),
-      canAddNotes: boolFromForm(formData, "canAddNotes"),
-      canExport: boolFromForm(formData, "canExport"),
-      canGenerateAIInsights: boolFromForm(formData, "canGenerateAIInsights"),
+      ...permissions,
       note,
       expiresAt: addDays(new Date(), 7),
     },
@@ -480,6 +483,8 @@ export async function revokeCareAccessAction(formData: FormData) {
     throw new Error("Access record not found.");
   }
 
+  const permissions = permissionsFromForm(formData);
+
   await db.careAccess.update({
     where: { id: access.id },
     data: {
@@ -521,14 +526,12 @@ export async function updateCareAccessPermissionsAction(formData: FormData) {
     throw new Error("Access record not found.");
   }
 
+  const permissions = permissionsFromForm(formData);
+
   await db.careAccess.update({
     where: { id: access.id },
     data: {
-      canViewRecords: boolFromForm(formData, "canViewRecords"),
-      canEditRecords: boolFromForm(formData, "canEditRecords"),
-      canAddNotes: boolFromForm(formData, "canAddNotes"),
-      canExport: boolFromForm(formData, "canExport"),
-      canGenerateAIInsights: boolFromForm(formData, "canGenerateAIInsights"),
+      ...permissions,
       note: String(formData.get("note") || "").trim() || null,
     },
   });

--- a/docs/PATCH_61_CARE_TEAM_PERMISSION_ENFORCEMENT.md
+++ b/docs/PATCH_61_CARE_TEAM_PERMISSION_ENFORCEMENT.md
@@ -1,0 +1,45 @@
+# Patch 61 — Care Team Permission Enforcement Audit
+
+## Summary
+
+This patch centralizes VitaVault care-team permission checks so shared patient workflows use one consistent permission matrix instead of repeating flag logic in multiple places.
+
+## What changed
+
+- Added `lib/care-permissions.ts` with shared permission helpers.
+- Updated `requireOwnerAccess()` to use the shared permission evaluator.
+- Updated care-team invite/update flows so advanced permissions imply view access before they are saved.
+- Updated caregiver workspace permission cards to use the shared permission matrix.
+- Added `tests/care-permissions.test.ts` for owner access, view dependency, scoped permission mapping, grant normalization, and workflow audit coverage.
+
+## Safety
+
+- No Prisma migration.
+- No package changes.
+- No README changes.
+- No route changes.
+- No database schema changes.
+- Existing permission booleans are reused.
+
+## Notes
+
+Scoped permissions such as edit, notes, export, and AI now depend on view access. This keeps care-team records consistent because a caregiver should not be able to act on a shared patient record they cannot view.
+
+## Recommended checks
+
+```powershell
+npm install
+npm run db:validate:ci
+npm run actions:check
+npm run actions:imports
+npm run actions:shadow
+npm run typecheck
+npm run lint
+npm run test:run
+```
+
+Targeted test:
+
+```powershell
+npm run test:run -- tests/care-permissions.test.ts
+```

--- a/lib/access.ts
+++ b/lib/access.ts
@@ -1,13 +1,8 @@
-import { CareAccessRole } from "@prisma/client";
+import type { CareAccessRole } from "@prisma/client";
 import { db } from "@/lib/db";
+import { canUseCarePermission, type CarePermission } from "@/lib/care-permissions";
 
-export type AccessPermission =
-  | "view"
-  | "edit"
-  | "notes"
-  | "export"
-  | "ai"
-  | "alerts";
+export type AccessPermission = CarePermission;
 
 export type OwnerAccessContext = {
   ownerUserId: string;
@@ -54,18 +49,7 @@ export async function requireOwnerAccess(
     throw new Error("Access denied.");
   }
 
-  const allowed =
-    permission === "view" || permission === "alerts"
-      ? grant.canViewRecords
-      : permission === "edit"
-      ? grant.canEditRecords
-      : permission === "notes"
-      ? grant.canAddNotes
-      : permission === "export"
-      ? grant.canExport
-      : grant.canGenerateAIInsights;
-
-  if (!allowed) {
+  if (!canUseCarePermission({ ...grant, isOwner: false }, permission)) {
     throw new Error("You do not have permission for this action.");
   }
 

--- a/lib/care-permissions.ts
+++ b/lib/care-permissions.ts
@@ -1,0 +1,127 @@
+import type { CareAccessRole } from "@prisma/client";
+
+export type CarePermission = "view" | "edit" | "notes" | "export" | "ai" | "alerts";
+
+export type CarePermissionFlags = {
+  canViewRecords: boolean;
+  canEditRecords: boolean;
+  canAddNotes: boolean;
+  canExport: boolean;
+  canGenerateAIInsights: boolean;
+};
+
+export type CarePermissionContext = CarePermissionFlags & {
+  accessRole: CareAccessRole | "OWNER";
+  isOwner?: boolean;
+};
+
+export type CarePermissionMatrixItem = {
+  permission: CarePermission;
+  label: string;
+  enabled: boolean;
+  description: string;
+};
+
+export const carePermissionLabels: Record<CarePermission, string> = {
+  view: "View records",
+  edit: "Edit records",
+  notes: "Add notes",
+  export: "Export data",
+  ai: "Generate AI insights",
+  alerts: "Review alerts",
+};
+
+export const carePermissionDescriptions: Record<CarePermission, string> = {
+  view: "Can review shared profile, records, alerts, and care context.",
+  edit: "Can update shared patient records where product flows allow edits.",
+  notes: "Can contribute care context and follow-up notes in supported workflows.",
+  export: "Can prepare printable or downloadable care handoff packets.",
+  ai: "Can request AI-assisted summaries for the shared patient record.",
+  alerts: "Can review visible alert context from the shared patient workspace.",
+};
+
+export const carePermissionOrder: CarePermission[] = ["view", "edit", "notes", "export", "ai"];
+
+export const carePermissionWorkflowChecklist: Array<{
+  workflow: string;
+  permission: CarePermission;
+  enforcement: string;
+}> = [
+  {
+    workflow: "Shared patient workspace",
+    permission: "view",
+    enforcement: "requireOwnerAccess(actor.id, ownerUserId, 'view')",
+  },
+  {
+    workflow: "Care note create / pin / archive",
+    permission: "notes",
+    enforcement: "requireOwnerAccess(actor.id, ownerUserId, 'notes')",
+  },
+  {
+    workflow: "Patient AI insight generation",
+    permission: "ai",
+    enforcement: "requireOwnerAccess(actor.id, ownerUserId, 'ai')",
+  },
+  {
+    workflow: "Patient export / handoff packet visibility",
+    permission: "export",
+    enforcement: "access.canExport UI gate with server-side permission helpers available",
+  },
+  {
+    workflow: "Shared alert review",
+    permission: "alerts",
+    enforcement: "alerts inherit the view-records permission gate",
+  },
+];
+
+function permissionFlag(access: CarePermissionFlags, permission: CarePermission) {
+  if (permission === "view" || permission === "alerts") return access.canViewRecords;
+  if (permission === "edit") return access.canEditRecords;
+  if (permission === "notes") return access.canAddNotes;
+  if (permission === "export") return access.canExport;
+  return access.canGenerateAIInsights;
+}
+
+export function normalizeCarePermissionInput(input: CarePermissionFlags): CarePermissionFlags {
+  const hasScopedPermission = input.canEditRecords || input.canAddNotes || input.canExport || input.canGenerateAIInsights;
+
+  return {
+    ...input,
+    canViewRecords: input.canViewRecords || hasScopedPermission,
+  };
+}
+
+export function canUseCarePermission(access: CarePermissionContext, permission: CarePermission) {
+  if (access.isOwner || access.accessRole === "OWNER") return true;
+  if (!access.canViewRecords) return false;
+  return permissionFlag(access, permission);
+}
+
+export function assertCarePermission(access: CarePermissionContext, permission: CarePermission) {
+  if (!canUseCarePermission(access, permission)) {
+    throw new Error("You do not have permission for this action.");
+  }
+}
+
+export function buildCarePermissionMatrix(access: CarePermissionContext): CarePermissionMatrixItem[] {
+  return carePermissionOrder.map((permission) => ({
+    permission,
+    label: carePermissionLabels[permission],
+    enabled: canUseCarePermission(access, permission),
+    description: carePermissionDescriptions[permission],
+  }));
+}
+
+export function summarizeCarePermissionAccess(access: CarePermissionContext) {
+  const matrix = buildCarePermissionMatrix(access);
+  const enabled = matrix.filter((item) => item.enabled);
+  const disabled = matrix.filter((item) => !item.enabled);
+
+  return {
+    total: matrix.length,
+    enabled: enabled.length,
+    disabled: disabled.length,
+    enabledLabels: enabled.map((item) => item.label),
+    disabledLabels: disabled.map((item) => item.label),
+  };
+}

--- a/lib/caregiver-workspace.ts
+++ b/lib/caregiver-workspace.ts
@@ -1,6 +1,7 @@
 import type { AlertSeverity, AlertStatus, CareAccessRole, LabFlag, ReminderState, SymptomSeverity } from "@prisma/client";
 
 import { db } from "@/lib/db";
+import { buildCarePermissionMatrix } from "@/lib/care-permissions";
 
 export type CaregiverPermission = {
   label: string;
@@ -55,33 +56,11 @@ function permissionMatrix(access: {
   canExport: boolean;
   canGenerateAIInsights: boolean;
 }): CaregiverPermission[] {
-  return [
-    {
-      label: "View records",
-      enabled: access.canViewRecords,
-      description: "Can review shared profile, records, alerts, and care context.",
-    },
-    {
-      label: "Edit records",
-      enabled: access.canEditRecords,
-      description: "Can update shared patient records where product flows allow edits.",
-    },
-    {
-      label: "Add notes",
-      enabled: access.canAddNotes,
-      description: "Can contribute care context and follow-up notes in supported workflows.",
-    },
-    {
-      label: "Export data",
-      enabled: access.canExport,
-      description: "Can prepare printable or downloadable care handoff packets.",
-    },
-    {
-      label: "Generate AI insights",
-      enabled: access.canGenerateAIInsights,
-      description: "Can request AI-assisted summaries for the shared patient record.",
-    },
-  ];
+  return buildCarePermissionMatrix(access).map((item) => ({
+    label: item.label,
+    enabled: item.enabled,
+    description: item.description,
+  }));
 }
 
 function severityScore(severity: AlertSeverity | SymptomSeverity | LabFlag | ReminderState | AlertStatus | string) {

--- a/tests/care-permissions.test.ts
+++ b/tests/care-permissions.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCarePermissionMatrix,
+  canUseCarePermission,
+  carePermissionWorkflowChecklist,
+  normalizeCarePermissionInput,
+  summarizeCarePermissionAccess,
+  type CarePermissionContext,
+} from "@/lib/care-permissions";
+
+function access(overrides: Partial<CarePermissionContext> = {}): CarePermissionContext {
+  return {
+    accessRole: "CAREGIVER",
+    canViewRecords: true,
+    canEditRecords: false,
+    canAddNotes: false,
+    canExport: false,
+    canGenerateAIInsights: false,
+    ...overrides,
+  };
+}
+
+describe("care permission enforcement helpers", () => {
+  it("treats owners as fully authorized across care-team workflows", () => {
+    const owner = access({
+      accessRole: "OWNER",
+      isOwner: true,
+      canViewRecords: false,
+      canEditRecords: false,
+      canAddNotes: false,
+      canExport: false,
+      canGenerateAIInsights: false,
+    });
+
+    expect(canUseCarePermission(owner, "view")).toBe(true);
+    expect(canUseCarePermission(owner, "edit")).toBe(true);
+    expect(canUseCarePermission(owner, "notes")).toBe(true);
+    expect(canUseCarePermission(owner, "export")).toBe(true);
+    expect(canUseCarePermission(owner, "ai")).toBe(true);
+  });
+
+  it("requires view access before scoped care-team permissions can be used", () => {
+    const noView = access({
+      canViewRecords: false,
+      canEditRecords: true,
+      canAddNotes: true,
+      canExport: true,
+      canGenerateAIInsights: true,
+    });
+
+    expect(canUseCarePermission(noView, "view")).toBe(false);
+    expect(canUseCarePermission(noView, "edit")).toBe(false);
+    expect(canUseCarePermission(noView, "notes")).toBe(false);
+    expect(canUseCarePermission(noView, "export")).toBe(false);
+    expect(canUseCarePermission(noView, "ai")).toBe(false);
+    expect(canUseCarePermission(noView, "alerts")).toBe(false);
+  });
+
+  it("maps each scoped permission to the matching persisted care-access flag", () => {
+    const grant = access({
+      canViewRecords: true,
+      canEditRecords: true,
+      canAddNotes: false,
+      canExport: true,
+      canGenerateAIInsights: false,
+    });
+
+    expect(canUseCarePermission(grant, "view")).toBe(true);
+    expect(canUseCarePermission(grant, "alerts")).toBe(true);
+    expect(canUseCarePermission(grant, "edit")).toBe(true);
+    expect(canUseCarePermission(grant, "notes")).toBe(false);
+    expect(canUseCarePermission(grant, "export")).toBe(true);
+    expect(canUseCarePermission(grant, "ai")).toBe(false);
+  });
+
+  it("normalizes saved grants so advanced permissions imply view access", () => {
+    expect(
+      normalizeCarePermissionInput({
+        canViewRecords: false,
+        canEditRecords: false,
+        canAddNotes: true,
+        canExport: false,
+        canGenerateAIInsights: false,
+      })
+    ).toEqual({
+      canViewRecords: true,
+      canEditRecords: false,
+      canAddNotes: true,
+      canExport: false,
+      canGenerateAIInsights: false,
+    });
+  });
+
+  it("builds a reviewer-friendly permission matrix and summary", () => {
+    const grant = access({ canAddNotes: true, canGenerateAIInsights: true });
+    const matrix = buildCarePermissionMatrix(grant);
+    const summary = summarizeCarePermissionAccess(grant);
+
+    expect(matrix.map((item) => item.label)).toEqual([
+      "View records",
+      "Edit records",
+      "Add notes",
+      "Export data",
+      "Generate AI insights",
+    ]);
+    expect(summary.enabledLabels).toEqual(["View records", "Add notes", "Generate AI insights"]);
+    expect(summary.disabledLabels).toEqual(["Edit records", "Export data"]);
+  });
+
+  it("documents the core workflow permission gates that should stay enforced", () => {
+    expect(carePermissionWorkflowChecklist.map((item) => item.permission)).toEqual([
+      "view",
+      "notes",
+      "ai",
+      "export",
+      "alerts",
+    ]);
+    expect(carePermissionWorkflowChecklist.map((item) => item.workflow)).toContain("Care note create / pin / archive");
+    expect(carePermissionWorkflowChecklist.map((item) => item.workflow)).toContain("Patient AI insight generation");
+  });
+});


### PR DESCRIPTION
## Summary

This patch centralizes VitaVault's care-team permission rules and adds tests proving shared patient workflows respect the correct permission flags.

## Changes

- Added shared care permission helpers
- Updated `requireOwnerAccess()` to use the centralized evaluator
- Normalized care-team invite and permission update flows
- Ensured advanced permissions imply view access before being saved
- Updated caregiver workspace permission cards to use the shared matrix
- Added care permission tests for owners, scoped access, view dependency, and workflow audit coverage
- Added Patch 61 documentation under `docs/`

## Safety

- No Prisma migration
- No dependency changes
- No README changes
- No route changes
- Uses existing `CareAccess` fields only

## Checks

Run locally:

```powershell
npm install
npm run db:validate:ci
npm run actions:check
npm run actions:imports
npm run actions:shadow
npm run typecheck
npm run lint
npm run test:run