### PR TITLE
Polish Export Center reliability

### DIFF
--- a/app/exports/[type]/route.ts
+++ b/app/exports/[type]/route.ts
@@ -3,6 +3,10 @@ import { requireUser } from "@/lib/session";
 import { db } from "@/lib/db";
 import { toCsv } from "@/lib/export";
 import { formatDate, formatDateTime, bpLabel } from "@/lib/utils";
+import {
+  exportDefinitionMap,
+  exportDefinitions,
+} from "@/lib/export-definitions";
 
 function formatBytes(bytes: number | null | undefined) {
   if (!bytes || bytes <= 0) return "0 B";
@@ -15,7 +19,23 @@ function formatBytes(bytes: number | null | undefined) {
   }
   return `${value >= 10 || unitIndex === 0 ? Math.round(value) : value.toFixed(1)} ${units[unitIndex]}`;
 }
-import { exportDefinitionMap } from "@/lib/export-definitions";
+
+function unknownExportResponse(type: string) {
+  return NextResponse.json(
+    {
+      error: "Unknown export type.",
+      type,
+      supportedTypes: exportDefinitions.map((definition) => definition.type),
+    },
+    {
+      status: 404,
+      headers: {
+        "Cache-Control": "no-store",
+        "X-Content-Type-Options": "nosniff",
+      },
+    },
+  );
+}
 
 function csvResponse(type: string, rows: Record<string, unknown>[]) {
   const timestamp = new Date().toISOString().slice(0, 10);
@@ -26,16 +46,20 @@ function csvResponse(type: string, rows: Record<string, unknown>[]) {
       "Content-Type": "text/csv; charset=utf-8",
       "Content-Disposition": `attachment; filename="${filename}"`,
       "Cache-Control": "no-store",
+      "X-Content-Type-Options": "nosniff",
     },
   });
 }
 
