### PR TITLE
Add device connection reliability panel

### DIFF
--- a/app/device-connection/[id]/page.tsx
+++ b/app/device-connection/[id]/page.tsx
@@ -1,16 +1,56 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { Activity, AlertTriangle, DatabaseZap, HeartPulse, RefreshCcw, ShieldCheck, Smartphone } from "lucide-react";
+import {
+  Activity,
+  AlertTriangle,
+  DatabaseZap,
+  HeartPulse,
+  RefreshCcw,
+  ShieldCheck,
+  Smartphone,
+} from "lucide-react";
 import { AppShell } from "@/components/app-shell";
 import { EmptyState, PageHeader, StatusPill } from "@/components/common";
-import { Badge, Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui";
 import { requireUser } from "@/lib/session";
-import { connectionStatusTone, formatDateTime, getDeviceConnectionDetailData, parseJsonObject, readingDisplayValue, readingLabel, sourceLabel, syncJobStatusTone } from "@/lib/device-integrations";
-import { clearDeviceConnectionErrorAction, disconnectDeviceConnectionAction, reconnectDeviceConnectionAction, revokeDeviceConnectionAction } from "../actions";
+import {
+  connectionStatusTone,
+  formatDateTime,
+  getDeviceConnectionDetailData,
+  parseJsonObject,
+  readingDisplayValue,
+  readingLabel,
+  sourceLabel,
+  syncJobStatusTone,
+} from "@/lib/device-integrations";
+import {
+  clearDeviceConnectionErrorAction,
+  disconnectDeviceConnectionAction,
+  reconnectDeviceConnectionAction,
+  revokeDeviceConnectionAction,
+} from "../actions";
 
-function vitalDisplayValue(vital: { systolic: number | null; diastolic: number | null; heartRate: number | null; bloodSugar: number | null; oxygenSaturation: number | null; temperatureC: number | null; weightKg: number | null }) {
+function vitalDisplayValue(vital: {
+  systolic: number | null;
+  diastolic: number | null;
+  heartRate: number | null;
+  bloodSugar: number | null;
+  oxygenSaturation: number | null;
+  temperatureC: number | null;
+  weightKg: number | null;
+}) {
   const parts = [
-    vital.systolic && vital.diastolic ? `${vital.systolic}/${vital.diastolic} BP` : null,
+    vital.systolic && vital.diastolic
+      ? `${vital.systolic}/${vital.diastolic} BP`
+      : null,
     vital.heartRate ? `${vital.heartRate} bpm` : null,
     vital.bloodSugar ? `${vital.bloodSugar} glucose` : null,
     vital.oxygenSaturation ? `${vital.oxygenSaturation}% SpO2` : null,
@@ -20,32 +60,432 @@ function vitalDisplayValue(vital: { systolic: number | null; diastolic: number |
   return parts.join(" • ") || "Device vital";
 }
 
-function ConnectionActionPanel({ connection }: { connection: { id: string; status: string; lastError: string | null } }) {
-  return <Card><CardHeader><CardTitle>Connection actions</CardTitle><CardDescription className="mt-1">Safe lifecycle actions for this user-owned device connection.</CardDescription></CardHeader><CardContent className="space-y-3">
-    {connection.status === "ACTIVE" || connection.status === "ERROR" ? <form action={disconnectDeviceConnectionAction}><input type="hidden" name="connectionId" value={connection.id} /><Button type="submit" variant="outline" className="w-full">Disconnect</Button></form> : null}
-    {connection.status === "DISCONNECTED" || connection.status === "ERROR" ? <form action={reconnectDeviceConnectionAction}><input type="hidden" name="connectionId" value={connection.id} /><Button type="submit" className="w-full">Reconnect / mark active</Button></form> : null}
-    {connection.lastError ? <form action={clearDeviceConnectionErrorAction}><input type="hidden" name="connectionId" value={connection.id} /><Button type="submit" variant="outline" className="w-full">Clear last error</Button></form> : null}
-    {connection.status !== "REVOKED" ? <form action={revokeDeviceConnectionAction} className="space-y-2 rounded-2xl border border-border/60 bg-background/40 p-3"><input type="hidden" name="connectionId" value={connection.id} /><input name="confirmation" placeholder="Type REVOKE" className="h-10 w-full rounded-2xl border border-input bg-background/70 px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring" /><Button type="submit" variant="destructive" className="w-full">Revoke connection</Button><p className="text-xs text-muted-foreground">Historical readings remain available for audit and reports.</p></form> : null}
-  </CardContent></Card>;
+function ConnectionActionPanel({
+  connection,
+}: {
+  connection: { id: string; status: string; lastError: string | null };
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Connection actions</CardTitle>
+        <CardDescription className="mt-1">
+          Safe lifecycle actions for this user-owned device connection.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {connection.status === "ACTIVE" || connection.status === "ERROR" ? (
+          <form action={disconnectDeviceConnectionAction}>
+            <input type="hidden" name="connectionId" value={connection.id} />
+            <Button type="submit" variant="outline" className="w-full">
+              Disconnect
+            </Button>
+          </form>
+        ) : null}
+        {connection.status === "DISCONNECTED" ||
+        connection.status === "ERROR" ? (
+          <form action={reconnectDeviceConnectionAction}>
+            <input type="hidden" name="connectionId" value={connection.id} />
+            <Button type="submit" className="w-full">
+              Reconnect / mark active
+            </Button>
+          </form>
+        ) : null}
+        {connection.lastError ? (
+          <form action={clearDeviceConnectionErrorAction}>
+            <input type="hidden" name="connectionId" value={connection.id} />
+            <Button type="submit" variant="outline" className="w-full">
+              Clear last error
+            </Button>
+          </form>
+        ) : null}
+        {connection.status !== "REVOKED" ? (
+          <form
+            action={revokeDeviceConnectionAction}
+            className="space-y-2 rounded-2xl border border-border/60 bg-background/40 p-3"
+          >
+            <input type="hidden" name="connectionId" value={connection.id} />
+            <input
+              name="confirmation"
+              placeholder="Type REVOKE"
+              className="h-10 w-full rounded-2xl border border-input bg-background/70 px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+            <Button type="submit" variant="destructive" className="w-full">
+              Revoke connection
+            </Button>
+            <p className="text-xs text-muted-foreground">
+              Historical readings remain available for audit and reports.
+            </p>
+          </form>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
 }
 
-export default async function DeviceConnectionDetailPage({ params }: { params: Promise<{ id: string }> }) {
+export default async function DeviceConnectionDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
   const user = await requireUser();
   const { id } = await params;
-  const data = await getDeviceConnectionDetailData({ userId: user.id!, connectionId: id });
+  const data = await getDeviceConnectionDetailData({
+    userId: user.id!,
+    connectionId: id,
+  });
   if (!data) notFound();
-  const { connection, health } = data;
-  return <AppShell><div className="mx-auto max-w-7xl space-y-6 p-6">
-    <PageHeader title={connection.deviceLabel || sourceLabel(connection.source)} description="Review this device connection, recent readings, sync jobs, job-run history, mirrored vitals, and stored metadata." action={<div className="flex flex-wrap gap-2"><Link href="/device-connection" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium hover:bg-muted/50">Back to devices</Link><Link href="/device-sync-simulator" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium hover:bg-muted/50">Run simulator</Link></div>} />
-    <div className="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]"><Card><CardHeader><div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between"><div><CardTitle>Connection overview</CardTitle><CardDescription className="mt-1">Source, platform, client device id, scopes, and latest sync state.</CardDescription></div><div className="flex flex-wrap gap-2"><StatusPill tone={connectionStatusTone(connection.status)}>{connection.status}</StatusPill><StatusPill tone={health.tone}>{health.label}</StatusPill></div></div></CardHeader><CardContent className="space-y-5">
-      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4"><div className="rounded-2xl border border-border/60 p-4"><Smartphone className="h-5 w-5 text-primary" /><p className="mt-3 text-sm text-muted-foreground">Source</p><p className="font-medium">{sourceLabel(connection.source)}</p></div><div className="rounded-2xl border border-border/60 p-4"><Activity className="h-5 w-5 text-primary" /><p className="mt-3 text-sm text-muted-foreground">Platform</p><p className="font-medium">{connection.platform}</p></div><div className="rounded-2xl border border-border/60 p-4"><DatabaseZap className="h-5 w-5 text-primary" /><p className="mt-3 text-sm text-muted-foreground">Readings</p><p className="font-medium">{connection._count.readings}</p></div><div className="rounded-2xl border border-border/60 p-4"><RefreshCcw className="h-5 w-5 text-primary" /><p className="mt-3 text-sm text-muted-foreground">Sync jobs</p><p className="font-medium">{connection._count.syncJobs}</p></div></div>
-      <dl className="grid gap-4 text-sm md:grid-cols-2"><div><dt className="text-muted-foreground">Client device id</dt><dd className="mt-1 break-all font-medium">{connection.clientDeviceId}</dd></div><div><dt className="text-muted-foreground">App version</dt><dd className="mt-1 font-medium">{connection.appVersion || "—"}</dd></div><div><dt className="text-muted-foreground">Created</dt><dd className="mt-1 font-medium">{formatDateTime(connection.createdAt)}</dd></div><div><dt className="text-muted-foreground">Last synced</dt><dd className="mt-1 font-medium">{formatDateTime(connection.lastSyncedAt)}</dd></div></dl>
-      {data.scopes.length ? <div><p className="text-sm font-medium">Scopes</p><div className="mt-2 flex flex-wrap gap-2">{data.scopes.map((scope) => <Badge key={scope}>{scope}</Badge>)}</div></div> : null}
-      {connection.lastError ? <div className="rounded-2xl border border-rose-200/70 bg-rose-50/70 p-4 text-sm text-rose-700 dark:border-rose-900/50 dark:bg-rose-950/30 dark:text-rose-200"><div className="flex items-start gap-2"><AlertTriangle className="mt-0.5 h-4 w-4" /><span>{connection.lastError}</span></div></div> : null}
-    </CardContent></Card><div className="space-y-6"><ConnectionActionPanel connection={connection} /><Card><CardHeader><CardTitle>Traceability</CardTitle><CardDescription className="mt-1">How this connection feeds the rest of VitaVault.</CardDescription></CardHeader><CardContent className="space-y-3 text-sm text-muted-foreground"><div className="flex items-start gap-3 rounded-2xl border border-border/60 p-4"><DatabaseZap className="mt-0.5 h-4 w-4 text-primary" /><div>Raw device readings remain source-aware and timestamped.</div></div><div className="flex items-start gap-3 rounded-2xl border border-border/60 p-4"><HeartPulse className="mt-0.5 h-4 w-4 text-primary" /><div>Supported readings mirror into the normal vitals workflow.</div></div><div className="flex items-start gap-3 rounded-2xl border border-border/60 p-4"><ShieldCheck className="mt-0.5 h-4 w-4 text-primary" /><div>Lifecycle actions write audit-log records for reviewer visibility.</div></div></CardContent></Card></div></div>
-    <div className="grid gap-6 xl:grid-cols-3"><Card><CardHeader><CardTitle>Recent readings</CardTitle><CardDescription>Latest raw records for this connection.</CardDescription></CardHeader><CardContent className="space-y-3">{data.readings.map((reading) => { const metadata = parseJsonObject(reading.metadataJson); const rawPayload = parseJsonObject(reading.rawPayloadJson); return <div key={reading.id} className="rounded-2xl border border-border/60 bg-background/50 p-4"><div className="flex flex-wrap items-center justify-between gap-2"><p className="font-medium">{readingLabel(reading.readingType)}</p><Badge>{formatDateTime(reading.capturedAt)}</Badge></div><p className="mt-2 text-2xl font-semibold">{readingDisplayValue(reading)}</p>{metadata ? <pre className="mt-3 max-h-28 overflow-auto rounded-xl bg-muted/40 p-3 text-xs">{JSON.stringify(metadata, null, 2)}</pre> : null}{rawPayload ? <pre className="mt-3 max-h-28 overflow-auto rounded-xl bg-muted/40 p-3 text-xs">{JSON.stringify(rawPayload, null, 2)}</pre> : null}</div>; })}{data.readings.length === 0 ? <EmptyState title="No readings for this connection" description="Run a sync to populate source-aware readings." /> : null}</CardContent></Card>
-      <Card><CardHeader><CardTitle>Sync jobs</CardTitle><CardDescription>Import attempts linked to this connection.</CardDescription></CardHeader><CardContent className="space-y-3">{data.syncJobs.map((job) => { const metadata = parseJsonObject(job.metadataJson); return <div key={job.id} className="rounded-2xl border border-border/60 bg-background/50 p-4"><div className="flex flex-wrap items-center justify-between gap-2"><p className="font-medium">Sync job</p><StatusPill tone={syncJobStatusTone(job.status)}>{job.status}</StatusPill></div><div className="mt-3 grid gap-1 text-xs text-muted-foreground"><p>Requested: {job.requestedCount}</p><p>Accepted: {job.acceptedCount}</p><p>Mirrored: {job.mirroredCount}</p><p>Started: {formatDateTime(job.startedAt)}</p><p>Finished: {formatDateTime(job.finishedAt)}</p></div>{job.errorMessage ? <p className="mt-3 text-sm text-destructive">{job.errorMessage}</p> : null}{metadata ? <pre className="mt-3 max-h-28 overflow-auto rounded-xl bg-muted/40 p-3 text-xs">{JSON.stringify(metadata, null, 2)}</pre> : null}</div>; })}{data.syncJobs.length === 0 ? <EmptyState title="No sync jobs yet" description="Mobile imports and simulator runs will appear here." /> : null}</CardContent></Card>
-      <Card><CardHeader><CardTitle>Mirrored vitals</CardTitle><CardDescription>Latest vitals created from this connection source.</CardDescription></CardHeader><CardContent className="space-y-3">{data.mirroredVitals.map((vital) => <div key={vital.id} className="rounded-2xl border border-border/60 bg-background/50 p-4"><div className="flex flex-wrap items-center justify-between gap-2"><p className="font-medium">{vitalDisplayValue(vital)}</p><Badge>{sourceLabel(vital.readingSource)}</Badge></div><p className="mt-2 text-xs text-muted-foreground">Recorded {formatDateTime(vital.recordedAt)}</p>{vital.notes ? <p className="mt-2 text-sm text-muted-foreground">{vital.notes}</p> : null}</div>)}{data.mirroredVitals.length === 0 ? <EmptyState title="No mirrored vitals yet" description="Supported readings mirror into vitals after ingestion." /> : null}</CardContent></Card></div>
-    <Card><CardHeader><CardTitle>Job runs</CardTitle><CardDescription>Persisted worker/job-run records tied to this device connection.</CardDescription></CardHeader><CardContent className="space-y-3">{data.jobRuns.map((run) => <div key={run.id} className="rounded-2xl border border-border/60 bg-background/50 p-4"><div className="flex flex-wrap items-center justify-between gap-2"><div><p className="font-medium">{run.jobName}</p><p className="text-xs text-muted-foreground">{sourceLabel(run.jobKind)}</p></div><Badge>{run.status}</Badge></div><div className="mt-3 grid gap-1 text-xs text-muted-foreground md:grid-cols-4"><p>Attempts: {run.attemptsMade} / {run.maxAttempts}</p><p>Created: {formatDateTime(run.createdAt)}</p><p>Finished: {formatDateTime(run.finishedAt)}</p><p>{run.errorMessage || "No error"}</p></div></div>)}{data.jobRuns.length === 0 ? <EmptyState title="No job runs yet" description="Queue-backed device sync job runs will appear here when available." /> : null}</CardContent></Card>
-  </div></AppShell>;
+  const { connection, health, reliability } = data;
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-7xl space-y-6 p-6">
+        <PageHeader
+          title={connection.deviceLabel || sourceLabel(connection.source)}
+          description="Review this device connection, recent readings, sync jobs, job-run history, mirrored vitals, and stored metadata."
+          action={
+            <div className="flex flex-wrap gap-2">
+              <Link
+                href="/device-connection"
+                className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium hover:bg-muted/50"
+              >
+                Back to devices
+              </Link>
+              <Link
+                href="/device-sync-simulator"
+                className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium hover:bg-muted/50"
+              >
+                Run simulator
+              </Link>
+            </div>
+          }
+        />
+        <div className="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+          <Card>
+            <CardHeader>
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                <div>
+                  <CardTitle>Connection overview</CardTitle>
+                  <CardDescription className="mt-1">
+                    Source, platform, client device id, scopes, and latest sync
+                    state.
+                  </CardDescription>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <StatusPill tone={connectionStatusTone(connection.status)}>
+                    {connection.status}
+                  </StatusPill>
+                  <StatusPill tone={health.tone}>{health.label}</StatusPill>
+                  <StatusPill tone={reliability.tone}>
+                    {reliability.label}
+                  </StatusPill>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-5">
+              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+                <div className="rounded-2xl border border-border/60 p-4">
+                  <Smartphone className="h-5 w-5 text-primary" />
+                  <p className="mt-3 text-sm text-muted-foreground">Source</p>
+                  <p className="font-medium">
+                    {sourceLabel(connection.source)}
+                  </p>
+                </div>
+                <div className="rounded-2xl border border-border/60 p-4">
+                  <Activity className="h-5 w-5 text-primary" />
+                  <p className="mt-3 text-sm text-muted-foreground">Platform</p>
+                  <p className="font-medium">{connection.platform}</p>
+                </div>
+                <div className="rounded-2xl border border-border/60 p-4">
+                  <DatabaseZap className="h-5 w-5 text-primary" />
+                  <p className="mt-3 text-sm text-muted-foreground">Readings</p>
+                  <p className="font-medium">{connection._count.readings}</p>
+                </div>
+                <div className="rounded-2xl border border-border/60 p-4">
+                  <RefreshCcw className="h-5 w-5 text-primary" />
+                  <p className="mt-3 text-sm text-muted-foreground">
+                    Sync jobs
+                  </p>
+                  <p className="font-medium">{connection._count.syncJobs}</p>
+                </div>
+              </div>
+              <dl className="grid gap-4 text-sm md:grid-cols-2">
+                <div>
+                  <dt className="text-muted-foreground">Client device id</dt>
+                  <dd className="mt-1 break-all font-medium">
+                    {connection.clientDeviceId}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-muted-foreground">App version</dt>
+                  <dd className="mt-1 font-medium">
+                    {connection.appVersion || "—"}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-muted-foreground">Created</dt>
+                  <dd className="mt-1 font-medium">
+                    {formatDateTime(connection.createdAt)}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-muted-foreground">Last synced</dt>
+                  <dd className="mt-1 font-medium">
+                    {formatDateTime(connection.lastSyncedAt)}
+                  </dd>
+                </div>
+              </dl>
+              {data.scopes.length ? (
+                <div>
+                  <p className="text-sm font-medium">Scopes</p>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {data.scopes.map((scope) => (
+                      <Badge key={scope}>{scope}</Badge>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+              {connection.lastError ? (
+                <div className="rounded-2xl border border-rose-200/70 bg-rose-50/70 p-4 text-sm text-rose-700 dark:border-rose-900/50 dark:bg-rose-950/30 dark:text-rose-200">
+                  <div className="flex items-start gap-2">
+                    <AlertTriangle className="mt-0.5 h-4 w-4" />
+                    <span>{connection.lastError}</span>
+                  </div>
+                </div>
+              ) : null}
+            </CardContent>
+          </Card>
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Reliability signal</CardTitle>
+                <CardDescription className="mt-1">
+                  Freshness and remediation guidance for this specific device
+                  source.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm">
+                <div className="flex flex-wrap items-center gap-2">
+                  <StatusPill tone={reliability.tone}>
+                    {reliability.label}
+                  </StatusPill>
+                  <Badge>{reliability.syncAgeLabel}</Badge>
+                </div>
+                <p className="text-muted-foreground">
+                  {reliability.description}
+                </p>
+                <div className="rounded-2xl border border-border/60 bg-background/40 p-3">
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Next step
+                  </p>
+                  <p className="mt-1 font-medium">{reliability.nextStep}</p>
+                </div>
+              </CardContent>
+            </Card>
+            <ConnectionActionPanel connection={connection} />
+            <Card>
+              <CardHeader>
+                <CardTitle>Traceability</CardTitle>
+                <CardDescription className="mt-1">
+                  How this connection feeds the rest of VitaVault.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-muted-foreground">
+                <div className="flex items-start gap-3 rounded-2xl border border-border/60 p-4">
+                  <DatabaseZap className="mt-0.5 h-4 w-4 text-primary" />
+                  <div>
+                    Raw device readings remain source-aware and timestamped.
+                  </div>
+                </div>
+                <div className="flex items-start gap-3 rounded-2xl border border-border/60 p-4">
+                  <HeartPulse className="mt-0.5 h-4 w-4 text-primary" />
+                  <div>
+                    Supported readings mirror into the normal vitals workflow.
+                  </div>
+                </div>
+                <div className="flex items-start gap-3 rounded-2xl border border-border/60 p-4">
+                  <ShieldCheck className="mt-0.5 h-4 w-4 text-primary" />
+                  <div>
+                    Lifecycle actions write audit-log records for reviewer
+                    visibility.
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+        <div className="grid gap-6 xl:grid-cols-3">
+          <Card>
+            <CardHeader>
+              <CardTitle>Recent readings</CardTitle>
+              <CardDescription>
+                Latest raw records for this connection.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {data.readings.map((reading) => {
+                const metadata = parseJsonObject(reading.metadataJson);
+                const rawPayload = parseJsonObject(reading.rawPayloadJson);
+                return (
+                  <div
+                    key={reading.id}
+                    className="rounded-2xl border border-border/60 bg-background/50 p-4"
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <p className="font-medium">
+                        {readingLabel(reading.readingType)}
+                      </p>
+                      <Badge>{formatDateTime(reading.capturedAt)}</Badge>
+                    </div>
+                    <p className="mt-2 text-2xl font-semibold">
+                      {readingDisplayValue(reading)}
+                    </p>
+                    {metadata ? (
+                      <pre className="mt-3 max-h-28 overflow-auto rounded-xl bg-muted/40 p-3 text-xs">
+                        {JSON.stringify(metadata, null, 2)}
+                      </pre>
+                    ) : null}
+                    {rawPayload ? (
+                      <pre className="mt-3 max-h-28 overflow-auto rounded-xl bg-muted/40 p-3 text-xs">
+                        {JSON.stringify(rawPayload, null, 2)}
+                      </pre>
+                    ) : null}
+                  </div>
+                );
+              })}
+              {data.readings.length === 0 ? (
+                <EmptyState
+                  title="No readings for this connection"
+                  description="Run a sync to populate source-aware readings."
+                />
+              ) : null}
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Sync jobs</CardTitle>
+              <CardDescription>
+                Import attempts linked to this connection.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {data.syncJobs.map((job) => {
+                const metadata = parseJsonObject(job.metadataJson);
+                return (
+                  <div
+                    key={job.id}
+                    className="rounded-2xl border border-border/60 bg-background/50 p-4"
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <p className="font-medium">Sync job</p>
+                      <StatusPill tone={syncJobStatusTone(job.status)}>
+                        {job.status}
+                      </StatusPill>
+                    </div>
+                    <div className="mt-3 grid gap-1 text-xs text-muted-foreground">
+                      <p>Requested: {job.requestedCount}</p>
+                      <p>Accepted: {job.acceptedCount}</p>
+                      <p>Mirrored: {job.mirroredCount}</p>
+                      <p>Started: {formatDateTime(job.startedAt)}</p>
+                      <p>Finished: {formatDateTime(job.finishedAt)}</p>
+                    </div>
+                    {job.errorMessage ? (
+                      <p className="mt-3 text-sm text-destructive">
+                        {job.errorMessage}
+                      </p>
+                    ) : null}
+                    {metadata ? (
+                      <pre className="mt-3 max-h-28 overflow-auto rounded-xl bg-muted/40 p-3 text-xs">
+                        {JSON.stringify(metadata, null, 2)}
+                      </pre>
+                    ) : null}
+                  </div>
+                );
+              })}
+              {data.syncJobs.length === 0 ? (
+                <EmptyState
+                  title="No sync jobs yet"
+                  description="Mobile imports and simulator runs will appear here."
+                />
+              ) : null}
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Mirrored vitals</CardTitle>
+              <CardDescription>
+                Latest vitals created from this connection source.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {data.mirroredVitals.map((vital) => (
+                <div
+                  key={vital.id}
+                  className="rounded-2xl border border-border/60 bg-background/50 p-4"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="font-medium">{vitalDisplayValue(vital)}</p>
+                    <Badge>{sourceLabel(vital.readingSource)}</Badge>
+                  </div>
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    Recorded {formatDateTime(vital.recordedAt)}
+                  </p>
+                  {vital.notes ? (
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      {vital.notes}
+                    </p>
+                  ) : null}
+                </div>
+              ))}
+              {data.mirroredVitals.length === 0 ? (
+                <EmptyState
+                  title="No mirrored vitals yet"
+                  description="Supported readings mirror into vitals after ingestion."
+                />
+              ) : null}
+            </CardContent>
+          </Card>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>Job runs</CardTitle>
+            <CardDescription>
+              Persisted worker/job-run records tied to this device connection.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {data.jobRuns.map((run) => (
+              <div
+                key={run.id}
+                className="rounded-2xl border border-border/60 bg-background/50 p-4"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <p className="font-medium">{run.jobName}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {sourceLabel(run.jobKind)}
+                    </p>
+                  </div>
+                  <Badge>{run.status}</Badge>
+                </div>
+                <div className="mt-3 grid gap-1 text-xs text-muted-foreground md:grid-cols-4">
+                  <p>
+                    Attempts: {run.attemptsMade} / {run.maxAttempts}
+                  </p>
+                  <p>Created: {formatDateTime(run.createdAt)}</p>
+                  <p>Finished: {formatDateTime(run.finishedAt)}</p>
+                  <p>{run.errorMessage || "No error"}</p>
+                </div>
+              </div>
+            ))}
+            {data.jobRuns.length === 0 ? (
+              <EmptyState
+                title="No job runs yet"
+                description="Queue-backed device sync job runs will appear here when available."
+              />
+            ) : null}
+          </CardContent>
+        </Card>
+      </div>
+    </AppShell>
+  );
 }

--- a/app/device-connection/page.tsx
+++ b/app/device-connection/page.tsx
@@ -1,25 +1,121 @@
 import type { ReactNode } from "react";
 import Link from "next/link";
-import { Activity, AlertTriangle, ClipboardList, DatabaseZap, HeartPulse, Lock, RefreshCcw, ShieldCheck, Smartphone, Watch } from "lucide-react";
+import {
+  Activity,
+  AlertTriangle,
+  ClipboardList,
+  DatabaseZap,
+  HeartPulse,
+  Lock,
+  RefreshCcw,
+  ShieldCheck,
+  Smartphone,
+  Watch,
+} from "lucide-react";
 import { AppShell } from "@/components/app-shell";
 import { EmptyState, PageHeader, StatusPill } from "@/components/common";
-import { Badge, Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui";
 import { requireUser } from "@/lib/session";
-import { buildConnectionHealthSummary, connectionStatusTone, formatDateTime, getDeviceIntegrationDashboardData, parseScopes, readingDisplayValue, readingLabel, sourceLabel, syncJobStatusTone } from "@/lib/device-integrations";
-import { connectorCategoryLabel, connectorStatusLabel } from "@/lib/device-provider-connectors";
-import { clearDeviceConnectionErrorAction, disconnectDeviceConnectionAction, reconnectDeviceConnectionAction, revokeDeviceConnectionAction } from "./actions";
+import {
+  buildConnectionHealthSummary,
+  connectionStatusTone,
+  formatDateTime,
+  getDeviceIntegrationDashboardData,
+  parseScopes,
+  readingDisplayValue,
+  readingLabel,
+  sourceLabel,
+  syncJobStatusTone,
+} from "@/lib/device-integrations";
+import {
+  connectorCategoryLabel,
+  connectorStatusLabel,
+} from "@/lib/device-provider-connectors";
+import {
+  clearDeviceConnectionErrorAction,
+  disconnectDeviceConnectionAction,
+  reconnectDeviceConnectionAction,
+  revokeDeviceConnectionAction,
+} from "./actions";
 
-function StatCard({ title, value, description, icon }: { title: string; value: number | string; description: string; icon: ReactNode }) {
-  return <Card><CardHeader className="pb-3"><div className="flex items-start justify-between gap-3"><div><CardDescription>{title}</CardDescription><CardTitle className="mt-2 text-3xl">{value}</CardTitle></div><div className="rounded-2xl border border-border/60 bg-background/70 p-2">{icon}</div></div></CardHeader><CardContent><p className="text-sm text-muted-foreground">{description}</p></CardContent></Card>;
+function StatCard({
+  title,
+  value,
+  description,
+  icon,
+}: {
+  title: string;
+  value: number | string;
+  description: string;
+  icon: ReactNode;
+}) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardDescription>{title}</CardDescription>
+            <CardTitle className="mt-2 text-3xl">{value}</CardTitle>
+          </div>
+          <div className="rounded-2xl border border-border/60 bg-background/70 p-2">
+            {icon}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </CardContent>
+    </Card>
+  );
 }
 
-function DeviceActionForms({ connection }: { connection: { id: string; status: string; lastError: string | null } }) {
-  return <div className="flex flex-wrap gap-2">
-    <Link href={`/device-connection/${connection.id}`} className="inline-flex h-9 items-center justify-center rounded-xl border border-border/70 bg-background/60 px-3 text-sm font-medium hover:bg-muted/50">View detail</Link>
-    {connection.status === "ACTIVE" || connection.status === "ERROR" ? <form action={disconnectDeviceConnectionAction}><input type="hidden" name="connectionId" value={connection.id} /><Button type="submit" variant="outline" size="sm">Disconnect</Button></form> : null}
-    {connection.status === "DISCONNECTED" || connection.status === "ERROR" ? <form action={reconnectDeviceConnectionAction}><input type="hidden" name="connectionId" value={connection.id} /><Button type="submit" size="sm">Reconnect</Button></form> : null}
-    {connection.lastError ? <form action={clearDeviceConnectionErrorAction}><input type="hidden" name="connectionId" value={connection.id} /><Button type="submit" variant="outline" size="sm">Clear error</Button></form> : null}
-  </div>;
+function DeviceActionForms({
+  connection,
+}: {
+  connection: { id: string; status: string; lastError: string | null };
+}) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Link
+        href={`/device-connection/${connection.id}`}
+        className="inline-flex h-9 items-center justify-center rounded-xl border border-border/70 bg-background/60 px-3 text-sm font-medium hover:bg-muted/50"
+      >
+        View detail
+      </Link>
+      {connection.status === "ACTIVE" || connection.status === "ERROR" ? (
+        <form action={disconnectDeviceConnectionAction}>
+          <input type="hidden" name="connectionId" value={connection.id} />
+          <Button type="submit" variant="outline" size="sm">
+            Disconnect
+          </Button>
+        </form>
+      ) : null}
+      {connection.status === "DISCONNECTED" || connection.status === "ERROR" ? (
+        <form action={reconnectDeviceConnectionAction}>
+          <input type="hidden" name="connectionId" value={connection.id} />
+          <Button type="submit" size="sm">
+            Reconnect
+          </Button>
+        </form>
+      ) : null}
+      {connection.lastError ? (
+        <form action={clearDeviceConnectionErrorAction}>
+          <input type="hidden" name="connectionId" value={connection.id} />
+          <Button type="submit" variant="outline" size="sm">
+            Clear error
+          </Button>
+        </form>
+      ) : null}
+    </div>
+  );
 }
 
 export default async function DeviceConnectionsPage() {
@@ -29,46 +125,521 @@ export default async function DeviceConnectionsPage() {
   return (
     <AppShell>
       <div className="mx-auto max-w-7xl space-y-6 p-6">
-        <PageHeader title="Device Integrations" description="Manage connected mobile and health-device sync records, review ingestion health, test API payloads, and trace readings into sync jobs and mirrored vitals." action={<div className="flex flex-wrap gap-2"><Link href="/device-sync-simulator" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium hover:bg-muted/50">Run simulator</Link><Link href="/api-docs" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium hover:bg-muted/50">API docs</Link></div>} />
+        <PageHeader
+          title="Device Integrations"
+          description="Manage connected mobile and health-device sync records, review ingestion health, test API payloads, and trace readings into sync jobs and mirrored vitals."
+          action={
+            <div className="flex flex-wrap gap-2">
+              <Link
+                href="/device-sync-simulator"
+                className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium hover:bg-muted/50"
+              >
+                Run simulator
+              </Link>
+              <Link
+                href="/api-docs"
+                className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium hover:bg-muted/50"
+              >
+                API docs
+              </Link>
+            </div>
+          }
+        />
 
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
-          <StatCard title="Connections" value={data.summary.totalConnections} description="Mobile or device links registered for this account." icon={<Smartphone className="h-5 w-5 text-primary" />} />
-          <StatCard title="Active" value={data.summary.activeConnections} description="Connections currently accepting syncs." icon={<Watch className="h-5 w-5 text-emerald-500" />} />
-          <StatCard title="Readings" value={data.summary.totalReadings} description="Raw source-aware readings stored from connected devices." icon={<Activity className="h-5 w-5 text-sky-500" />} />
-          <StatCard title="Sync jobs" value={data.summary.totalSyncJobs} description="Persisted sync attempts linked to device connections." icon={<DatabaseZap className="h-5 w-5 text-violet-500" />} />
-          <StatCard title="Mobile sessions" value={data.summary.activeSessions} description="Active bearer-token sessions that can call mobile endpoints." icon={<ShieldCheck className="h-5 w-5 text-rose-500" />} />
+          <StatCard
+            title="Connections"
+            value={data.summary.totalConnections}
+            description="Mobile or device links registered for this account."
+            icon={<Smartphone className="h-5 w-5 text-primary" />}
+          />
+          <StatCard
+            title="Active"
+            value={data.summary.activeConnections}
+            description="Connections currently accepting syncs."
+            icon={<Watch className="h-5 w-5 text-emerald-500" />}
+          />
+          <StatCard
+            title="Readings"
+            value={data.summary.totalReadings}
+            description="Raw source-aware readings stored from connected devices."
+            icon={<Activity className="h-5 w-5 text-sky-500" />}
+          />
+          <StatCard
+            title="Sync jobs"
+            value={data.summary.totalSyncJobs}
+            description="Persisted sync attempts linked to device connections."
+            icon={<DatabaseZap className="h-5 w-5 text-violet-500" />}
+          />
+          <StatCard
+            title="Needs review"
+            value={data.summary.reliability.needsReview}
+            description="Blocked, paused, revoked, or stale connections requiring attention."
+            icon={<AlertTriangle className="h-5 w-5 text-amber-500" />}
+          />
         </div>
+
+        <Card>
+          <CardHeader>
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+              <div>
+                <CardTitle>Reliability command center</CardTitle>
+                <CardDescription className="mt-1">
+                  Operational view of freshness, blocked syncs, paused devices,
+                  and connections waiting for their first payload.
+                </CardDescription>
+              </div>
+              <StatusPill
+                tone={
+                  data.summary.reliability.needsReview ? "warning" : "success"
+                }
+              >
+                {data.summary.reliability.needsReview
+                  ? `${data.summary.reliability.needsReview} connection${data.summary.reliability.needsReview === 1 ? "" : "s"} to review`
+                  : "All tracked connections stable"}
+              </StatusPill>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-3 text-sm md:grid-cols-2 xl:grid-cols-7">
+              <div className="rounded-2xl border border-border/60 p-3">
+                <div className="text-muted-foreground">Current</div>
+                <div className="mt-1 text-2xl font-semibold">
+                  {data.summary.reliability.current}
+                </div>
+              </div>
+              <div className="rounded-2xl border border-border/60 p-3">
+                <div className="text-muted-foreground">Sync due</div>
+                <div className="mt-1 text-2xl font-semibold">
+                  {data.summary.reliability.due}
+                </div>
+              </div>
+              <div className="rounded-2xl border border-border/60 p-3">
+                <div className="text-muted-foreground">Stale</div>
+                <div className="mt-1 text-2xl font-semibold">
+                  {data.summary.reliability.stale}
+                </div>
+              </div>
+              <div className="rounded-2xl border border-border/60 p-3">
+                <div className="text-muted-foreground">Blocked</div>
+                <div className="mt-1 text-2xl font-semibold">
+                  {data.summary.reliability.blocked}
+                </div>
+              </div>
+              <div className="rounded-2xl border border-border/60 p-3">
+                <div className="text-muted-foreground">Paused</div>
+                <div className="mt-1 text-2xl font-semibold">
+                  {data.summary.reliability.paused}
+                </div>
+              </div>
+              <div className="rounded-2xl border border-border/60 p-3">
+                <div className="text-muted-foreground">First sync</div>
+                <div className="mt-1 text-2xl font-semibold">
+                  {data.summary.reliability.awaitingFirstSync}
+                </div>
+              </div>
+              <div className="rounded-2xl border border-border/60 p-3">
+                <div className="text-muted-foreground">Revoked</div>
+                <div className="mt-1 text-2xl font-semibold">
+                  {data.summary.reliability.revoked}
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
 
         <div className="grid gap-6 xl:grid-cols-[1.25fr_0.75fr]">
           <Card>
-            <CardHeader><div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between"><div><CardTitle>Connection management</CardTitle><CardDescription className="mt-1">Real database-backed connections from mobile API syncs and the simulator, with safe user-owned lifecycle actions.</CardDescription></div><StatusPill tone={data.summary.erroredConnections ? "danger" : "success"}>{data.summary.erroredConnections ? `${data.summary.erroredConnections} needs review` : "No active errors"}</StatusPill></div></CardHeader>
+            <CardHeader>
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                <div>
+                  <CardTitle>Connection management</CardTitle>
+                  <CardDescription className="mt-1">
+                    Real database-backed connections from mobile API syncs and
+                    the simulator, with safe user-owned lifecycle actions.
+                  </CardDescription>
+                </div>
+                <StatusPill
+                  tone={data.summary.erroredConnections ? "danger" : "success"}
+                >
+                  {data.summary.erroredConnections
+                    ? `${data.summary.erroredConnections} needs review`
+                    : "No active errors"}
+                </StatusPill>
+              </div>
+            </CardHeader>
             <CardContent className="space-y-4">
               {data.connections.map((connection) => {
                 const health = buildConnectionHealthSummary(connection);
+                const reliability = connection.reliability;
                 const scopes = parseScopes(connection.scopesJson);
-                return <div key={connection.id} className="rounded-[28px] border border-border/60 bg-background/50 p-5">
-                  <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between"><div className="space-y-3"><div className="flex flex-wrap items-center gap-2"><Badge>{sourceLabel(connection.source)}</Badge><Badge>{connection.platform}</Badge><StatusPill tone={connectionStatusTone(connection.status)}>{connection.status}</StatusPill><StatusPill tone={health.tone}>{health.label}</StatusPill></div><div><h2 className="text-lg font-semibold">{connection.deviceLabel || sourceLabel(connection.source)}</h2><p className="text-sm text-muted-foreground">{connection.clientDeviceId} {connection.appVersion ? `• app ${connection.appVersion}` : ""}</p></div><p className="max-w-2xl text-sm text-muted-foreground">{health.description}</p></div><DeviceActionForms connection={connection} /></div>
-                  <div className="mt-5 grid gap-3 text-sm md:grid-cols-2 xl:grid-cols-4"><div className="rounded-2xl border border-border/60 p-3"><div className="text-muted-foreground">Last sync</div><div className="mt-1 font-medium">{formatDateTime(connection.lastSyncedAt)}</div></div><div className="rounded-2xl border border-border/60 p-3"><div className="text-muted-foreground">Readings</div><div className="mt-1 font-medium">{connection._count.readings}</div></div><div className="rounded-2xl border border-border/60 p-3"><div className="text-muted-foreground">Sync jobs</div><div className="mt-1 font-medium">{connection._count.syncJobs}</div></div><div className="rounded-2xl border border-border/60 p-3"><div className="text-muted-foreground">Job runs</div><div className="mt-1 font-medium">{connection._count.jobRuns}</div></div></div>
-                  {scopes.length ? <div className="mt-4 flex flex-wrap gap-2">{scopes.map((scope) => <Badge key={scope}>{scope}</Badge>)}</div> : null}
-                  {connection.lastError ? <div className="mt-4 rounded-2xl border border-rose-200/70 bg-rose-50/70 p-4 text-sm text-rose-700 dark:border-rose-900/50 dark:bg-rose-950/30 dark:text-rose-200">{connection.lastError}</div> : null}
-                  {connection.status !== "REVOKED" ? <form action={revokeDeviceConnectionAction} className="mt-4 flex flex-col gap-2 rounded-2xl border border-border/60 bg-background/40 p-3 sm:flex-row sm:items-center"><input type="hidden" name="connectionId" value={connection.id} /><input name="confirmation" placeholder="Type REVOKE" className="h-9 rounded-xl border border-input bg-background/70 px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring" /><Button type="submit" variant="destructive" size="sm">Revoke</Button><p className="text-xs text-muted-foreground">Historical readings stay available for audit.</p></form> : null}
-                </div>;
+                return (
+                  <div
+                    key={connection.id}
+                    className="rounded-[28px] border border-border/60 bg-background/50 p-5"
+                  >
+                    <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+                      <div className="space-y-3">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Badge>{sourceLabel(connection.source)}</Badge>
+                          <Badge>{connection.platform}</Badge>
+                          <StatusPill
+                            tone={connectionStatusTone(connection.status)}
+                          >
+                            {connection.status}
+                          </StatusPill>
+                          <StatusPill tone={health.tone}>
+                            {health.label}
+                          </StatusPill>
+                          <StatusPill tone={reliability.tone}>
+                            {reliability.label}
+                          </StatusPill>
+                        </div>
+                        <div>
+                          <h2 className="text-lg font-semibold">
+                            {connection.deviceLabel ||
+                              sourceLabel(connection.source)}
+                          </h2>
+                          <p className="text-sm text-muted-foreground">
+                            {connection.clientDeviceId}{" "}
+                            {connection.appVersion
+                              ? `• app ${connection.appVersion}`
+                              : ""}
+                          </p>
+                        </div>
+                        <p className="max-w-2xl text-sm text-muted-foreground">
+                          {health.description} {reliability.nextStep}
+                        </p>
+                      </div>
+                      <DeviceActionForms connection={connection} />
+                    </div>
+                    <div className="mt-5 grid gap-3 text-sm md:grid-cols-2 xl:grid-cols-4">
+                      <div className="rounded-2xl border border-border/60 p-3">
+                        <div className="text-muted-foreground">Last sync</div>
+                        <div className="mt-1 font-medium">
+                          {formatDateTime(connection.lastSyncedAt)}
+                        </div>
+                        <div className="mt-1 text-xs text-muted-foreground">
+                          {reliability.syncAgeLabel}
+                        </div>
+                      </div>
+                      <div className="rounded-2xl border border-border/60 p-3">
+                        <div className="text-muted-foreground">Readings</div>
+                        <div className="mt-1 font-medium">
+                          {connection._count.readings}
+                        </div>
+                      </div>
+                      <div className="rounded-2xl border border-border/60 p-3">
+                        <div className="text-muted-foreground">Sync jobs</div>
+                        <div className="mt-1 font-medium">
+                          {connection._count.syncJobs}
+                        </div>
+                      </div>
+                      <div className="rounded-2xl border border-border/60 p-3">
+                        <div className="text-muted-foreground">Job runs</div>
+                        <div className="mt-1 font-medium">
+                          {connection._count.jobRuns}
+                        </div>
+                      </div>
+                    </div>
+                    {scopes.length ? (
+                      <div className="mt-4 flex flex-wrap gap-2">
+                        {scopes.map((scope) => (
+                          <Badge key={scope}>{scope}</Badge>
+                        ))}
+                      </div>
+                    ) : null}
+                    {connection.lastError ? (
+                      <div className="mt-4 rounded-2xl border border-rose-200/70 bg-rose-50/70 p-4 text-sm text-rose-700 dark:border-rose-900/50 dark:bg-rose-950/30 dark:text-rose-200">
+                        {connection.lastError}
+                      </div>
+                    ) : null}
+                    {connection.status !== "REVOKED" ? (
+                      <form
+                        action={revokeDeviceConnectionAction}
+                        className="mt-4 flex flex-col gap-2 rounded-2xl border border-border/60 bg-background/40 p-3 sm:flex-row sm:items-center"
+                      >
+                        <input
+                          type="hidden"
+                          name="connectionId"
+                          value={connection.id}
+                        />
+                        <input
+                          name="confirmation"
+                          placeholder="Type REVOKE"
+                          className="h-9 rounded-xl border border-input bg-background/70 px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        />
+                        <Button type="submit" variant="destructive" size="sm">
+                          Revoke
+                        </Button>
+                        <p className="text-xs text-muted-foreground">
+                          Historical readings stay available for audit.
+                        </p>
+                      </form>
+                    ) : null}
+                  </div>
+                );
               })}
-              {data.connections.length === 0 ? <EmptyState title="No device connections yet" description="Run the simulator or call the mobile device readings endpoint to create the first connection." /> : null}
+              {data.connections.length === 0 ? (
+                <EmptyState
+                  title="No device connections yet"
+                  description="Run the simulator or call the mobile device readings endpoint to create the first connection."
+                />
+              ) : null}
             </CardContent>
           </Card>
 
           <div className="space-y-6">
-            <Card><CardHeader><CardTitle>Provider connector map</CardTitle><CardDescription className="mt-1">Adapter contracts for phone health platforms, wearables, and smart devices that normalize into the same mobile API.</CardDescription></CardHeader><CardContent className="space-y-3"><div className="grid gap-3 sm:grid-cols-3"><div className="rounded-2xl border border-border/60 p-3"><div className="text-xs text-muted-foreground">Providers</div><div className="mt-1 text-2xl font-semibold">{data.providerSummary.totalConnectors}</div></div><div className="rounded-2xl border border-border/60 p-3"><div className="text-xs text-muted-foreground">API-ready</div><div className="mt-1 text-2xl font-semibold">{data.providerSummary.readyConnectors}</div></div><div className="rounded-2xl border border-border/60 p-3"><div className="text-xs text-muted-foreground">Reading types</div><div className="mt-1 text-2xl font-semibold">{data.providerSummary.supportedReadingTypes}</div></div></div>{data.providerConnectors.map((connector) => <div key={connector.source} className="rounded-2xl border border-border/60 bg-background/40 p-3"><div className="flex flex-wrap items-center justify-between gap-2"><div><p className="font-medium">{connector.label}</p><p className="mt-1 text-xs text-muted-foreground">{connectorCategoryLabel(connector.category)} • {connector.platformHints.join(", ")}</p></div><StatusPill tone={connector.status === "ready" ? "success" : connector.status === "simulated" ? "info" : "warning"}>{connectorStatusLabel(connector.status)}</StatusPill></div><p className="mt-2 text-xs text-muted-foreground">{connector.authModel}</p><div className="mt-3 flex flex-wrap gap-1">{connector.supportedReadings.slice(0, 4).map((type) => <Badge key={type}>{readingLabel(type)}</Badge>)}{connector.supportedReadings.length > 4 ? <Badge>+{connector.supportedReadings.length - 4}</Badge> : null}</div></div>)}</CardContent></Card>
-            <Card><CardHeader><CardTitle>Mobile API QA panel</CardTitle><CardDescription className="mt-1">Use this payload shape when testing a real mobile client or Postman request.</CardDescription></CardHeader><CardContent className="space-y-4"><pre className="max-h-[420px] overflow-auto rounded-2xl border border-border/60 bg-muted/40 p-4 text-xs">{JSON.stringify(data.qaPayload, null, 2)}</pre><div className="space-y-2">{data.qaChecklist.map((item) => <div key={item} className="flex items-start gap-2 text-sm text-muted-foreground"><ClipboardList className="mt-0.5 h-4 w-4 text-primary" /><span>{item}</span></div>)}</div></CardContent></Card>
-            <Card><CardHeader><CardTitle>Supported readings</CardTitle><CardDescription className="mt-1">Schema-backed values accepted by `/api/mobile/device-readings`.</CardDescription></CardHeader><CardContent className="space-y-3">{data.supportedReadings.map((reading) => <div key={reading.type} className="rounded-2xl border border-border/60 bg-background/40 p-3"><p className="font-medium">{readingLabel(reading.type)}</p><p className="mt-1 text-xs text-muted-foreground">Required: {reading.requiredValue}</p><p className="text-xs text-muted-foreground">{reading.behavior}</p></div>)}</CardContent></Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Provider connector map</CardTitle>
+                <CardDescription className="mt-1">
+                  Adapter contracts for phone health platforms, wearables, and
+                  smart devices that normalize into the same mobile API.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <div className="grid gap-3 sm:grid-cols-3">
+                  <div className="rounded-2xl border border-border/60 p-3">
+                    <div className="text-xs text-muted-foreground">
+                      Providers
+                    </div>
+                    <div className="mt-1 text-2xl font-semibold">
+                      {data.providerSummary.totalConnectors}
+                    </div>
+                  </div>
+                  <div className="rounded-2xl border border-border/60 p-3">
+                    <div className="text-xs text-muted-foreground">
+                      API-ready
+                    </div>
+                    <div className="mt-1 text-2xl font-semibold">
+                      {data.providerSummary.readyConnectors}
+                    </div>
+                  </div>
+                  <div className="rounded-2xl border border-border/60 p-3">
+                    <div className="text-xs text-muted-foreground">
+                      Reading types
+                    </div>
+                    <div className="mt-1 text-2xl font-semibold">
+                      {data.providerSummary.supportedReadingTypes}
+                    </div>
+                  </div>
+                </div>
+                {data.providerConnectors.map((connector) => (
+                  <div
+                    key={connector.source}
+                    className="rounded-2xl border border-border/60 bg-background/40 p-3"
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div>
+                        <p className="font-medium">{connector.label}</p>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {connectorCategoryLabel(connector.category)} •{" "}
+                          {connector.platformHints.join(", ")}
+                        </p>
+                      </div>
+                      <StatusPill
+                        tone={
+                          connector.status === "ready"
+                            ? "success"
+                            : connector.status === "simulated"
+                              ? "info"
+                              : "warning"
+                        }
+                      >
+                        {connectorStatusLabel(connector.status)}
+                      </StatusPill>
+                    </div>
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      {connector.authModel}
+                    </p>
+                    <div className="mt-3 flex flex-wrap gap-1">
+                      {connector.supportedReadings.slice(0, 4).map((type) => (
+                        <Badge key={type}>{readingLabel(type)}</Badge>
+                      ))}
+                      {connector.supportedReadings.length > 4 ? (
+                        <Badge>+{connector.supportedReadings.length - 4}</Badge>
+                      ) : null}
+                    </div>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Mobile API QA panel</CardTitle>
+                <CardDescription className="mt-1">
+                  Use this payload shape when testing a real mobile client or
+                  Postman request.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <pre className="max-h-[420px] overflow-auto rounded-2xl border border-border/60 bg-muted/40 p-4 text-xs">
+                  {JSON.stringify(data.qaPayload, null, 2)}
+                </pre>
+                <div className="space-y-2">
+                  {data.qaChecklist.map((item) => (
+                    <div
+                      key={item}
+                      className="flex items-start gap-2 text-sm text-muted-foreground"
+                    >
+                      <ClipboardList className="mt-0.5 h-4 w-4 text-primary" />
+                      <span>{item}</span>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Supported readings</CardTitle>
+                <CardDescription className="mt-1">
+                  Schema-backed values accepted by
+                  `/api/mobile/device-readings`.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {data.supportedReadings.map((reading) => (
+                  <div
+                    key={reading.type}
+                    className="rounded-2xl border border-border/60 bg-background/40 p-3"
+                  >
+                    <p className="font-medium">{readingLabel(reading.type)}</p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Required: {reading.requiredValue}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {reading.behavior}
+                    </p>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
           </div>
         </div>
 
         <div className="grid gap-6 lg:grid-cols-3">
-          <Card><CardHeader><CardTitle>Recent readings</CardTitle><CardDescription>Latest raw readings from any connection.</CardDescription></CardHeader><CardContent className="space-y-3">{data.recentReadings.map((reading) => <div key={reading.id} className="rounded-2xl border border-border/60 bg-background/50 p-4"><div className="flex flex-wrap items-center justify-between gap-2"><p className="font-medium">{readingLabel(reading.readingType)}</p><Badge>{sourceLabel(reading.source)}</Badge></div><p className="mt-2 text-2xl font-semibold">{readingDisplayValue(reading)}</p><p className="mt-1 text-xs text-muted-foreground">Captured {formatDateTime(reading.capturedAt)}</p></div>)}{data.recentReadings.length === 0 ? <EmptyState title="No readings yet" description="Accepted mobile/device readings will appear here." /> : null}</CardContent></Card>
-          <Card><CardHeader><CardTitle>Recent sync jobs</CardTitle><CardDescription>Accepted, mirrored, failed, and partial import runs.</CardDescription></CardHeader><CardContent className="space-y-3">{data.recentSyncJobs.map((job) => <div key={job.id} className="rounded-2xl border border-border/60 bg-background/50 p-4"><div className="flex flex-wrap items-center justify-between gap-2"><p className="font-medium">{sourceLabel(job.source)}</p><StatusPill tone={syncJobStatusTone(job.status)}>{job.status}</StatusPill></div><div className="mt-3 grid gap-1 text-xs text-muted-foreground"><p>Requested: {job.requestedCount}</p><p>Accepted: {job.acceptedCount}</p><p>Mirrored: {job.mirroredCount}</p><p>Created: {formatDateTime(job.createdAt)}</p></div>{job.connectionId ? <Link href={`/device-connection/${job.connectionId}`} className="mt-3 inline-flex text-sm font-medium text-primary hover:underline">Open connection</Link> : null}{job.errorMessage ? <p className="mt-3 text-sm text-destructive">{job.errorMessage}</p> : null}</div>)}{data.recentSyncJobs.length === 0 ? <EmptyState title="No sync jobs yet" description="Mobile imports and simulator runs will create sync jobs." /> : null}</CardContent></Card>
-          <Card><CardHeader><CardTitle>Security posture</CardTitle><CardDescription>How this module stays honest for a portfolio/demo app.</CardDescription></CardHeader><CardContent className="space-y-4 text-sm text-muted-foreground"><div className="flex items-start gap-3 rounded-2xl border border-border/60 p-4"><Lock className="mt-0.5 h-4 w-4 text-primary" /><div>Mobile bearer tokens are separate from browser sessions and can be revoked from Security.</div></div><div className="flex items-start gap-3 rounded-2xl border border-border/60 p-4"><RefreshCcw className="mt-0.5 h-4 w-4 text-primary" /><div>Each ingestion run creates a sync job so imports can be audited and reviewed.</div></div><div className="flex items-start gap-3 rounded-2xl border border-border/60 p-4"><HeartPulse className="mt-0.5 h-4 w-4 text-primary" /><div>Supported readings mirror into normal vitals, while raw readings remain traceable.</div></div><div className="flex items-start gap-3 rounded-2xl border border-border/60 p-4"><AlertTriangle className="mt-0.5 h-4 w-4 text-primary" /><div>Device data is informational and not clinical advice or a medical-device workflow.</div></div></CardContent></Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Recent readings</CardTitle>
+              <CardDescription>
+                Latest raw readings from any connection.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {data.recentReadings.map((reading) => (
+                <div
+                  key={reading.id}
+                  className="rounded-2xl border border-border/60 bg-background/50 p-4"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="font-medium">
+                      {readingLabel(reading.readingType)}
+                    </p>
+                    <Badge>{sourceLabel(reading.source)}</Badge>
+                  </div>
+                  <p className="mt-2 text-2xl font-semibold">
+                    {readingDisplayValue(reading)}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Captured {formatDateTime(reading.capturedAt)}
+                  </p>
+                </div>
+              ))}
+              {data.recentReadings.length === 0 ? (
+                <EmptyState
+                  title="No readings yet"
+                  description="Accepted mobile/device readings will appear here."
+                />
+              ) : null}
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Recent sync jobs</CardTitle>
+              <CardDescription>
+                Accepted, mirrored, failed, and partial import runs.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {data.recentSyncJobs.map((job) => (
+                <div
+                  key={job.id}
+                  className="rounded-2xl border border-border/60 bg-background/50 p-4"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="font-medium">{sourceLabel(job.source)}</p>
+                    <StatusPill tone={syncJobStatusTone(job.status)}>
+                      {job.status}
+                    </StatusPill>
+                  </div>
+                  <div className="mt-3 grid gap-1 text-xs text-muted-foreground">
+                    <p>Requested: {job.requestedCount}</p>
+                    <p>Accepted: {job.acceptedCount}</p>
+                    <p>Mirrored: {job.mirroredCount}</p>
+                    <p>Created: {formatDateTime(job.createdAt)}</p>
+                  </div>
+                  {job.connectionId ? (
+                    <Link
+                      href={`/device-connection/${job.connectionId}`}
+                      className="mt-3 inline-flex text-sm font-medium text-primary hover:underline"
+                    >
+                      Open connection
+                    </Link>
+                  ) : null}
+                  {job.errorMessage ? (
+                    <p className="mt-3 text-sm text-destructive">
+                      {job.errorMessage}
+                    </p>
+                  ) : null}
+                </div>
+              ))}
+              {data.recentSyncJobs.length === 0 ? (
+                <EmptyState
+                  title="No sync jobs yet"
+                  description="Mobile imports and simulator runs will create sync jobs."
+                />
+              ) : null}
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Security posture</CardTitle>
+              <CardDescription>
+                How this module stays honest for a portfolio/demo app.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4 text-sm text-muted-foreground">
+              <div className="flex items-start gap-3 rounded-2xl border border-border/60 p-4">
+                <Lock className="mt-0.5 h-4 w-4 text-primary" />
+                <div>
+                  Mobile bearer tokens are separate from browser sessions and
+                  can be revoked from Security.
+                </div>
+              </div>
+              <div className="flex items-start gap-3 rounded-2xl border border-border/60 p-4">
+                <RefreshCcw className="mt-0.5 h-4 w-4 text-primary" />
+                <div>
+                  Each ingestion run creates a sync job so imports can be
+                  audited and reviewed.
+                </div>
+              </div>
+              <div className="flex items-start gap-3 rounded-2xl border border-border/60 p-4">
+                <HeartPulse className="mt-0.5 h-4 w-4 text-primary" />
+                <div>
+                  Supported readings mirror into normal vitals, while raw
+                  readings remain traceable.
+                </div>
+              </div>
+              <div className="flex items-start gap-3 rounded-2xl border border-border/60 p-4">
+                <AlertTriangle className="mt-0.5 h-4 w-4 text-primary" />
+                <div>
+                  Device data is informational and not clinical advice or a
+                  medical-device workflow.
+                </div>
+              </div>
+            </CardContent>
+          </Card>
         </div>
       </div>
     </AppShell>

--- a/docs/PATCH_62_DEVICE_CONNECTION_RELIABILITY_PANEL.md
+++ b/docs/PATCH_62_DEVICE_CONNECTION_RELIABILITY_PANEL.md
@@ -1,0 +1,63 @@
+# Patch 62 — Device Connection Reliability Panel
+
+## Summary
+
+Adds an operational reliability layer to the Device Integrations workspace without changing the database schema. The patch makes device freshness, blocked syncs, stale connections, paused devices, and first-sync status visible from both the list and detail pages.
+
+## Files changed
+
+- `lib/device-integrations.ts`
+- `app/device-connection/page.tsx`
+- `app/device-connection/[id]/page.tsx`
+- `tests/device-integrations.test.ts`
+
+## What changed
+
+- Added schema-safe device reliability helpers:
+  - `buildDeviceReliabilitySignal()`
+  - `buildConnectionReliabilitySummary()`
+- Added freshness thresholds:
+  - 24 hours: sync due
+  - 72 hours: stale sync
+- Added dashboard reliability summary counts for:
+  - Current
+  - Sync due
+  - Stale
+  - Blocked
+  - Paused
+  - Awaiting first sync
+  - Revoked
+  - Needs review
+- Added reliability badges and next-step guidance to each connection card.
+- Added a detail-page reliability panel with freshness and remediation guidance.
+- Added regression tests for reliability classification and summary counts.
+
+## Safety notes
+
+- No Prisma migration.
+- No dependency changes.
+- No README changes.
+- No API behavior changes.
+- No server action behavior changes.
+- Uses existing `DeviceConnection` fields only: status, last sync, and last error.
+
+## Validation
+
+Run:
+
+```powershell
+npm install
+npm run db:validate:ci
+npm run actions:check
+npm run actions:imports
+npm run actions:shadow
+npm run typecheck
+npm run lint
+npm run test:run
+```
+
+Targeted test:
+
+```powershell
+npm run test:run -- tests/device-integrations.test.ts
+```

--- a/lib/device-integrations.ts
+++ b/lib/device-integrations.ts
@@ -8,9 +8,17 @@ import {
 import { db } from "@/lib/db";
 import { getMobileSecurityChecklist } from "@/lib/mobile-api-security";
 import { SUPPORTED_DEVICE_READINGS } from "@/lib/mobile-device-api";
-import { buildProviderCapabilitySummary, getDeviceProviderConnectors } from "@/lib/device-provider-connectors";
+import {
+  buildProviderCapabilitySummary,
+  getDeviceProviderConnectors,
+} from "@/lib/device-provider-connectors";
 
-export type DeviceConnectionHealthTone = "neutral" | "info" | "success" | "warning" | "danger";
+export type DeviceConnectionHealthTone =
+  | "neutral"
+  | "info"
+  | "success"
+  | "warning"
+  | "danger";
 
 export const DEVICE_QA_SAMPLE_PAYLOAD = {
   source: ReadingSource.ANDROID_HEALTH_CONNECT,
@@ -19,26 +27,58 @@ export const DEVICE_QA_SAMPLE_PAYLOAD = {
   deviceLabel: "Pixel 8 Pro",
   appVersion: "1.0.0",
   scopes: ["vitals:write", "device:sync"],
-  syncMetadata: { batteryLevel: 88, network: "wifi", importMode: "manual-qa-panel" },
+  syncMetadata: {
+    batteryLevel: 88,
+    network: "wifi",
+    importMode: "manual-qa-panel",
+  },
   readings: [
-    { readingType: DeviceReadingType.HEART_RATE, capturedAt: "2026-05-07T08:35:00.000Z", clientReadingId: "hr-qa-001", unit: "bpm", valueInt: 78 },
-    { readingType: DeviceReadingType.BLOOD_PRESSURE, capturedAt: "2026-05-07T08:36:00.000Z", clientReadingId: "bp-qa-001", unit: "mmHg", systolic: 118, diastolic: 76 },
-    { readingType: DeviceReadingType.WEIGHT, capturedAt: "2026-05-07T08:37:00.000Z", clientReadingId: "weight-qa-001", unit: "kg", valueFloat: 71.4 },
+    {
+      readingType: DeviceReadingType.HEART_RATE,
+      capturedAt: "2026-05-07T08:35:00.000Z",
+      clientReadingId: "hr-qa-001",
+      unit: "bpm",
+      valueInt: 78,
+    },
+    {
+      readingType: DeviceReadingType.BLOOD_PRESSURE,
+      capturedAt: "2026-05-07T08:36:00.000Z",
+      clientReadingId: "bp-qa-001",
+      unit: "mmHg",
+      systolic: 118,
+      diastolic: 76,
+    },
+    {
+      readingType: DeviceReadingType.WEIGHT,
+      capturedAt: "2026-05-07T08:37:00.000Z",
+      clientReadingId: "weight-qa-001",
+      unit: "kg",
+      valueFloat: 71.4,
+    },
   ],
 } as const;
 
 export function sourceLabel(value: string) {
-  return value.toLowerCase().split("_").map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join(" ");
+  return value
+    .toLowerCase()
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
 }
 
 export function formatDateTime(value: Date | string | null | undefined) {
   if (!value) return "—";
   const date = value instanceof Date ? value : new Date(value);
   if (Number.isNaN(date.getTime())) return "—";
-  return new Intl.DateTimeFormat("en-PH", { dateStyle: "medium", timeStyle: "short" }).format(date);
+  return new Intl.DateTimeFormat("en-PH", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
 }
 
-export function connectionStatusTone(status: DeviceConnectionStatus | string): DeviceConnectionHealthTone {
+export function connectionStatusTone(
+  status: DeviceConnectionStatus | string,
+): DeviceConnectionHealthTone {
   if (status === DeviceConnectionStatus.ACTIVE) return "success";
   if (status === DeviceConnectionStatus.ERROR) return "danger";
   if (status === DeviceConnectionStatus.DISCONNECTED) return "warning";
@@ -46,9 +86,16 @@ export function connectionStatusTone(status: DeviceConnectionStatus | string): D
   return "neutral";
 }
 
-export function syncJobStatusTone(status: SyncJobStatus | string): DeviceConnectionHealthTone {
+export function syncJobStatusTone(
+  status: SyncJobStatus | string,
+): DeviceConnectionHealthTone {
   if (status === SyncJobStatus.SUCCEEDED) return "success";
-  if (status === SyncJobStatus.PARTIAL || status === SyncJobStatus.RUNNING || status === SyncJobStatus.QUEUED) return "info";
+  if (
+    status === SyncJobStatus.PARTIAL ||
+    status === SyncJobStatus.RUNNING ||
+    status === SyncJobStatus.QUEUED
+  )
+    return "info";
   if (status === SyncJobStatus.FAILED) return "danger";
   return "neutral";
 }
@@ -57,8 +104,19 @@ export function readingLabel(type: DeviceReadingType | string) {
   return sourceLabel(type);
 }
 
-export function readingDisplayValue(reading: { readingType: DeviceReadingType | string; unit: string | null; valueInt: number | null; valueFloat: number | null; systolic: number | null; diastolic: number | null; }) {
-  if (reading.readingType === DeviceReadingType.BLOOD_PRESSURE && reading.systolic && reading.diastolic) {
+export function readingDisplayValue(reading: {
+  readingType: DeviceReadingType | string;
+  unit: string | null;
+  valueInt: number | null;
+  valueFloat: number | null;
+  systolic: number | null;
+  diastolic: number | null;
+}) {
+  if (
+    reading.readingType === DeviceReadingType.BLOOD_PRESSURE &&
+    reading.systolic &&
+    reading.diastolic
+  ) {
     return `${reading.systolic}/${reading.diastolic} ${reading.unit || "mmHg"}`;
   }
   const value = reading.valueInt ?? reading.valueFloat;
@@ -70,7 +128,12 @@ export function parseScopes(scopesJson: string | null | undefined) {
   if (!scopesJson) return [];
   try {
     const parsed = JSON.parse(scopesJson);
-    return Array.isArray(parsed) ? parsed.filter((scope): scope is string => typeof scope === "string" && scope.trim().length > 0) : [];
+    return Array.isArray(parsed)
+      ? parsed.filter(
+          (scope): scope is string =>
+            typeof scope === "string" && scope.trim().length > 0,
+        )
+      : [];
   } catch {
     return [];
   }
@@ -80,23 +143,216 @@ export function parseJsonObject(value: string | null | undefined) {
   if (!value) return null;
   try {
     const parsed = JSON.parse(value);
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : null;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
   } catch {
     return null;
   }
 }
 
-export function buildConnectionHealthSummary(connection: { status: DeviceConnectionStatus; lastSyncedAt: Date | null; lastError: string | null; _count?: { readings?: number; syncJobs?: number; jobRuns?: number }; }) {
+export function buildConnectionHealthSummary(connection: {
+  status: DeviceConnectionStatus;
+  lastSyncedAt: Date | null;
+  lastError: string | null;
+  _count?: { readings?: number; syncJobs?: number; jobRuns?: number };
+}) {
   const readingCount = connection._count?.readings ?? 0;
   const syncJobCount = connection._count?.syncJobs ?? 0;
-  if (connection.status === DeviceConnectionStatus.REVOKED) return { tone: "danger" as const, label: "Revoked", description: "This device can no longer sync readings." };
-  if (connection.status === DeviceConnectionStatus.ERROR || connection.lastError) return { tone: "danger" as const, label: "Needs review", description: connection.lastError || "Last sync ended with an error." };
-  if (connection.status === DeviceConnectionStatus.DISCONNECTED) return { tone: "warning" as const, label: "Disconnected", description: "The connection is paused until you mark it active again." };
-  if (!connection.lastSyncedAt) return { tone: "info" as const, label: "Ready", description: "Connection exists but has not synced readings yet." };
-  return { tone: "success" as const, label: "Healthy", description: `${readingCount} reading${readingCount === 1 ? "" : "s"} across ${syncJobCount} sync job${syncJobCount === 1 ? "" : "s"}.` };
+  if (connection.status === DeviceConnectionStatus.REVOKED)
+    return {
+      tone: "danger" as const,
+      label: "Revoked",
+      description: "This device can no longer sync readings.",
+    };
+  if (
+    connection.status === DeviceConnectionStatus.ERROR ||
+    connection.lastError
+  )
+    return {
+      tone: "danger" as const,
+      label: "Needs review",
+      description: connection.lastError || "Last sync ended with an error.",
+    };
+  if (connection.status === DeviceConnectionStatus.DISCONNECTED)
+    return {
+      tone: "warning" as const,
+      label: "Disconnected",
+      description: "The connection is paused until you mark it active again.",
+    };
+  if (!connection.lastSyncedAt)
+    return {
+      tone: "info" as const,
+      label: "Ready",
+      description: "Connection exists but has not synced readings yet.",
+    };
+  return {
+    tone: "success" as const,
+    label: "Healthy",
+    description: `${readingCount} reading${readingCount === 1 ? "" : "s"} across ${syncJobCount} sync job${syncJobCount === 1 ? "" : "s"}.`,
+  };
 }
 
-export function buildDeviceQaCurl(baseUrl = "https://your-vitavault-domain.com") {
+export const DEVICE_SYNC_ATTENTION_HOURS = 24;
+export const DEVICE_SYNC_STALE_HOURS = 72;
+
+type ReliabilityConnection = {
+  status: DeviceConnectionStatus | string;
+  lastSyncedAt: Date | string | null;
+  lastError: string | null;
+  _count?: { readings?: number; syncJobs?: number; jobRuns?: number };
+};
+
+function ageInHours(value: Date | string | null | undefined, now: Date) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return Math.max(
+    0,
+    Math.round((now.getTime() - date.getTime()) / 36_000) / 100,
+  );
+}
+
+function formatAge(hours: number | null) {
+  if (hours === null) return "never";
+  if (hours < 1) return "less than 1 hour ago";
+  if (hours < 24)
+    return `${Math.round(hours)} hour${Math.round(hours) === 1 ? "" : "s"} ago`;
+  const days = Math.round(hours / 24);
+  return `${days} day${days === 1 ? "" : "s"} ago`;
+}
+
+export function buildDeviceReliabilitySignal(
+  connection: ReliabilityConnection,
+  now = new Date(),
+) {
+  const hoursSinceLastSync = ageInHours(connection.lastSyncedAt, now);
+  const syncAgeLabel = formatAge(hoursSinceLastSync);
+
+  if (connection.status === DeviceConnectionStatus.REVOKED) {
+    return {
+      tone: "danger" as const,
+      label: "Revoked",
+      description: "Connection has been revoked and cannot sync new readings.",
+      nextStep: "Create a new device link if this source should be used again.",
+      syncAgeLabel,
+      hoursSinceLastSync,
+      needsReview: true,
+      isStale: false,
+    };
+  }
+
+  if (
+    connection.status === DeviceConnectionStatus.ERROR ||
+    connection.lastError
+  ) {
+    return {
+      tone: "danger" as const,
+      label: "Blocked",
+      description:
+        connection.lastError || "Last sync reported an error and needs review.",
+      nextStep:
+        "Open the device detail page, review the last error, then reconnect or clear it after validation.",
+      syncAgeLabel,
+      hoursSinceLastSync,
+      needsReview: true,
+      isStale: true,
+    };
+  }
+
+  if (connection.status === DeviceConnectionStatus.DISCONNECTED) {
+    return {
+      tone: "warning" as const,
+      label: "Paused",
+      description:
+        "Connection is disconnected and will not accept fresh mobile/device readings.",
+      nextStep:
+        "Reconnect when the user confirms this device should sync again.",
+      syncAgeLabel,
+      hoursSinceLastSync,
+      needsReview: true,
+      isStale: false,
+    };
+  }
+
+  if (hoursSinceLastSync === null) {
+    return {
+      tone: "info" as const,
+      label: "Awaiting first sync",
+      description:
+        "Connection exists but has not submitted a reading batch yet.",
+      nextStep: "Run the simulator or submit a mobile device-readings payload.",
+      syncAgeLabel,
+      hoursSinceLastSync,
+      needsReview: false,
+      isStale: false,
+    };
+  }
+
+  if (hoursSinceLastSync >= DEVICE_SYNC_STALE_HOURS) {
+    return {
+      tone: "warning" as const,
+      label: "Stale sync",
+      description: `Last successful sync was ${syncAgeLabel}.`,
+      nextStep:
+        "Ask the device client to refresh permissions, token state, and background sync settings.",
+      syncAgeLabel,
+      hoursSinceLastSync,
+      needsReview: true,
+      isStale: true,
+    };
+  }
+
+  if (hoursSinceLastSync >= DEVICE_SYNC_ATTENTION_HOURS) {
+    return {
+      tone: "info" as const,
+      label: "Sync due",
+      description: `Last successful sync was ${syncAgeLabel}.`,
+      nextStep:
+        "Monitor the next scheduled mobile sync or run a manual QA payload.",
+      syncAgeLabel,
+      hoursSinceLastSync,
+      needsReview: false,
+      isStale: false,
+    };
+  }
+
+  return {
+    tone: "success" as const,
+    label: "Current",
+    description: `Last successful sync was ${syncAgeLabel}.`,
+    nextStep: "No action needed.",
+    syncAgeLabel,
+    hoursSinceLastSync,
+    needsReview: false,
+    isStale: false,
+  };
+}
+
+export function buildConnectionReliabilitySummary(
+  connections: ReliabilityConnection[],
+  now = new Date(),
+) {
+  const signals = connections.map((connection) =>
+    buildDeviceReliabilitySignal(connection, now),
+  );
+  return {
+    current: signals.filter((signal) => signal.label === "Current").length,
+    due: signals.filter((signal) => signal.label === "Sync due").length,
+    stale: signals.filter((signal) => signal.label === "Stale sync").length,
+    blocked: signals.filter((signal) => signal.label === "Blocked").length,
+    paused: signals.filter((signal) => signal.label === "Paused").length,
+    revoked: signals.filter((signal) => signal.label === "Revoked").length,
+    awaitingFirstSync: signals.filter(
+      (signal) => signal.label === "Awaiting first sync",
+    ).length,
+    needsReview: signals.filter((signal) => signal.needsReview).length,
+  };
+}
+
+export function buildDeviceQaCurl(
+  baseUrl = "https://your-vitavault-domain.com",
+) {
   return [
     `curl -X POST ${baseUrl}/api/mobile/device-readings \\`,
     '  -H "Authorization: Bearer <mobile_token>" \\',
@@ -117,38 +373,106 @@ export function buildDeviceQaChecklist() {
 }
 
 export async function getDeviceIntegrationDashboardData(userId: string) {
-  const [connections, recentReadings, recentSyncJobs, mirroredVitals, mobileSessions] = await Promise.all([
+  const [
+    connections,
+    recentReadings,
+    recentSyncJobs,
+    mirroredVitals,
+    mobileSessions,
+  ] = await Promise.all([
     db.deviceConnection.findMany({
       where: { userId },
       orderBy: [{ updatedAt: "desc" }, { createdAt: "desc" }],
-      select: { id: true, source: true, platform: true, clientDeviceId: true, deviceLabel: true, appVersion: true, status: true, scopesJson: true, lastSyncedAt: true, lastError: true, createdAt: true, updatedAt: true, _count: { select: { readings: true, syncJobs: true, jobRuns: true } } },
+      select: {
+        id: true,
+        source: true,
+        platform: true,
+        clientDeviceId: true,
+        deviceLabel: true,
+        appVersion: true,
+        status: true,
+        scopesJson: true,
+        lastSyncedAt: true,
+        lastError: true,
+        createdAt: true,
+        updatedAt: true,
+        _count: { select: { readings: true, syncJobs: true, jobRuns: true } },
+      },
     }),
     db.deviceReading.findMany({
       where: { userId },
       orderBy: { capturedAt: "desc" },
       take: 10,
-      select: { id: true, connectionId: true, source: true, platform: true, readingType: true, capturedAt: true, unit: true, valueInt: true, valueFloat: true, systolic: true, diastolic: true },
+      select: {
+        id: true,
+        connectionId: true,
+        source: true,
+        platform: true,
+        readingType: true,
+        capturedAt: true,
+        unit: true,
+        valueInt: true,
+        valueFloat: true,
+        systolic: true,
+        diastolic: true,
+      },
     }),
     db.syncJob.findMany({
       where: { userId },
       orderBy: { createdAt: "desc" },
       take: 10,
-      select: { id: true, connectionId: true, source: true, platform: true, status: true, requestedCount: true, acceptedCount: true, mirroredCount: true, errorMessage: true, createdAt: true, finishedAt: true },
+      select: {
+        id: true,
+        connectionId: true,
+        source: true,
+        platform: true,
+        status: true,
+        requestedCount: true,
+        acceptedCount: true,
+        mirroredCount: true,
+        errorMessage: true,
+        createdAt: true,
+        finishedAt: true,
+      },
     }),
     db.vitalRecord.findMany({
       where: { userId, readingSource: { not: ReadingSource.MANUAL } },
       orderBy: { recordedAt: "desc" },
       take: 8,
-      select: { id: true, recordedAt: true, readingSource: true, systolic: true, diastolic: true, heartRate: true, bloodSugar: true, oxygenSaturation: true, temperatureC: true, weightKg: true, notes: true },
+      select: {
+        id: true,
+        recordedAt: true,
+        readingSource: true,
+        systolic: true,
+        diastolic: true,
+        heartRate: true,
+        bloodSugar: true,
+        oxygenSaturation: true,
+        temperatureC: true,
+        weightKg: true,
+        notes: true,
+      },
     }),
     db.mobileSessionToken.findMany({
       where: { userId },
       orderBy: { createdAt: "desc" },
       take: 6,
-      select: { id: true, name: true, expiresAt: true, lastUsedAt: true, revokedAt: true, createdAt: true },
+      select: {
+        id: true,
+        name: true,
+        expiresAt: true,
+        lastUsedAt: true,
+        revokedAt: true,
+        createdAt: true,
+      },
     }),
   ]);
   const providerConnectors = getDeviceProviderConnectors();
+  const reliabilitySummary = buildConnectionReliabilitySummary(connections);
+  const connectionsWithReliability = connections.map((connection) => ({
+    ...connection,
+    reliability: buildDeviceReliabilitySignal(connection),
+  }));
   return {
     supportedReadings: SUPPORTED_DEVICE_READINGS,
     providerConnectors,
@@ -156,38 +480,152 @@ export async function getDeviceIntegrationDashboardData(userId: string) {
     qaPayload: DEVICE_QA_SAMPLE_PAYLOAD,
     qaCurl: buildDeviceQaCurl(),
     qaChecklist: buildDeviceQaChecklist(),
-    connections,
+    connections: connectionsWithReliability,
     recentReadings,
     recentSyncJobs,
     mirroredVitals,
     mobileSessions,
     summary: {
       totalConnections: connections.length,
-      activeConnections: connections.filter((connection) => connection.status === DeviceConnectionStatus.ACTIVE).length,
-      erroredConnections: connections.filter((connection) => connection.status === DeviceConnectionStatus.ERROR).length,
-      disconnectedConnections: connections.filter((connection) => connection.status === DeviceConnectionStatus.DISCONNECTED).length,
-      revokedConnections: connections.filter((connection) => connection.status === DeviceConnectionStatus.REVOKED).length,
-      totalReadings: connections.reduce((total, connection) => total + connection._count.readings, 0),
-      totalSyncJobs: connections.reduce((total, connection) => total + connection._count.syncJobs, 0),
+      activeConnections: connections.filter(
+        (connection) => connection.status === DeviceConnectionStatus.ACTIVE,
+      ).length,
+      erroredConnections: connections.filter(
+        (connection) => connection.status === DeviceConnectionStatus.ERROR,
+      ).length,
+      disconnectedConnections: connections.filter(
+        (connection) =>
+          connection.status === DeviceConnectionStatus.DISCONNECTED,
+      ).length,
+      revokedConnections: connections.filter(
+        (connection) => connection.status === DeviceConnectionStatus.REVOKED,
+      ).length,
+      totalReadings: connections.reduce(
+        (total, connection) => total + connection._count.readings,
+        0,
+      ),
+      totalSyncJobs: connections.reduce(
+        (total, connection) => total + connection._count.syncJobs,
+        0,
+      ),
       recentReadings: recentReadings.length,
-      acceptedCount: recentSyncJobs.reduce((total, job) => total + job.acceptedCount, 0),
-      mirroredCount: recentSyncJobs.reduce((total, job) => total + job.mirroredCount, 0),
-      activeSessions: mobileSessions.filter((session) => !session.revokedAt && session.expiresAt > new Date()).length,
+      acceptedCount: recentSyncJobs.reduce(
+        (total, job) => total + job.acceptedCount,
+        0,
+      ),
+      mirroredCount: recentSyncJobs.reduce(
+        (total, job) => total + job.mirroredCount,
+        0,
+      ),
+      activeSessions: mobileSessions.filter(
+        (session) => !session.revokedAt && session.expiresAt > new Date(),
+      ).length,
+      reliability: reliabilitySummary,
     },
   };
 }
 
-export async function getDeviceConnectionDetailData(params: { userId: string; connectionId: string }) {
+export async function getDeviceConnectionDetailData(params: {
+  userId: string;
+  connectionId: string;
+}) {
   const connection = await db.deviceConnection.findFirst({
     where: { id: params.connectionId, userId: params.userId },
-    select: { id: true, source: true, platform: true, clientDeviceId: true, deviceLabel: true, appVersion: true, status: true, scopesJson: true, lastSyncedAt: true, lastError: true, createdAt: true, updatedAt: true, _count: { select: { readings: true, syncJobs: true, jobRuns: true } } },
+    select: {
+      id: true,
+      source: true,
+      platform: true,
+      clientDeviceId: true,
+      deviceLabel: true,
+      appVersion: true,
+      status: true,
+      scopesJson: true,
+      lastSyncedAt: true,
+      lastError: true,
+      createdAt: true,
+      updatedAt: true,
+      _count: { select: { readings: true, syncJobs: true, jobRuns: true } },
+    },
   });
   if (!connection) return null;
   const [readings, syncJobs, jobRuns, mirroredVitals] = await Promise.all([
-    db.deviceReading.findMany({ where: { userId: params.userId, connectionId: connection.id }, orderBy: { capturedAt: "desc" }, take: 25, select: { id: true, readingType: true, capturedAt: true, unit: true, valueInt: true, valueFloat: true, systolic: true, diastolic: true, metadataJson: true, rawPayloadJson: true } }),
-    db.syncJob.findMany({ where: { userId: params.userId, connectionId: connection.id }, orderBy: { createdAt: "desc" }, take: 12, select: { id: true, status: true, requestedCount: true, acceptedCount: true, mirroredCount: true, errorMessage: true, metadataJson: true, startedAt: true, finishedAt: true, createdAt: true } }),
-    db.jobRun.findMany({ where: { userId: params.userId, connectionId: connection.id }, orderBy: { createdAt: "desc" }, take: 8, select: { id: true, jobName: true, jobKind: true, status: true, attemptsMade: true, maxAttempts: true, errorMessage: true, createdAt: true, finishedAt: true } }),
-    db.vitalRecord.findMany({ where: { userId: params.userId, readingSource: connection.source }, orderBy: { recordedAt: "desc" }, take: 10, select: { id: true, recordedAt: true, readingSource: true, systolic: true, diastolic: true, heartRate: true, bloodSugar: true, oxygenSaturation: true, temperatureC: true, weightKg: true, notes: true } }),
+    db.deviceReading.findMany({
+      where: { userId: params.userId, connectionId: connection.id },
+      orderBy: { capturedAt: "desc" },
+      take: 25,
+      select: {
+        id: true,
+        readingType: true,
+        capturedAt: true,
+        unit: true,
+        valueInt: true,
+        valueFloat: true,
+        systolic: true,
+        diastolic: true,
+        metadataJson: true,
+        rawPayloadJson: true,
+      },
+    }),
+    db.syncJob.findMany({
+      where: { userId: params.userId, connectionId: connection.id },
+      orderBy: { createdAt: "desc" },
+      take: 12,
+      select: {
+        id: true,
+        status: true,
+        requestedCount: true,
+        acceptedCount: true,
+        mirroredCount: true,
+        errorMessage: true,
+        metadataJson: true,
+        startedAt: true,
+        finishedAt: true,
+        createdAt: true,
+      },
+    }),
+    db.jobRun.findMany({
+      where: { userId: params.userId, connectionId: connection.id },
+      orderBy: { createdAt: "desc" },
+      take: 8,
+      select: {
+        id: true,
+        jobName: true,
+        jobKind: true,
+        status: true,
+        attemptsMade: true,
+        maxAttempts: true,
+        errorMessage: true,
+        createdAt: true,
+        finishedAt: true,
+      },
+    }),
+    db.vitalRecord.findMany({
+      where: { userId: params.userId, readingSource: connection.source },
+      orderBy: { recordedAt: "desc" },
+      take: 10,
+      select: {
+        id: true,
+        recordedAt: true,
+        readingSource: true,
+        systolic: true,
+        diastolic: true,
+        heartRate: true,
+        bloodSugar: true,
+        oxygenSaturation: true,
+        temperatureC: true,
+        weightKg: true,
+        notes: true,
+      },
+    }),
   ]);
-  return { connection, readings, syncJobs, jobRuns, mirroredVitals, scopes: parseScopes(connection.scopesJson), health: buildConnectionHealthSummary(connection) };
+  return {
+    connection,
+    readings,
+    syncJobs,
+    jobRuns,
+    mirroredVitals,
+    scopes: parseScopes(connection.scopesJson),
+    health: buildConnectionHealthSummary(connection),
+    reliability: buildDeviceReliabilitySignal(connection),
+  };
 }

--- a/tests/device-integrations.test.ts
+++ b/tests/device-integrations.test.ts
@@ -1,36 +1,93 @@
 import { describe, expect, it, vi } from "vitest";
-import { DeviceConnectionStatus, DeviceReadingType, ReadingSource, SyncJobStatus } from "@prisma/client";
+import {
+  DeviceConnectionStatus,
+  DeviceReadingType,
+  ReadingSource,
+  SyncJobStatus,
+} from "@prisma/client";
 
 vi.mock("@/lib/db", () => ({ db: {} }));
 
 describe("device integration helpers", () => {
   it("formats labels, readings, and scopes safely", async () => {
-    const { sourceLabel, readingLabel, readingDisplayValue, parseScopes } = await import("@/lib/device-integrations");
-    expect(sourceLabel(ReadingSource.ANDROID_HEALTH_CONNECT)).toBe("Android Health Connect");
-    expect(readingLabel(DeviceReadingType.OXYGEN_SATURATION)).toBe("Oxygen Saturation");
-    expect(parseScopes('["vitals:write","device:sync",123]')).toEqual(["vitals:write", "device:sync"]);
+    const { sourceLabel, readingLabel, readingDisplayValue, parseScopes } =
+      await import("@/lib/device-integrations");
+    expect(sourceLabel(ReadingSource.ANDROID_HEALTH_CONNECT)).toBe(
+      "Android Health Connect",
+    );
+    expect(readingLabel(DeviceReadingType.OXYGEN_SATURATION)).toBe(
+      "Oxygen Saturation",
+    );
+    expect(parseScopes('["vitals:write","device:sync",123]')).toEqual([
+      "vitals:write",
+      "device:sync",
+    ]);
     expect(parseScopes("not-json")).toEqual([]);
-    expect(readingDisplayValue({ readingType: DeviceReadingType.BLOOD_PRESSURE, unit: "mmHg", valueInt: null, valueFloat: null, systolic: 120, diastolic: 78 })).toBe("120/78 mmHg");
+    expect(
+      readingDisplayValue({
+        readingType: DeviceReadingType.BLOOD_PRESSURE,
+        unit: "mmHg",
+        valueInt: null,
+        valueFloat: null,
+        systolic: 120,
+        diastolic: 78,
+      }),
+    ).toBe("120/78 mmHg");
   });
 
   it("maps connection and sync states to portfolio-safe tones", async () => {
-    const { connectionStatusTone, syncJobStatusTone, buildConnectionHealthSummary } = await import("@/lib/device-integrations");
+    const {
+      connectionStatusTone,
+      syncJobStatusTone,
+      buildConnectionHealthSummary,
+    } = await import("@/lib/device-integrations");
     expect(connectionStatusTone(DeviceConnectionStatus.ACTIVE)).toBe("success");
-    expect(connectionStatusTone(DeviceConnectionStatus.DISCONNECTED)).toBe("warning");
+    expect(connectionStatusTone(DeviceConnectionStatus.DISCONNECTED)).toBe(
+      "warning",
+    );
     expect(connectionStatusTone(DeviceConnectionStatus.ERROR)).toBe("danger");
     expect(syncJobStatusTone(SyncJobStatus.SUCCEEDED)).toBe("success");
     expect(syncJobStatusTone(SyncJobStatus.PARTIAL)).toBe("info");
     expect(syncJobStatusTone(SyncJobStatus.FAILED)).toBe("danger");
-    expect(buildConnectionHealthSummary({ status: DeviceConnectionStatus.ACTIVE, lastSyncedAt: new Date("2026-05-07T08:00:00.000Z"), lastError: null, _count: { readings: 3, syncJobs: 1, jobRuns: 1 } })).toMatchObject({ tone: "success", label: "Healthy" });
-    expect(buildConnectionHealthSummary({ status: DeviceConnectionStatus.ERROR, lastSyncedAt: null, lastError: "Provider token expired." })).toMatchObject({ tone: "danger", label: "Needs review" });
+    expect(
+      buildConnectionHealthSummary({
+        status: DeviceConnectionStatus.ACTIVE,
+        lastSyncedAt: new Date("2026-05-07T08:00:00.000Z"),
+        lastError: null,
+        _count: { readings: 3, syncJobs: 1, jobRuns: 1 },
+      }),
+    ).toMatchObject({ tone: "success", label: "Healthy" });
+    expect(
+      buildConnectionHealthSummary({
+        status: DeviceConnectionStatus.ERROR,
+        lastSyncedAt: null,
+        lastError: "Provider token expired.",
+      }),
+    ).toMatchObject({ tone: "danger", label: "Needs review" });
   });
 
   it("builds a schema-backed QA payload and curl example", async () => {
-    const { DEVICE_QA_SAMPLE_PAYLOAD, buildDeviceQaCurl, buildDeviceQaChecklist } = await import("@/lib/device-integrations");
-    expect(DEVICE_QA_SAMPLE_PAYLOAD.source).toBe(ReadingSource.ANDROID_HEALTH_CONNECT);
-    expect(DEVICE_QA_SAMPLE_PAYLOAD.readings.map((reading) => reading.readingType)).toEqual([DeviceReadingType.HEART_RATE, DeviceReadingType.BLOOD_PRESSURE, DeviceReadingType.WEIGHT]);
-    expect(buildDeviceQaCurl("https://example.com")).toContain("/api/mobile/device-readings");
-    expect(buildDeviceQaChecklist()).toContain("Confirm a SyncJob records requested, accepted, and mirrored counts.");
+    const {
+      DEVICE_QA_SAMPLE_PAYLOAD,
+      buildDeviceQaCurl,
+      buildDeviceQaChecklist,
+    } = await import("@/lib/device-integrations");
+    expect(DEVICE_QA_SAMPLE_PAYLOAD.source).toBe(
+      ReadingSource.ANDROID_HEALTH_CONNECT,
+    );
+    expect(
+      DEVICE_QA_SAMPLE_PAYLOAD.readings.map((reading) => reading.readingType),
+    ).toEqual([
+      DeviceReadingType.HEART_RATE,
+      DeviceReadingType.BLOOD_PRESSURE,
+      DeviceReadingType.WEIGHT,
+    ]);
+    expect(buildDeviceQaCurl("https://example.com")).toContain(
+      "/api/mobile/device-readings",
+    );
+    expect(buildDeviceQaChecklist()).toContain(
+      "Confirm a SyncJob records requested, accepted, and mirrored counts.",
+    );
   });
 
   it("parses JSON object metadata without throwing", async () => {
@@ -39,5 +96,90 @@ describe("device integration helpers", () => {
     expect(parseJsonObject('["not-object"]')).toBeNull();
     expect(parseJsonObject("bad-json")).toBeNull();
     expect(parseJsonObject(null)).toBeNull();
+  });
+
+  it("classifies reliability freshness and review states", async () => {
+    const { buildDeviceReliabilitySignal, buildConnectionReliabilitySummary } =
+      await import("@/lib/device-integrations");
+    const now = new Date("2026-05-12T08:00:00.000Z");
+
+    expect(
+      buildDeviceReliabilitySignal(
+        {
+          status: DeviceConnectionStatus.ACTIVE,
+          lastSyncedAt: new Date("2026-05-12T07:30:00.000Z"),
+          lastError: null,
+        },
+        now,
+      ),
+    ).toMatchObject({ label: "Current", tone: "success", needsReview: false });
+    expect(
+      buildDeviceReliabilitySignal(
+        {
+          status: DeviceConnectionStatus.ACTIVE,
+          lastSyncedAt: new Date("2026-05-11T07:00:00.000Z"),
+          lastError: null,
+        },
+        now,
+      ),
+    ).toMatchObject({ label: "Sync due", tone: "info", needsReview: false });
+    expect(
+      buildDeviceReliabilitySignal(
+        {
+          status: DeviceConnectionStatus.ACTIVE,
+          lastSyncedAt: new Date("2026-05-08T07:00:00.000Z"),
+          lastError: null,
+        },
+        now,
+      ),
+    ).toMatchObject({
+      label: "Stale sync",
+      tone: "warning",
+      needsReview: true,
+    });
+    expect(
+      buildDeviceReliabilitySignal(
+        {
+          status: DeviceConnectionStatus.ERROR,
+          lastSyncedAt: null,
+          lastError: "Token expired",
+        },
+        now,
+      ),
+    ).toMatchObject({ label: "Blocked", tone: "danger", needsReview: true });
+
+    expect(
+      buildConnectionReliabilitySummary(
+        [
+          {
+            status: DeviceConnectionStatus.ACTIVE,
+            lastSyncedAt: new Date("2026-05-12T07:30:00.000Z"),
+            lastError: null,
+          },
+          {
+            status: DeviceConnectionStatus.ACTIVE,
+            lastSyncedAt: new Date("2026-05-08T07:00:00.000Z"),
+            lastError: null,
+          },
+          {
+            status: DeviceConnectionStatus.DISCONNECTED,
+            lastSyncedAt: null,
+            lastError: null,
+          },
+          {
+            status: DeviceConnectionStatus.REVOKED,
+            lastSyncedAt: null,
+            lastError: null,
+          },
+        ],
+        now,
+      ),
+    ).toMatchObject({
+      current: 1,
+      stale: 1,
+      paused: 1,
+      revoked: 1,
+      needsReview: 3,
+    });
   });
 });


### PR DESCRIPTION
## Summary

This patch adds an operational reliability layer to VitaVault's Device Integrations workspace.

## Changes

- Added reliability helpers for device freshness and review classification
- Added freshness thresholds for sync due and stale sync states
- Added reliability summary counts to the device integrations dashboard
- Added a Reliability Command Center to `/device-connection`
- Added reliability badges and next-step guidance to connection cards
- Added a per-device Reliability Signal panel to `/device-connection/[id]`
- Added regression tests for reliability classification and summary counts
- Added Patch 62 documentation under `docs/`

## Safety

- No Prisma migration
- No dependency changes
- No README changes
- No API behavior changes
- No server action behavior changes
- Uses existing DeviceConnection fields only

## Checks

Run locally:

```powershell
npm install
npm run db:validate:ci
npm run actions:check
npm run actions:imports
npm run actions:shadow
npm run typecheck
npm run lint
npm run test:run