-export async function GET(_: Request, { params }: { params: Promise<{ type: string }> }) {
+export async function GET(
+  _: Request,
+  { params }: { params: Promise<{ type: string }> },
+) {
   const user = await requireUser();
   const { type } = await params;
 
   if (!exportDefinitionMap.has(type)) {
-    return NextResponse.json({ error: "Unknown export type." }, { status: 404 });
+    return unknownExportResponse(type);
   }
 
   let rows: Record<string, unknown>[] = [];
@@ -216,7 +240,7 @@ export async function GET(_: Request, { params }: { params: Promise<{ type: stri
       break;
     }
     default:
-      return NextResponse.json({ error: "Unknown export type." }, { status: 404 });
+      return unknownExportResponse(type);
   }
 
   return csvResponse(type, rows);

--- a/app/exports/page.tsx
+++ b/app/exports/page.tsx
@@ -1,12 +1,38 @@
 import Link from "next/link";
-import { ArrowRight, ClipboardCheck, Download, FileSpreadsheet, FileText, ShieldCheck, Sparkles } from "lucide-react";
+import {
+  AlertTriangle,
+  ArrowRight,
+  CheckCircle2,
+  ClipboardCheck,
+  Download,
+  FileSpreadsheet,
+  FileText,
+  ShieldCheck,
+  Sparkles,
+} from "lucide-react";
 import { AppShell } from "@/components/app-shell";
 import { PageHeader, StatusPill } from "@/components/common";
-import { Badge, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
+import {
+  Badge,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui";
 import { ModuleHero, DataCard } from "@/components/module-sections";
-import { PageTransition, StaggerGroup, StaggerItem } from "@/components/page-transition";
+import {
+  PageTransition,
+  StaggerGroup,
+  StaggerItem,
+} from "@/components/page-transition";
 import { exportDefinitions } from "@/lib/export-definitions";
-import { getExportCenterData, type ExportActionItem, type ExportPacket } from "@/lib/export-center";
+import {
+  getExportCenterData,
+  type ExportActionItem,
+  type ExportPacket,
+  type ExportReliabilitySignal,
+} from "@/lib/export-center";
 
 const groups = ["Core", "Monitoring", "Coordination"] as const;
 
@@ -28,7 +54,10 @@ function ProgressBar({ value }: { value: number }) {
   const safeValue = Math.max(0, Math.min(100, value));
   return (
     <div className="h-2 overflow-hidden rounded-full bg-muted">
-      <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${safeValue}%` }} />
+      <div
+        className="h-full rounded-full bg-primary transition-all"
+        style={{ width: `${safeValue}%` }}
+      />
     </div>
   );
 }
@@ -39,19 +68,32 @@ function PacketCard({ packet }: { packet: ExportPacket }) {
       <div className="space-y-3">
         <div className="flex items-start justify-between gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
-            {packet.format === "Print / PDF" ? <FileText className="h-4 w-4" /> : <ClipboardCheck className="h-4 w-4" />}
+            {packet.format === "Print / PDF" ? (
+              <FileText className="h-4 w-4" />
+            ) : (
+              <ClipboardCheck className="h-4 w-4" />
+            )}
           </div>
-          <StatusPill tone={readinessTone(packet.readiness)}>{packet.readiness}</StatusPill>
+          <StatusPill tone={readinessTone(packet.readiness)}>
+            {packet.readiness}
+          </StatusPill>
         </div>
         <div>
           <p className="font-semibold">{packet.title}</p>
-          <p className="mt-1 text-sm text-muted-foreground">{packet.description}</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {packet.description}
+          </p>
         </div>
-        <p className="rounded-2xl border border-border/60 bg-background/50 p-3 text-xs text-muted-foreground">{packet.reason}</p>
+        <p className="rounded-2xl border border-border/60 bg-background/50 p-3 text-xs text-muted-foreground">
+          {packet.reason}
+        </p>
       </div>
       <div className="mt-4 flex items-center justify-between gap-3">
         <Badge>{packet.format}</Badge>
-        <Link href={packet.href} className="inline-flex items-center justify-center rounded-2xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm hover:opacity-95">
+        <Link
+          href={packet.href}
+          className="inline-flex items-center justify-center rounded-2xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm hover:opacity-95"
+        >
           Open
           <ArrowRight className="ml-2 h-4 w-4" />
         </Link>
@@ -60,15 +102,57 @@ function PacketCard({ packet }: { packet: ExportPacket }) {
   );
 }
 
+function ReliabilityChecklist({
+  items,
+}: {
+  items: ExportReliabilitySignal["checklist"];
+}) {
+  const statusTone = (status: "pass" | "review" | "blocked"): Tone => {
+    if (status === "pass") return "success";
+    if (status === "review") return "warning";
+    return "danger";
+  };
+
+  return (
+    <div className="space-y-3">
+      {items.map((item) => (
+        <div
+          key={item.label}
+          className="rounded-2xl border border-border/60 bg-background/50 p-4"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-sm font-medium">{item.label}</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {item.description}
+              </p>
+            </div>
+            <StatusPill tone={statusTone(item.status)}>
+              {item.status}
+            </StatusPill>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function ActionItemCard({ item }: { item: ExportActionItem }) {
   return (
-    <Link href={item.href} className="block rounded-2xl border border-border/60 bg-background/50 p-4 transition hover:border-border hover:bg-muted/40">
+    <Link
+      href={item.href}
+      className="block rounded-2xl border border-border/60 bg-background/50 p-4 transition hover:border-border hover:bg-muted/40"
+    >
       <div className="flex items-start justify-between gap-3">
         <div>
           <p className="font-medium">{item.title}</p>
-          <p className="mt-1 text-sm text-muted-foreground">{item.description}</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {item.description}
+          </p>
         </div>
-        <StatusPill tone={priorityTone(item.priority)}>{item.priority}</StatusPill>
+        <StatusPill tone={priorityTone(item.priority)}>
+          {item.priority}
+        </StatusPill>
       </div>
     </Link>
   );
@@ -86,8 +170,12 @@ export default async function ExportsPage() {
             description="Prepare CSV datasets, print-ready patient packets, and workflow handoff views from one reporting workspace."
             action={
               <div className="flex flex-wrap gap-2">
-                <Badge className="bg-background/70">{data.summary.csvExportTypes} CSV exports</Badge>
-                <Badge className="bg-background/70">{data.summary.reportPackets} report packets</Badge>
+                <Badge className="bg-background/70">
+                  {data.summary.csvExportTypes} CSV exports
+                </Badge>
+                <Badge className="bg-background/70">
+                  {data.summary.reportPackets} report packets
+                </Badge>
               </div>
             }
           />
@@ -99,10 +187,26 @@ export default async function ExportsPage() {
             title="A stronger export workspace for patient records, clinical review, and operational reporting"
             description="CSV exports stay available for spreadsheet work, while report packet shortcuts make doctor visits, emergency handoffs, and care-plan reviews easier to prepare."
             stats={[
-              { label: "Readiness", value: `${data.summary.readinessScore}%`, hint: "Profile, records, documents, and provider context" },
-              { label: "Records covered", value: data.summary.totalRecords, hint: "Across exportable record families" },
-              { label: "Open alerts", value: data.summary.openAlerts, hint: `${data.summary.highRiskAlerts} high-priority` },
-              { label: "Document links", value: `${data.summary.documentLinkRate}%`, hint: "Documents connected to records" },
+              {
+                label: "Readiness",
+                value: `${data.summary.readinessScore}%`,
+                hint: "Profile, records, documents, and provider context",
+              },
+              {
+                label: "Records covered",
+                value: data.summary.totalRecords,
+                hint: "Across exportable record families",
+              },
+              {
+                label: "Open alerts",
+                value: data.summary.openAlerts,
+                hint: `${data.summary.highRiskAlerts} high-priority`,
+              },
+              {
+                label: "Document links",
+                value: `${data.summary.documentLinkRate}%`,
+                hint: "Documents connected to records",
+              },
             ]}
           />
         </PageTransition>
@@ -111,25 +215,39 @@ export default async function ExportsPage() {
           <Card>
             <CardHeader>
               <CardTitle>Export readiness</CardTitle>
-              <CardDescription className="mt-1">How ready this workspace is for clean handoff, reporting, and review packets.</CardDescription>
+              <CardDescription className="mt-1">
+                How ready this workspace is for clean handoff, reporting, and
+                review packets.
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="flex items-center justify-between gap-4">
                 <div>
-                  <p className="text-3xl font-semibold">{data.summary.readinessScore}%</p>
-                  <p className="text-sm text-muted-foreground">Overall export readiness</p>
+                  <p className="text-3xl font-semibold">
+                    {data.summary.readinessScore}%
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    Overall export readiness
+                  </p>
                 </div>
-                <StatusPill tone={data.summary.readinessScore >= 75 ? "success" : data.summary.readinessScore >= 50 ? "warning" : "danger"}>
-                  {data.summary.readinessScore >= 75 ? "Ready" : "Needs review"}
+                <StatusPill tone={data.reliability.tone}>
+                  {data.reliability.status}
                 </StatusPill>
               </div>
               <ProgressBar value={data.summary.readinessScore} />
               <div className="grid gap-3 md:grid-cols-3">
                 {data.csvCoverage.map((item) => (
-                  <div key={item.label} className="rounded-2xl border border-border/60 bg-background/50 p-4">
-                    <p className="text-xs font-medium text-muted-foreground">{item.label}</p>
+                  <div
+                    key={item.label}
+                    className="rounded-2xl border border-border/60 bg-background/50 p-4"
+                  >
+                    <p className="text-xs font-medium text-muted-foreground">
+                      {item.label}
+                    </p>
                     <p className="mt-1 text-2xl font-semibold">{item.value}</p>
-                    <p className="mt-1 text-xs text-muted-foreground">{item.description}</p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {item.description}
+                    </p>
                   </div>
                 ))}
               </div>
@@ -138,11 +256,82 @@ export default async function ExportsPage() {
 
           <Card>
             <CardHeader>
+              <CardTitle>Reliability signal</CardTitle>
+              <CardDescription className="mt-1">
+                A pre-share safety layer for export packets and CSV downloads.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="rounded-2xl border border-border/60 bg-background/50 p-4">
+                <div className="flex items-start gap-3">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                    {data.reliability.status === "Ready" ? (
+                      <CheckCircle2 className="h-4 w-4" />
+                    ) : (
+                      <AlertTriangle className="h-4 w-4" />
+                    )}
+                  </div>
+                  <div>
+                    <p className="font-semibold">{data.reliability.label}</p>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      {data.reliability.description}
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="rounded-2xl border border-border/60 bg-background/50 p-4">
+                  <p className="text-xs font-medium text-muted-foreground">
+                    Review actions
+                  </p>
+                  <p className="mt-1 text-2xl font-semibold">
+                    {data.reliability.reviewActionCount}
+                  </p>
+                </div>
+                <div className="rounded-2xl border border-border/60 bg-background/50 p-4">
+                  <p className="text-xs font-medium text-muted-foreground">
+                    High priority
+                  </p>
+                  <p className="mt-1 text-2xl font-semibold">
+                    {data.reliability.highPriorityActions}
+                  </p>
+                </div>
+              </div>
+              {data.reliability.blockedReasons.length > 0 ? (
+                <div className="space-y-2 rounded-2xl border border-destructive/30 bg-destructive/5 p-4 text-sm text-muted-foreground">
+                  {data.reliability.blockedReasons.map((reason) => (
+                    <p key={reason}>{reason}</p>
+                  ))}
+                </div>
+              ) : null}
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="grid gap-6 xl:grid-cols-[0.85fr_1fr]">
+          <Card>
+            <CardHeader>
+              <CardTitle>Reliability checklist</CardTitle>
+              <CardDescription className="mt-1">
+                Signals checked before sharing packets externally.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ReliabilityChecklist items={data.reliability.checklist} />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
               <CardTitle>Recommended before exporting</CardTitle>
-              <CardDescription className="mt-1">Fix the highest-impact gaps before sharing reports.</CardDescription>
+              <CardDescription className="mt-1">
+                Fix the highest-impact gaps before sharing reports.
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
-              {data.actionItems.map((item) => <ActionItemCard key={item.title} item={item} />)}
+              {data.actionItems.map((item) => (
+                <ActionItemCard key={item.title} item={item} />
+              ))}
             </CardContent>
           </Card>
         </div>
@@ -155,19 +344,28 @@ export default async function ExportsPage() {
                   <div className="flex items-start justify-between gap-3">
                     <div>
                       <CardTitle>CSV export library</CardTitle>
-                      <CardDescription className="mt-1">Download structured datasets from the main health, monitoring, and coordination modules.</CardDescription>
+                      <CardDescription className="mt-1">
+                        Download structured datasets from the main health,
+                        monitoring, and coordination modules.
+                      </CardDescription>
                     </div>
                     <FileSpreadsheet className="h-5 w-5 text-primary" />
                   </div>
                 </CardHeader>
                 <CardContent className="space-y-6">
                   {groups.map((group) => {
-                    const items = exportDefinitions.filter((item) => item.group === group);
+                    const items = exportDefinitions.filter(
+                      (item) => item.group === group,
+                    );
                     return (
                       <div key={group} className="space-y-3">
                         <div className="flex items-center justify-between gap-3">
-                          <p className="text-sm font-semibold tracking-wide text-foreground/90">{group}</p>
-                          <Badge className="rounded-full bg-background/70">{items.length} exports</Badge>
+                          <p className="text-sm font-semibold tracking-wide text-foreground/90">
+                            {group}
+                          </p>
+                          <Badge className="rounded-full bg-background/70">
+                            {items.length} exports
+                          </Badge>
                         </div>
                         <div className="grid gap-4 md:grid-cols-2">
                           {items.map((item) => (
@@ -177,13 +375,22 @@ export default async function ExportsPage() {
                                   <FileSpreadsheet className="h-4 w-4" />
                                 </div>
                                 <div>
-                                  <p className="text-sm font-semibold">{item.title}</p>
-                                  <p className="mt-1 text-sm text-muted-foreground">{item.description}</p>
+                                  <p className="text-sm font-semibold">
+                                    {item.title}
+                                  </p>
+                                  <p className="mt-1 text-sm text-muted-foreground">
+                                    {item.description}
+                                  </p>
                                 </div>
                               </div>
                               <div className="mt-4 flex items-center justify-between gap-3">
-                                <Badge className="bg-background/70">{item.format}</Badge>
-                                <Link href={item.href} className="inline-flex items-center justify-center rounded-2xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm hover:opacity-95">
+                                <Badge className="bg-background/70">
+                                  {item.format}
+                                </Badge>
+                                <Link
+                                  href={item.href}
+                                  className="inline-flex items-center justify-center rounded-2xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm hover:opacity-95"
+                                >
                                   <Download className="mr-2 h-4 w-4" />
                                   Download
                                 </Link>
@@ -205,13 +412,18 @@ export default async function ExportsPage() {
                     <div className="flex items-start justify-between gap-3">
                       <div>
                         <CardTitle>Report packets and handoff views</CardTitle>
-                        <CardDescription className="mt-1">Open print-friendly packets or review workspaces before sharing records.</CardDescription>
+                        <CardDescription className="mt-1">
+                          Open print-friendly packets or review workspaces
+                          before sharing records.
+                        </CardDescription>
                       </div>
                       <Sparkles className="h-5 w-5 text-primary" />
                     </div>
                   </CardHeader>
                   <CardContent className="grid gap-4">
-                    {data.packets.map((packet) => <PacketCard key={packet.href} packet={packet} />)}
+                    {data.packets.map((packet) => (
+                      <PacketCard key={packet.href} packet={packet} />
+                    ))}
                   </CardContent>
                 </Card>
 
@@ -220,7 +432,9 @@ export default async function ExportsPage() {
                     <div className="flex items-start gap-3">
                       <ShieldCheck className="mt-0.5 h-4 w-4 text-primary" />
                       <p className="text-sm text-muted-foreground">
-                        Exports are scoped to the signed-in user. Print packets should be reviewed before sharing with providers, caregivers, or external recipients.
+                        Exports are scoped to the signed-in user. Print packets
+                        should be reviewed before sharing with providers,
+                        caregivers, or external recipients.
                       </p>
                     </div>
                   </CardContent>

--- a/docs/PATCH_65_EXPORT_CENTER_RELIABILITY_POLISH.md
+++ b/docs/PATCH_65_EXPORT_CENTER_RELIABILITY_POLISH.md
@@ -1,0 +1,45 @@
+# Patch 65 — Export Center Reliability Polish
+
+## Summary
+
+This patch adds a reliability layer to VitaVault's Export Center so export packets and CSV downloads are easier to review before sharing externally.
+
+## What changed
+
+- Added a pure export reliability classifier in `lib/export-center.ts`.
+- Added a reliability signal to the Export Center data payload.
+- Added a reliability signal card and checklist to `/exports`.
+- Added no-store and `X-Content-Type-Options: nosniff` headers to CSV responses.
+- Improved unknown export responses with the requested type and supported export type list.
+- Expanded export-center tests for ready/blocked reliability states.
+- Expanded export route tests for unknown-export response details and safer CSV headers.
+
+## Safety
+
+- No Prisma migration.
+- No schema changes.
+- No dependency changes.
+- No README changes.
+- No authenticated route behavior changes.
+- No export definitions were removed.
+
+## Validation
+
+Recommended local checks:
+
+```powershell
+npm install
+npm run db:validate:ci
+npm run actions:check
+npm run actions:imports
+npm run actions:shadow
+npm run typecheck
+npm run lint
+npm run test:run
+```
+
+Targeted checks:
+
+```powershell
+npm run test:run -- tests/export-center.test.ts tests/exports-route.test.ts
+```

--- a/lib/export-center.ts
+++ b/lib/export-center.ts
@@ -1,4 +1,11 @@
-import { AlertSeverity, AlertStatus, CareNotePriority, LabFlag, MedicationLogStatus, ReminderState } from "@prisma/client";
+import {
+  AlertSeverity,
+  AlertStatus,
+  CareNotePriority,
+  LabFlag,
+  MedicationLogStatus,
+  ReminderState,
+} from "@prisma/client";
 import { db } from "@/lib/db";
 import { requireUser } from "@/lib/session";
 import { exportDefinitions } from "@/lib/export-definitions";
@@ -19,6 +26,24 @@ export type ExportActionItem = {
   priority: "high" | "medium" | "low";
 };
 
+export type ExportReliabilityStatus = "Ready" | "Needs review" | "Blocked";
+
+export type ExportReliabilitySignal = {
+  status: ExportReliabilityStatus;
+  label: string;
+  description: string;
+  tone: "success" | "warning" | "danger";
+  safeToShare: boolean;
+  highPriorityActions: number;
+  reviewActionCount: number;
+  blockedReasons: string[];
+  checklist: Array<{
+    label: string;
+    status: "pass" | "review" | "blocked";
+    description: string;
+  }>;
+};
+
 function pct(value: number, total: number) {
   if (total <= 0) return 0;
   return Math.round((value / total) * 100);
@@ -27,6 +52,137 @@ function pct(value: number, total: number) {
 function scoreFromChecks(checks: boolean[]) {
   if (!checks.length) return 0;
   return pct(checks.filter(Boolean).length, checks.length);
+}
+
+export function buildExportReliabilitySignal(input: {
+  readinessScore: number;
+  documentLinkRate: number;
+  medicationAdherenceRate: number;
+  openAlerts: number;
+  highRiskAlerts: number;
+  activeReminders: number;
+  actionItems: ExportActionItem[];
+}): ExportReliabilitySignal {
+  const highPriorityActions = input.actionItems.filter(
+    (item) => item.priority === "high",
+  ).length;
+  const reviewActionCount = input.actionItems.filter(
+    (item) => item.priority !== "low",
+  ).length;
+  const blockedReasons: string[] = [];
+
+  if (input.readinessScore < 40) {
+    blockedReasons.push("Overall export readiness is below 40%.");
+  }
+
+  if (input.highRiskAlerts > 0) {
+    blockedReasons.push(
+      `${input.highRiskAlerts} high-priority alert${input.highRiskAlerts === 1 ? "" : "s"} should be reviewed before sharing.`,
+    );
+  }
+
+  const checklist: ExportReliabilitySignal["checklist"] = [
+    {
+      label: "Core readiness",
+      status:
+        input.readinessScore >= 75
+          ? "pass"
+          : input.readinessScore >= 40
+            ? "review"
+            : "blocked",
+      description: `${input.readinessScore}% readiness across profile, records, documents, and provider context.`,
+    },
+    {
+      label: "Document links",
+      status:
+        input.documentLinkRate >= 75 || input.documentLinkRate === 0
+          ? "pass"
+          : input.documentLinkRate >= 50
+            ? "review"
+            : "blocked",
+      description:
+        input.documentLinkRate === 0
+          ? "No linked-document coverage yet."
+          : `${input.documentLinkRate}% of documents are linked to source records.`,
+    },
+    {
+      label: "Medication adherence",
+      status:
+        input.medicationAdherenceRate >= 80 ||
+        input.medicationAdherenceRate === 0
+          ? "pass"
+          : input.medicationAdherenceRate >= 60
+            ? "review"
+            : "blocked",
+      description:
+        input.medicationAdherenceRate === 0
+          ? "No medication log history available for the last 30 days."
+          : `${input.medicationAdherenceRate}% adherence signal over the last 30 days.`,
+    },
+    {
+      label: "Alert review",
+      status:
+        input.highRiskAlerts > 0
+          ? "blocked"
+          : input.openAlerts > 0
+            ? "review"
+            : "pass",
+      description: `${input.openAlerts} open alert${input.openAlerts === 1 ? "" : "s"}; ${input.highRiskAlerts} high-priority.`,
+    },
+    {
+      label: "Reminder state",
+      status: input.activeReminders > 0 ? "review" : "pass",
+      description: `${input.activeReminders} due, overdue, or missed reminder${input.activeReminders === 1 ? "" : "s"}.`,
+    },
+  ];
+
+  if (blockedReasons.length > 0) {
+    return {
+      status: "Blocked",
+      label: "Review before sharing",
+      description:
+        "High-risk export blockers are present. Resolve them before sending records outside the workspace.",
+      tone: "danger",
+      safeToShare: false,
+      highPriorityActions,
+      reviewActionCount,
+      blockedReasons,
+      checklist,
+    };
+  }
+
+  if (
+    reviewActionCount > 0 ||
+    input.readinessScore < 75 ||
+    input.openAlerts > 0 ||
+    input.activeReminders > 0
+  ) {
+    return {
+      status: "Needs review",
+      label: "Prepare before sharing",
+      description:
+        "Exports are available, but the workspace has review items that should be checked before handoff.",
+      tone: "warning",
+      safeToShare: true,
+      highPriorityActions,
+      reviewActionCount,
+      blockedReasons,
+      checklist,
+    };
+  }
+
+  return {
+    status: "Ready",
+    label: "Ready to share",
+    description:
+      "Core records look consistent and no high-priority export blockers were detected.",
+    tone: "success",
+    safeToShare: true,
+    highPriorityActions,
+    reviewActionCount,
+    blockedReasons,
+    checklist,
+  };
 }
 
 type CareNoteCountDelegate = {
@@ -66,76 +222,167 @@ export async function getExportCenterData() {
   ] = await Promise.all([
     db.healthProfile.findUnique({ where: { userId: user.id } }),
     db.medication.count({ where: { userId: user.id } }),
-    db.medicationLog.count({ where: { userId: user.id, loggedAt: { gte: thirtyDaysAgo } } }),
-    db.medicationLog.count({ where: { userId: user.id, loggedAt: { gte: thirtyDaysAgo }, status: { in: [MedicationLogStatus.MISSED, MedicationLogStatus.SKIPPED] } } }),
+    db.medicationLog.count({
+      where: { userId: user.id, loggedAt: { gte: thirtyDaysAgo } },
+    }),
+    db.medicationLog.count({
+      where: {
+        userId: user.id,
+        loggedAt: { gte: thirtyDaysAgo },
+        status: {
+          in: [MedicationLogStatus.MISSED, MedicationLogStatus.SKIPPED],
+        },
+      },
+    }),
     db.appointment.count({ where: { userId: user.id } }),
-    db.appointment.count({ where: { userId: user.id, scheduledAt: { gte: now } } }),
+    db.appointment.count({
+      where: { userId: user.id, scheduledAt: { gte: now } },
+    }),
     db.labResult.count({ where: { userId: user.id } }),
-    db.labResult.count({ where: { userId: user.id, flag: { in: [LabFlag.BORDERLINE, LabFlag.HIGH, LabFlag.LOW] } } }),
+    db.labResult.count({
+      where: {
+        userId: user.id,
+        flag: { in: [LabFlag.BORDERLINE, LabFlag.HIGH, LabFlag.LOW] },
+      },
+    }),
     db.vitalRecord.count({ where: { userId: user.id } }),
     db.symptomEntry.count({ where: { userId: user.id } }),
-    db.symptomEntry.count({ where: { userId: user.id, severity: "SEVERE", resolved: false } }),
+    db.symptomEntry.count({
+      where: { userId: user.id, severity: "SEVERE", resolved: false },
+    }),
     db.vaccinationRecord.count({ where: { userId: user.id } }),
     db.medicalDocument.count({ where: { userId: user.id } }),
-    db.medicalDocument.count({ where: { userId: user.id, linkedRecordType: { not: null }, linkedRecordId: { not: null } } }),
+    db.medicalDocument.count({
+      where: {
+        userId: user.id,
+        linkedRecordType: { not: null },
+        linkedRecordId: { not: null },
+      },
+    }),
     db.reminder.count({ where: { userId: user.id } }),
-    db.reminder.count({ where: { userId: user.id, state: { in: [ReminderState.DUE, ReminderState.OVERDUE, ReminderState.MISSED] } } }),
-    db.alertEvent.count({ where: { userId: user.id, status: AlertStatus.OPEN } }),
-    db.alertEvent.count({ where: { userId: user.id, status: AlertStatus.OPEN, severity: { in: [AlertSeverity.HIGH, AlertSeverity.CRITICAL] } } }),
+    db.reminder.count({
+      where: {
+        userId: user.id,
+        state: {
+          in: [ReminderState.DUE, ReminderState.OVERDUE, ReminderState.MISSED],
+        },
+      },
+    }),
+    db.alertEvent.count({
+      where: { userId: user.id, status: AlertStatus.OPEN },
+    }),
+    db.alertEvent.count({
+      where: {
+        userId: user.id,
+        status: AlertStatus.OPEN,
+        severity: { in: [AlertSeverity.HIGH, AlertSeverity.CRITICAL] },
+      },
+    }),
     db.doctor.count({ where: { userId: user.id } }),
   ]);
 
   const careNoteDelegate = getOptionalCareNoteDelegate();
   const [careNotes, urgentCareNotes] = careNoteDelegate
     ? await Promise.all([
-        careNoteDelegate.count({ where: { ownerUserId: user.id, archivedAt: null } }),
-        careNoteDelegate.count({ where: { ownerUserId: user.id, archivedAt: null, priority: { in: [CareNotePriority.HIGH, CareNotePriority.URGENT] } } }),
+        careNoteDelegate.count({
+          where: { ownerUserId: user.id, archivedAt: null },
+        }),
+        careNoteDelegate.count({
+          where: {
+            ownerUserId: user.id,
+            archivedAt: null,
+            priority: { in: [CareNotePriority.HIGH, CareNotePriority.URGENT] },
+          },
+        }),
       ])
     : [0, 0];
 
-  const profileReady = Boolean(profile?.fullName && profile?.dateOfBirth && profile?.emergencyContactName && profile?.emergencyContactPhone);
+  const profileReady = Boolean(
+    profile?.fullName &&
+    profile?.dateOfBirth &&
+    profile?.emergencyContactName &&
+    profile?.emergencyContactPhone,
+  );
   const medicationReady = medications > 0;
   const clinicalReady = labs > 0 || vitals > 0 || symptoms > 0;
   const documentReady = documents > 0;
   const providerReady = doctors > 0 || appointments > 0;
-  const readinessScore = scoreFromChecks([profileReady, medicationReady, clinicalReady, documentReady, providerReady]);
+  const readinessScore = scoreFromChecks([
+    profileReady,
+    medicationReady,
+    clinicalReady,
+    documentReady,
+    providerReady,
+  ]);
   const documentLinkRate = pct(linkedDocuments, documents);
-  const medicationAdherenceRate = medicationLogs30d > 0 ? Math.max(0, 100 - pct(missedMedicationLogs30d, medicationLogs30d)) : 0;
+  const medicationAdherenceRate =
+    medicationLogs30d > 0
+      ? Math.max(0, 100 - pct(missedMedicationLogs30d, medicationLogs30d))
+      : 0;
 
   const csvCoverage = [
-    { label: "Core records", value: appointments + medications + labs + vaccinations, description: "Appointments, medications, lab results, and vaccination records." },
-    { label: "Monitoring data", value: vitals + symptoms, description: "Vitals and symptom history for trends and review." },
-    { label: "Coordination", value: reminders + documents + openAlerts + careNotes, description: "Reminders, documents, alert snapshots, and care notes." },
+    {
+      label: "Core records",
+      value: appointments + medications + labs + vaccinations,
+      description:
+        "Appointments, medications, lab results, and vaccination records.",
+    },
+    {
+      label: "Monitoring data",
+      value: vitals + symptoms,
+      description: "Vitals and symptom history for trends and review.",
+    },
+    {
+      label: "Coordination",
+      value: reminders + documents + openAlerts + careNotes,
+      description: "Reminders, documents, alert snapshots, and care notes.",
+    },
   ];
 
   const packets: ExportPacket[] = [
     {
       title: "Patient summary packet",
-      description: "A broad handoff report for patient profile, recent records, reminders, and risk context.",
+      description:
+        "A broad handoff report for patient profile, recent records, reminders, and risk context.",
       href: "/summary/print?mode=compact",
       format: "Print / PDF",
       readiness: profileReady ? "Ready" : "Review first",
-      reason: profileReady ? "Profile and emergency basics are available." : "Add profile and emergency contact details before sharing.",
+      reason: profileReady
+        ? "Profile and emergency basics are available."
+        : "Add profile and emergency contact details before sharing.",
     },
     {
       title: "Doctor visit packet",
-      description: "A provider-focused report for upcoming visits and clinical handoff preparation.",
+      description:
+        "A provider-focused report for upcoming visits and clinical handoff preparation.",
       href: "/summary/print?mode=doctor",
       format: "Print / PDF",
-      readiness: upcomingAppointments > 0 || providerReady ? "Ready" : "Setup needed",
-      reason: upcomingAppointments > 0 ? "Upcoming appointment context is available." : "Add an appointment or provider to make this stronger.",
+      readiness:
+        upcomingAppointments > 0 || providerReady ? "Ready" : "Setup needed",
+      reason:
+        upcomingAppointments > 0
+          ? "Upcoming appointment context is available."
+          : "Add an appointment or provider to make this stronger.",
     },
     {
       title: "Emergency health card",
-      description: "A compact printable card for emergency contact, allergies, conditions, medications, and latest vitals.",
+      description:
+        "A compact printable card for emergency contact, allergies, conditions, medications, and latest vitals.",
       href: "/emergency-card/print",
       format: "Print / PDF",
-      readiness: profile?.emergencyContactName && profile?.emergencyContactPhone ? "Ready" : "Review first",
-      reason: profile?.emergencyContactName && profile?.emergencyContactPhone ? "Emergency contact details are present." : "Emergency contact details are missing.",
+      readiness:
+        profile?.emergencyContactName && profile?.emergencyContactPhone
+          ? "Ready"
+          : "Review first",
+      reason:
+        profile?.emergencyContactName && profile?.emergencyContactPhone
+          ? "Emergency contact details are present."
+          : "Emergency contact details are missing.",
     },
     {
       title: "Care plan review workspace",
-      description: "A workflow view for current care gaps, action items, upcoming care, and provider context.",
+      description:
+        "A workflow view for current care gaps, action items, upcoming care, and provider context.",
       href: "/care-plan",
       format: "Workspace",
       readiness: readinessScore >= 60 ? "Ready" : "Review first",
@@ -146,11 +393,15 @@ export async function getExportCenterData() {
   if (careNoteDelegate) {
     packets.push({
       title: "Care-team notes packet",
-      description: "A collaboration-focused report builder preset that includes care notes, timeline context, and shared access details.",
+      description:
+        "A collaboration-focused report builder preset that includes care notes, timeline context, and shared access details.",
       href: "/report-builder?preset=care-team-weekly",
       format: "Workspace",
       readiness: careNotes > 0 ? "Ready" : "Setup needed",
-      reason: careNotes > 0 ? `${careNotes} active care note${careNotes === 1 ? "" : "s"} available for handoff context.` : "Add a care note before preparing a collaboration packet.",
+      reason:
+        careNotes > 0
+          ? `${careNotes} active care note${careNotes === 1 ? "" : "s"} available for handoff context.`
+          : "Add a care note before preparing a collaboration packet.",
     });
   }
 
@@ -159,7 +410,8 @@ export async function getExportCenterData() {
   if (!profileReady) {
     actionItems.push({
       title: "Complete profile and emergency details",
-      description: "Patient summary and emergency reports are more useful when identity, date of birth, and emergency contact fields are complete.",
+      description:
+        "Patient summary and emergency reports are more useful when identity, date of birth, and emergency contact fields are complete.",
       href: "/onboarding",
       priority: "high",
     });
@@ -213,26 +465,50 @@ export async function getExportCenterData() {
   if (actionItems.length === 0) {
     actionItems.push({
       title: "Export readiness looks healthy",
-      description: "Core profile, records, and reporting context look ready for handoff and review workflows.",
+      description:
+        "Core profile, records, and reporting context look ready for handoff and review workflows.",
       href: "/summary",
       priority: "low",
     });
   }
 
-  return {
-    summary: {
-      readinessScore,
-      csvExportTypes: exportDefinitions.length,
-      reportPackets: packets.length,
-      totalRecords: medications + appointments + labs + vitals + symptoms + vaccinations + documents + reminders + openAlerts + careNotes,
-      documentLinkRate,
-      medicationAdherenceRate,
-      activeReminders,
-      openAlerts,
-      highRiskAlerts,
+  const summary = {
+    readinessScore,
+    csvExportTypes: exportDefinitions.length,
+    reportPackets: packets.length,
+    totalRecords:
+      medications +
+      appointments +
+      labs +
+      vitals +
+      symptoms +
+      vaccinations +
+      documents +
+      reminders +
+      openAlerts +
       careNotes,
-      urgentCareNotes,
-    },
+    documentLinkRate,
+    medicationAdherenceRate,
+    activeReminders,
+    openAlerts,
+    highRiskAlerts,
+    careNotes,
+    urgentCareNotes,
+  };
+
+  const reliability = buildExportReliabilitySignal({
+    readinessScore: summary.readinessScore,
+    documentLinkRate: summary.documentLinkRate,
+    medicationAdherenceRate: summary.medicationAdherenceRate,
+    openAlerts: summary.openAlerts,
+    highRiskAlerts: summary.highRiskAlerts,
+    activeReminders: summary.activeReminders,
+    actionItems,
+  });
+
+  return {
+    summary,
+    reliability,
     csvCoverage,
     packets,
     actionItems,

--- a/tests/export-center.test.ts
+++ b/tests/export-center.test.ts
@@ -79,12 +79,32 @@ describe("export center data", () => {
     expect(data.summary.reportPackets).toBe(4);
     expect(data.summary.documentLinkRate).toBe(50);
     expect(data.summary.medicationAdherenceRate).toBe(80);
-    expect(data.csvCoverage.map((item) => item.label)).toEqual(["Core records", "Monitoring data", "Coordination"]);
+    expect(data.reliability.status).toBe("Blocked");
+    expect(data.reliability.safeToShare).toBe(false);
+    expect(data.reliability.highPriorityActions).toBeGreaterThan(0);
+    expect(data.reliability.blockedReasons.join(" ")).toContain(
+      "high-priority alert",
+    );
+    expect(data.csvCoverage.map((item) => item.label)).toEqual([
+      "Core records",
+      "Monitoring data",
+      "Coordination",
+    ]);
     expect(data.packets.map((item) => item.title)).toEqual(
-      expect.arrayContaining(["Patient summary packet", "Doctor visit packet", "Emergency health card", "Care plan review workspace"]),
+      expect.arrayContaining([
+        "Patient summary packet",
+        "Doctor visit packet",
+        "Emergency health card",
+        "Care plan review workspace",
+      ]),
     );
     expect(data.actionItems.map((item) => item.title)).toEqual(
-      expect.arrayContaining(["Improve document link coverage", "Review high-risk open alerts", "Add lab review context", "Review severe unresolved symptoms"]),
+      expect.arrayContaining([
+        "Improve document link coverage",
+        "Review high-risk open alerts",
+        "Add lab review context",
+        "Review severe unresolved symptoms",
+      ]),
     );
   });
 
@@ -121,7 +141,58 @@ describe("export center data", () => {
 
     expect(data.summary.documentLinkRate).toBe(100);
     expect(data.summary.medicationAdherenceRate).toBe(100);
+    expect(data.reliability.status).toBe("Ready");
+    expect(data.reliability.safeToShare).toBe(true);
     expect(data.actionItems).toHaveLength(1);
     expect(data.actionItems[0]?.title).toBe("Export readiness looks healthy");
+  });
+
+  it("classifies export reliability states without requiring database access", async () => {
+    const { buildExportReliabilitySignal } =
+      await import("@/lib/export-center");
+
+    const blocked = buildExportReliabilitySignal({
+      readinessScore: 35,
+      documentLinkRate: 20,
+      medicationAdherenceRate: 55,
+      openAlerts: 2,
+      highRiskAlerts: 1,
+      activeReminders: 1,
+      actionItems: [
+        {
+          title: "Review critical alert",
+          description: "Needs review",
+          href: "/alerts",
+          priority: "high",
+        },
+      ],
+    });
+
+    expect(blocked.status).toBe("Blocked");
+    expect(blocked.safeToShare).toBe(false);
+    expect(blocked.checklist.some((item) => item.status === "blocked")).toBe(
+      true,
+    );
+
+    const ready = buildExportReliabilitySignal({
+      readinessScore: 100,
+      documentLinkRate: 100,
+      medicationAdherenceRate: 95,
+      openAlerts: 0,
+      highRiskAlerts: 0,
+      activeReminders: 0,
+      actionItems: [
+        {
+          title: "Export readiness looks healthy",
+          description: "Ready",
+          href: "/summary",
+          priority: "low",
+        },
+      ],
+    });
+
+    expect(ready.status).toBe("Ready");
+    expect(ready.safeToShare).toBe(true);
+    expect(ready.blockedReasons).toHaveLength(0);
   });
 });

--- a/tests/exports-route.test.ts
+++ b/tests/exports-route.test.ts
@@ -41,8 +41,12 @@ describe("exports route", () => {
     } as never);
 
     expect(response.status).toBe(404);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
     const body = await response.json();
     expect(body.error).toBe("Unknown export type.");
+    expect(body.type).toBe("nope");
+    expect(body.supportedTypes).toContain("medications");
   });
 
   it("returns medication data as CSV for the current user", async () => {
@@ -64,13 +68,20 @@ describe("exports route", () => {
     ]);
 
     const { GET } = await import("@/app/exports/[type]/route");
-    const response = await GET(new Request("http://localhost/exports/medications"), {
-      params: Promise.resolve({ type: "medications" }),
-    } as never);
+    const response = await GET(
+      new Request("http://localhost/exports/medications"),
+      {
+        params: Promise.resolve({ type: "medications" }),
+      } as never,
+    );
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toContain("text/csv");
-    expect(response.headers.get("Content-Disposition")).toContain("medications-");
+    expect(response.headers.get("Content-Disposition")).toContain(
+      "medications-",
+    );
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
     const csv = await response.text();
     expect(csv).toContain("Name,Dosage,Frequency,Instructions,Times");
     expect(csv).toContain("Metformin");


### PR DESCRIPTION
## Summary

This patch adds a reliability layer to VitaVault's Export Center so users can review packet safety, data readiness, and export blockers before sharing records.

## Changes

- Added export reliability classification helpers
- Added reliability signal data to the Export Center payload
- Added a reliability signal card to `/exports`
- Added a reliability checklist for readiness, document links, medication adherence, alerts, and reminders
- Added safer CSV response headers
- Improved unknown export responses with supported export type details
- Expanded export-center and export route tests
- Added Patch 65 documentation under `docs/`

## Safety

- No Prisma migration
- No schema changes
- No dependency changes
- No README changes
- No export definitions removed
- Existing CSV export URLs remain unchanged

## Checks

Run locally:

```powershell
npm install
npm run db:validate:ci
npm run actions:check
npm run actions:imports
npm run actions:shadow
npm run typecheck
npm run lint
npm run test:run