### PR TITLE
Add Notification Center reliability actions

### DIFF
--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -5,22 +5,33 @@ import {
   CalendarClock,
   ClipboardList,
   FileText,
-  HeartPulse,
   Inbox,
   RadioTower,
   Users,
   CheckCircle2,
+  ClipboardCheck,
   Clock3,
   RotateCcw,
+  Sparkles,
 } from "lucide-react";
 import { AppShell } from "@/components/app-shell";
 import { EmptyState, PageHeader, StatusPill } from "@/components/common";
-import { Badge, Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui";
 import { requireUser } from "@/lib/session";
 import {
   getNotificationCenterData,
+  getNotificationItemSignal,
   type NotificationItem,
   type NotificationPriority,
+  type NotificationReliabilityState,
   type NotificationSource,
   type NotificationTone,
 } from "@/lib/notification-center";
@@ -53,9 +64,21 @@ const sourceIcons: Record<NotificationSource, typeof BellRing> = {
   DEVICE: RadioTower,
 };
 
+const stateLabels: Record<NotificationReliabilityState, string> = {
+  urgent: "Urgent",
+  due_now: "Due now",
+  follow_up: "Follow-up",
+  stale: "Stale",
+  scheduled: "Scheduled",
+  review: "Needs review",
+};
+
 function formatDateTime(value: Date | null | undefined) {
   if (!value) return "—";
-  return new Intl.DateTimeFormat("en-PH", { dateStyle: "medium", timeStyle: "short" }).format(value);
+  return new Intl.DateTimeFormat("en-PH", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(value);
 }
 
 function priorityTone(priority: NotificationPriority): NotificationTone {
@@ -136,7 +159,9 @@ function NotificationActions({ item }: { item: NotificationItem }) {
         </form>
         <form action={skipNotificationReminderAction}>
           <input type="hidden" name="reminderId" value={item.sourceId} />
-          <Button type="submit" size="sm" variant="ghost">Skip</Button>
+          <Button type="submit" size="sm" variant="ghost">
+            Skip
+          </Button>
         </form>
       </div>
     );
@@ -151,6 +176,7 @@ function NotificationActions({ item }: { item: NotificationItem }) {
 
 function NotificationCard({ item }: { item: NotificationItem }) {
   const Icon = sourceIcons[item.source];
+  const signal = getNotificationItemSignal(item);
 
   return (
     <div className="rounded-3xl border border-border/60 bg-background/50 p-5 transition hover:border-border hover:bg-muted/30">
@@ -161,16 +187,40 @@ function NotificationCard({ item }: { item: NotificationItem }) {
           </div>
           <div className="min-w-0 space-y-2">
             <div className="flex flex-wrap items-center gap-2">
-              <StatusPill tone={sourceTone(item.source)}>{sourceLabels[item.source]}</StatusPill>
-              <StatusPill tone={priorityTone(item.priority)}>{item.priority}</StatusPill>
+              <StatusPill tone={sourceTone(item.source)}>
+                {sourceLabels[item.source]}
+              </StatusPill>
+              <StatusPill tone={priorityTone(item.priority)}>
+                {item.priority}
+              </StatusPill>
+              <StatusPill tone={signal.tone}>{signal.label}</StatusPill>
               <Badge>{item.status}</Badge>
             </div>
             <div>
-              <Link href={item.href} className="font-semibold tracking-tight hover:underline">
+              <Link
+                href={item.href}
+                className="font-semibold tracking-tight hover:underline"
+              >
                 {item.title}
               </Link>
-              <p className="mt-1 text-sm leading-6 text-muted-foreground">{item.description}</p>
-              <p className="mt-2 text-xs text-muted-foreground">Recommended action: {item.actionHint}</p>
+              <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                {item.description}
+              </p>
+              <div className="mt-3 grid gap-2 text-xs text-muted-foreground sm:grid-cols-2">
+                <div className="rounded-2xl border border-border/60 bg-background/70 p-3">
+                  <span className="font-semibold text-foreground">Action:</span>{" "}
+                  {signal.actionLabel}
+                </div>
+                <div className="rounded-2xl border border-border/60 bg-background/70 p-3">
+                  <span className="font-semibold text-foreground">
+                    Cleanup:
+                  </span>{" "}
+                  {signal.cleanupHint}
+                </div>
+              </div>
+              <p className="mt-2 text-xs text-muted-foreground">
+                Original recommendation: {item.actionHint}
+              </p>
             </div>
             <NotificationActions item={item} />
           </div>
@@ -178,13 +228,24 @@ function NotificationCard({ item }: { item: NotificationItem }) {
         <div className="shrink-0 text-left text-xs text-muted-foreground md:text-right">
           <p>{item.meta}</p>
           <p className="mt-1">{formatDateTime(item.dueAt || item.createdAt)}</p>
+          <p className="mt-1 font-medium text-foreground">{signal.ageLabel}</p>
         </div>
       </div>
     </div>
   );
 }
 
-function MetricCard({ title, value, description, icon }: { title: string; value: number | string; description: string; icon: React.ReactNode }) {
+function MetricCard({
+  title,
+  value,
+  description,
+  icon,
+}: {
+  title: string;
+  value: number | string;
+  description: string;
+  icon: React.ReactNode;
+}) {
   return (
     <Card>
       <CardHeader className="pb-3">
@@ -193,7 +254,9 @@ function MetricCard({ title, value, description, icon }: { title: string; value:
             <CardDescription>{title}</CardDescription>
             <CardTitle className="mt-2 text-3xl">{value}</CardTitle>
           </div>
-          <div className="rounded-2xl border border-border/60 bg-background/70 p-2">{icon}</div>
+          <div className="rounded-2xl border border-border/60 bg-background/70 p-2">
+            {icon}
+          </div>
         </div>
       </CardHeader>
       <CardContent>
@@ -211,8 +274,14 @@ export default async function NotificationsPage({
   const user = await requireUser();
   const params = (await searchParams) ?? {};
   const source = typeof params.source === "string" ? params.source : "ALL";
-  const priority = typeof params.priority === "string" ? params.priority : "ALL";
-  const data = await getNotificationCenterData(user.id!, { source, priority });
+  const priority =
+    typeof params.priority === "string" ? params.priority : "ALL";
+  const state = typeof params.state === "string" ? params.state : "ALL";
+  const data = await getNotificationCenterData(user.id!, {
+    source,
+    priority,
+    state,
+  });
 
   return (
     <AppShell>
@@ -222,18 +291,59 @@ export default async function NotificationsPage({
           description="A unified action inbox for alerts, reminders, follow-ups, abnormal results, document hygiene, care invites, and device sync issues."
           action={
             <div className="flex flex-wrap gap-2">
-              <Link href="/alerts" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium hover:bg-muted/50">Alerts</Link>
-              <Link href="/reminders" className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium hover:bg-muted/50">Reminders</Link>
-              <Link href="/dashboard" className="inline-flex h-10 items-center justify-center rounded-2xl bg-primary px-4 text-sm font-medium text-primary-foreground shadow-sm hover:opacity-95">Dashboard</Link>
+              <Link
+                href="/alerts"
+                className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium hover:bg-muted/50"
+              >
+                Alerts
+              </Link>
+              <Link
+                href="/reminders"
+                className="inline-flex h-10 items-center justify-center rounded-2xl border border-border/70 bg-background/60 px-4 text-sm font-medium hover:bg-muted/50"
+              >
+                Reminders
+              </Link>
+              <Link
+                href="/dashboard"
+                className="inline-flex h-10 items-center justify-center rounded-2xl bg-primary px-4 text-sm font-medium text-primary-foreground shadow-sm hover:opacity-95"
+              >
+                Dashboard
+              </Link>
             </div>
           }
         />
 
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          <MetricCard title="Visible items" value={data.counts.visible} description={`${data.counts.total} total inbox signals before filters.`} icon={<Inbox className="h-5 w-5 text-primary" />} />
-          <MetricCard title="Critical" value={data.counts.critical} description="Critical alert or high-urgency workflow items." icon={<AlertTriangle className="h-5 w-5 text-rose-500" />} />
-          <MetricCard title="High priority" value={data.counts.high} description="Items that should be reviewed before routine updates." icon={<BellRing className="h-5 w-5 text-amber-500" />} />
-          <MetricCard title="Care workload" value={data.counts.medium + data.counts.low} description="Medium and low priority items for normal follow-up." icon={<HeartPulse className="h-5 w-5 text-emerald-500" />} />
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+          <MetricCard
+            title="Visible items"
+            value={data.counts.visible}
+            description={`${data.counts.total} total inbox signals before filters.`}
+            icon={<Inbox className="h-5 w-5 text-primary" />}
+          />
+          <MetricCard
+            title="Critical"
+            value={data.counts.critical}
+            description="Critical alert or high-urgency workflow items."
+            icon={<AlertTriangle className="h-5 w-5 text-rose-500" />}
+          />
+          <MetricCard
+            title="High priority"
+            value={data.counts.high}
+            description="Items that should be reviewed before routine updates."
+            icon={<BellRing className="h-5 w-5 text-amber-500" />}
+          />
+          <MetricCard
+            title="Actionable"
+            value={data.reliability.actionable}
+            description="Items with a direct follow-through or cleanup path."
+            icon={<ClipboardCheck className="h-5 w-5 text-emerald-500" />}
+          />
+          <MetricCard
+            title="Cleanup queue"
+            value={data.reliability.cleanupCandidates}
+            description="Stale or follow-up items that should be cleared soon."
+            icon={<Sparkles className="h-5 w-5 text-violet-500" />}
+          />
         </div>
 
         <div className="grid gap-6 xl:grid-cols-[0.85fr_1.15fr]">
@@ -241,15 +351,33 @@ export default async function NotificationsPage({
             <Card>
               <CardHeader>
                 <CardTitle>Filters</CardTitle>
-                <CardDescription>Switch between source and priority views without losing the inbox context.</CardDescription>
+                <CardDescription>
+                  Switch between source and priority views without losing the
+                  inbox context.
+                </CardDescription>
               </CardHeader>
               <CardContent className="space-y-5">
                 <div>
-                  <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Source</p>
+                  <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Source
+                  </p>
                   <div className="flex flex-wrap gap-2">
-                    <Link href={filterHref({ source: "ALL", priority })} className="rounded-full border border-border/60 px-3 py-1.5 text-xs font-medium hover:bg-muted/50">All</Link>
+                    <Link
+                      href={filterHref({ source: "ALL", priority, state })}
+                      className="rounded-full border border-border/60 px-3 py-1.5 text-xs font-medium hover:bg-muted/50"
+                    >
+                      All
+                    </Link>
                     {data.counts.bySource.map((row) => (
-                      <Link key={row.source} href={filterHref({ source: row.source, priority })} className="rounded-full border border-border/60 px-3 py-1.5 text-xs font-medium hover:bg-muted/50">
+                      <Link
+                        key={row.source}
+                        href={filterHref({
+                          source: row.source,
+                          priority,
+                          state,
+                        })}
+                        className="rounded-full border border-border/60 px-3 py-1.5 text-xs font-medium hover:bg-muted/50"
+                      >
                         {sourceLabels[row.source]} ({row.count})
                       </Link>
                     ))}
@@ -257,11 +385,46 @@ export default async function NotificationsPage({
                 </div>
 
                 <div>
-                  <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Priority</p>
+                  <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Priority
+                  </p>
                   <div className="flex flex-wrap gap-2">
-                    {(["ALL", "critical", "high", "medium", "low"] as const).map((option) => (
-                      <Link key={option} href={filterHref({ source, priority: option })} className="rounded-full border border-border/60 px-3 py-1.5 text-xs font-medium hover:bg-muted/50">
+                    {(
+                      ["ALL", "critical", "high", "medium", "low"] as const
+                    ).map((option) => (
+                      <Link
+                        key={option}
+                        href={filterHref({ source, priority: option, state })}
+                        className="rounded-full border border-border/60 px-3 py-1.5 text-xs font-medium hover:bg-muted/50"
+                      >
                         {option}
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Workflow state
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    <Link
+                      href={filterHref({ source, priority, state: "ALL" })}
+                      className="rounded-full border border-border/60 px-3 py-1.5 text-xs font-medium hover:bg-muted/50"
+                    >
+                      All
+                    </Link>
+                    {data.reliability.byState.map((row) => (
+                      <Link
+                        key={row.state}
+                        href={filterHref({
+                          source,
+                          priority,
+                          state: row.state,
+                        })}
+                        className="rounded-full border border-border/60 px-3 py-1.5 text-xs font-medium hover:bg-muted/50"
+                      >
+                        {stateLabels[row.state]} ({row.count})
                       </Link>
                     ))}
                   </div>
@@ -272,11 +435,18 @@ export default async function NotificationsPage({
             <Card>
               <CardHeader>
                 <CardTitle>Recommended next actions</CardTitle>
-                <CardDescription>Generated from the current notification workload. Use item actions to resolve, complete, snooze, or create follow-up reminders.</CardDescription>
+                <CardDescription>
+                  Generated from the current notification workload. Use item
+                  actions to resolve, complete, snooze, or create follow-up
+                  reminders.
+                </CardDescription>
               </CardHeader>
               <CardContent className="space-y-3">
                 {data.nextActions.map((action) => (
-                  <div key={action} className="rounded-2xl border border-border/60 bg-background/50 p-4 text-sm text-muted-foreground">
+                  <div
+                    key={action}
+                    className="rounded-2xl border border-border/60 bg-background/50 p-4 text-sm text-muted-foreground"
+                  >
                     {action}
                   </div>
                 ))}
@@ -288,14 +458,21 @@ export default async function NotificationsPage({
             <CardHeader>
               <CardTitle>Unified inbox</CardTitle>
               <CardDescription>
-                {source !== "ALL" || priority !== "ALL"
-                  ? `Filtered by source ${source} and priority ${priority}.`
+                {source !== "ALL" || priority !== "ALL" || state !== "ALL"
+                  ? `Filtered by source ${source}, priority ${priority}, and state ${state}.`
                   : "Sorted by priority first, then by the most relevant date."}
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
-              {data.items.map((item) => <NotificationCard key={item.id} item={item} />)}
-              {data.items.length === 0 ? <EmptyState title="Inbox is clear" description="No alerts, reminders, follow-ups, document gaps, care invites, or device issues match the current filter." /> : null}
+              {data.items.map((item) => (
+                <NotificationCard key={item.id} item={item} />
+              ))}
+              {data.items.length === 0 ? (
+                <EmptyState
+                  title="Inbox is clear"
+                  description="No alerts, reminders, follow-ups, document gaps, care invites, or device issues match the current filter."
+                />
+              ) : null}
             </CardContent>
           </Card>
         </div>

--- a/docs/PATCH_67_NOTIFICATION_CENTER_RELIABILITY_ACTIONS.md
+++ b/docs/PATCH_67_NOTIFICATION_CENTER_RELIABILITY_ACTIONS.md
@@ -1,0 +1,51 @@
+# Patch 67: Notification Center Reliability Actions
+
+## Summary
+
+This patch improves VitaVault's Notification Center with clearer workflow-state classification, action labels, stale cleanup signals, and regression coverage for notification follow-through behavior.
+
+## What changed
+
+- Added reusable notification reliability helpers in `lib/notification-center.ts`.
+- Classified notification items into workflow states:
+  - Urgent
+  - Due now
+  - Follow-up
+  - Stale
+  - Scheduled
+  - Needs review
+- Added source-specific action labels for alerts, reminders, appointments, labs, documents, care-team invites, and device sync issues.
+- Added stale/follow-up cleanup guidance so the inbox can be reviewed like an operational queue.
+- Added reliability summary counts to Notification Center data.
+- Added workflow-state filtering on `/notifications`.
+- Updated notification cards with action and cleanup guidance.
+- Added regression tests for reliability state classification, summary counts, action labels, and state filtering.
+
+## Safety notes
+
+- No Prisma migration.
+- No schema changes.
+- No dependency changes.
+- No README changes.
+- No notification persistence model was added.
+- Existing alert/reminder actions remain unchanged.
+- The patch uses existing generated notification sources and classifies them in memory.
+
+## Suggested local checks
+
+```powershell
+npm install
+npm run db:validate:ci
+npm run actions:check
+npm run actions:imports
+npm run actions:shadow
+npm run typecheck
+npm run lint
+npm run test:run
+```
+
+Targeted test:
+
+```powershell
+npm run test:run -- tests/notification-center.test.ts
+```

--- a/lib/notification-center.ts
+++ b/lib/notification-center.ts
@@ -10,7 +10,12 @@ import {
 import { db } from "@/lib/db";
 
 export type NotificationPriority = "critical" | "high" | "medium" | "low";
-export type NotificationTone = "danger" | "warning" | "info" | "success" | "neutral";
+export type NotificationTone =
+  | "danger"
+  | "warning"
+  | "info"
+  | "success"
+  | "neutral";
 export type NotificationSource =
   | "ALERT"
   | "REMINDER"
@@ -19,6 +24,14 @@ export type NotificationSource =
   | "DOCUMENT"
   | "CARE"
   | "DEVICE";
+
+export type NotificationReliabilityState =
+  | "urgent"
+  | "due_now"
+  | "follow_up"
+  | "stale"
+  | "scheduled"
+  | "review";
 
 export type NotificationItem = {
   id: string;
@@ -39,6 +52,34 @@ export type NotificationItem = {
 export type NotificationCenterFilters = {
   source?: string;
   priority?: string;
+  state?: string;
+};
+
+export type NotificationItemSignal = {
+  state: NotificationReliabilityState;
+  label: string;
+  tone: NotificationTone;
+  actionLabel: string;
+  cleanupHint: string;
+  ageLabel: string;
+  isStale: boolean;
+  isActionable: boolean;
+};
+
+export type NotificationReliabilitySummary = {
+  urgent: number;
+  dueNow: number;
+  followUp: number;
+  stale: number;
+  scheduled: number;
+  review: number;
+  actionable: number;
+  cleanupCandidates: number;
+  byState: Array<{
+    state: NotificationReliabilityState;
+    label: string;
+    count: number;
+  }>;
 };
 
 function addDays(date: Date, days: number) {
@@ -68,13 +109,18 @@ function alertPriority(severity: AlertSeverity): NotificationPriority {
 }
 
 function alertTone(severity: AlertSeverity): NotificationTone {
-  if (severity === AlertSeverity.CRITICAL || severity === AlertSeverity.HIGH) return "danger";
+  if (severity === AlertSeverity.CRITICAL || severity === AlertSeverity.HIGH)
+    return "danger";
   if (severity === AlertSeverity.MEDIUM) return "warning";
   return "info";
 }
 
-function reminderPriority(state: ReminderState, dueAt: Date): NotificationPriority {
-  if (state === ReminderState.OVERDUE || dueAt.getTime() < Date.now()) return "high";
+function reminderPriority(
+  state: ReminderState,
+  dueAt: Date,
+): NotificationPriority {
+  if (state === ReminderState.OVERDUE || dueAt.getTime() < Date.now())
+    return "high";
   if (dueAt.getTime() - Date.now() <= 4 * 60 * 60 * 1000) return "medium";
   return "low";
 }
@@ -91,24 +137,243 @@ function labTone(flag: LabFlag): NotificationTone {
   return "success";
 }
 
-function matchesFilter(item: NotificationItem, filters: NotificationCenterFilters) {
-  const source = filters.source && filters.source !== "ALL" ? filters.source : undefined;
-  const priority = filters.priority && filters.priority !== "ALL" ? filters.priority : undefined;
+function dayDifference(from: Date, to: Date) {
+  const start = new Date(from);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(to);
+  end.setHours(0, 0, 0, 0);
+  return Math.round((end.getTime() - start.getTime()) / (24 * 60 * 60 * 1000));
+}
+
+export function formatNotificationAgeLabel(
+  referenceDate: Date,
+  now = new Date(),
+) {
+  const days = dayDifference(now, referenceDate);
+
+  if (days === 0)
+    return referenceDate.getTime() >= now.getTime()
+      ? "Due today"
+      : "Updated today";
+  if (days === 1) return "Due tomorrow";
+  if (days > 1) return `Due in ${days} days`;
+  if (days === -1) return "1 day old";
+  return `${Math.abs(days)} days old`;
+}
+
+function isOlderThan(referenceDate: Date, now: Date, days: number) {
+  return referenceDate.getTime() < now.getTime() - days * 24 * 60 * 60 * 1000;
+}
+
+export function getNotificationActionLabel(
+  item: Pick<NotificationItem, "source" | "status" | "priority">,
+) {
+  if (item.source === "ALERT") {
+    return item.status === AlertStatus.ACKNOWLEDGED
+      ? "Resolve acknowledged alert"
+      : "Acknowledge or resolve alert";
+  }
+  if (item.source === "REMINDER") {
+    return item.status === ReminderState.OVERDUE ||
+      item.status === ReminderState.MISSED
+      ? "Complete, snooze, or skip overdue reminder"
+      : "Complete, snooze, or skip reminder";
+  }
+  if (item.source === "APPOINTMENT") return "Prepare visit packet";
+  if (item.source === "LAB") return "Review abnormal lab result";
+  if (item.source === "DOCUMENT") return "Link or document review notes";
+  if (item.source === "CARE") return "Review care-team invite";
+  if (item.source === "DEVICE") return "Review device sync health";
+  return item.priority === "critical" || item.priority === "high"
+    ? "Review now"
+    : "Create follow-up";
+}
+
+export function getNotificationItemSignal(
+  item: NotificationItem,
+  now = new Date(),
+): NotificationItemSignal {
+  const referenceDate = item.dueAt || item.createdAt;
+  const stale = isOlderThan(
+    referenceDate,
+    now,
+    item.priority === "low" ? 21 : 14,
+  );
+  const actionLabel = getNotificationActionLabel(item);
+
+  if (
+    item.priority === "critical" ||
+    (item.source === "DEVICE" && item.status === DeviceConnectionStatus.ERROR)
+  ) {
+    return {
+      state: "urgent",
+      label: "Urgent",
+      tone: "danger",
+      actionLabel,
+      cleanupHint: "Handle this before routine notification cleanup.",
+      ageLabel: formatNotificationAgeLabel(referenceDate, now),
+      isStale: stale,
+      isActionable: true,
+    };
+  }
+
+  if (
+    item.source === "REMINDER" &&
+    (item.status === ReminderState.OVERDUE ||
+      item.status === ReminderState.MISSED ||
+      (item.dueAt && item.dueAt.getTime() <= now.getTime()))
+  ) {
+    return {
+      state: "due_now",
+      label: "Due now",
+      tone: "warning",
+      actionLabel,
+      cleanupHint: "Complete, snooze, or skip to clear this item.",
+      ageLabel: formatNotificationAgeLabel(referenceDate, now),
+      isStale: stale,
+      isActionable: true,
+    };
+  }
+
+  if (item.status === AlertStatus.ACKNOWLEDGED) {
+    return {
+      state: "follow_up",
+      label: "Follow-up",
+      tone: "info",
+      actionLabel,
+      cleanupHint:
+        "Resolve this acknowledged item once the follow-up is complete.",
+      ageLabel: formatNotificationAgeLabel(referenceDate, now),
+      isStale: stale,
+      isActionable: true,
+    };
+  }
+
+  if (stale) {
+    return {
+      state: "stale",
+      label: "Stale",
+      tone: "neutral",
+      actionLabel,
+      cleanupHint:
+        "Create a follow-up or resolve the source record so it leaves the inbox.",
+      ageLabel: formatNotificationAgeLabel(referenceDate, now),
+      isStale: true,
+      isActionable: true,
+    };
+  }
+
+  if (
+    item.source === "APPOINTMENT" ||
+    (item.dueAt && item.dueAt.getTime() > now.getTime())
+  ) {
+    return {
+      state: "scheduled",
+      label: "Scheduled",
+      tone: "info",
+      actionLabel,
+      cleanupHint:
+        "Keep this visible until the scheduled date passes or preparation is complete.",
+      ageLabel: formatNotificationAgeLabel(referenceDate, now),
+      isStale: false,
+      isActionable: item.priority !== "low",
+    };
+  }
+
+  return {
+    state: "review",
+    label: "Needs review",
+    tone: item.priority === "high" ? "warning" : "neutral",
+    actionLabel,
+    cleanupHint: "Review this item or create a follow-up reminder.",
+    ageLabel: formatNotificationAgeLabel(referenceDate, now),
+    isStale: false,
+    isActionable: true,
+  };
+}
+
+export function buildNotificationReliabilitySummary(
+  items: NotificationItem[],
+  now = new Date(),
+): NotificationReliabilitySummary {
+  const signals = items.map((item) => getNotificationItemSignal(item, now));
+  const countState = (state: NotificationReliabilityState) =>
+    signals.filter((signal) => signal.state === state).length;
+
+  return {
+    urgent: countState("urgent"),
+    dueNow: countState("due_now"),
+    followUp: countState("follow_up"),
+    stale: countState("stale"),
+    scheduled: countState("scheduled"),
+    review: countState("review"),
+    actionable: signals.filter((signal) => signal.isActionable).length,
+    cleanupCandidates: signals.filter(
+      (signal) => signal.isStale || signal.state === "follow_up",
+    ).length,
+    byState: [
+      { state: "urgent", label: "Urgent", count: countState("urgent") },
+      { state: "due_now", label: "Due now", count: countState("due_now") },
+      {
+        state: "follow_up",
+        label: "Follow-up",
+        count: countState("follow_up"),
+      },
+      { state: "stale", label: "Stale", count: countState("stale") },
+      {
+        state: "scheduled",
+        label: "Scheduled",
+        count: countState("scheduled"),
+      },
+      { state: "review", label: "Needs review", count: countState("review") },
+    ],
+  };
+}
+
+function matchesFilter(
+  item: NotificationItem,
+  filters: NotificationCenterFilters,
+  now: Date,
+) {
+  const source =
+    filters.source && filters.source !== "ALL" ? filters.source : undefined;
+  const priority =
+    filters.priority && filters.priority !== "ALL"
+      ? filters.priority
+      : undefined;
+  const state =
+    filters.state && filters.state !== "ALL" ? filters.state : undefined;
 
   if (source && item.source !== source) return false;
   if (priority && item.priority !== priority) return false;
+  if (state && getNotificationItemSignal(item, now).state !== state)
+    return false;
   return true;
 }
 
-export async function getNotificationCenterData(userId: string, filters: NotificationCenterFilters = {}) {
+export async function getNotificationCenterData(
+  userId: string,
+  filters: NotificationCenterFilters = {},
+) {
   const now = new Date();
   const today = startOfToday();
   const soon = addDays(now, 14);
   const staleDeviceCutoff = addDays(now, -7);
 
-  const [alerts, reminders, appointments, labs, documents, careInvites, deviceConnections] = await Promise.all([
+  const [
+    alerts,
+    reminders,
+    appointments,
+    labs,
+    documents,
+    careInvites,
+    deviceConnections,
+  ] = await Promise.all([
     db.alertEvent.findMany({
-      where: { userId, status: { in: [AlertStatus.OPEN, AlertStatus.ACKNOWLEDGED] } },
+      where: {
+        userId,
+        status: { in: [AlertStatus.OPEN, AlertStatus.ACKNOWLEDGED] },
+      },
       orderBy: { createdAt: "desc" },
       take: 20,
       select: {
@@ -124,7 +389,14 @@ export async function getNotificationCenterData(userId: string, filters: Notific
     db.reminder.findMany({
       where: {
         userId,
-        state: { in: [ReminderState.DUE, ReminderState.SENT, ReminderState.OVERDUE, ReminderState.MISSED] },
+        state: {
+          in: [
+            ReminderState.DUE,
+            ReminderState.SENT,
+            ReminderState.OVERDUE,
+            ReminderState.MISSED,
+          ],
+        },
         dueAt: { lte: soon },
       },
       orderBy: { dueAt: "asc" },
@@ -157,7 +429,10 @@ export async function getNotificationCenterData(userId: string, filters: Notific
       },
     }),
     db.labResult.findMany({
-      where: { userId, flag: { in: [LabFlag.BORDERLINE, LabFlag.HIGH, LabFlag.LOW] } },
+      where: {
+        userId,
+        flag: { in: [LabFlag.BORDERLINE, LabFlag.HIGH, LabFlag.LOW] },
+      },
       orderBy: { dateTaken: "desc" },
       take: 12,
       select: {
@@ -238,16 +513,25 @@ export async function getNotificationCenterData(userId: string, filters: Notific
       createdAt: alert.createdAt,
       status: alert.status,
       meta: `${alert.category} • ${alert.severity}`,
-      actionHint: alert.status === AlertStatus.OPEN ? "Acknowledge or resolve this alert." : "Resolve this acknowledged alert.",
+      actionHint:
+        alert.status === AlertStatus.OPEN
+          ? "Acknowledge or resolve this alert."
+          : "Resolve this acknowledged alert.",
     })),
     ...reminders.map((reminder) => ({
       id: `reminder-${reminder.id}`,
       sourceId: reminder.id,
       source: "REMINDER" as const,
       title: reminder.title,
-      description: reminder.description || `${reminder.type} reminder due ${reminder.dueAt.toLocaleString()}`,
+      description:
+        reminder.description ||
+        `${reminder.type} reminder due ${reminder.dueAt.toLocaleString()}`,
       priority: reminderPriority(reminder.state, reminder.dueAt),
-      tone: reminder.state === ReminderState.OVERDUE || reminder.dueAt.getTime() < Date.now() ? "warning" as const : "info" as const,
+      tone:
+        reminder.state === ReminderState.OVERDUE ||
+        reminder.dueAt.getTime() < Date.now()
+          ? ("warning" as const)
+          : ("info" as const),
       href: `/reminders?state=${reminder.state}`,
       createdAt: reminder.createdAt,
       dueAt: reminder.dueAt,
@@ -261,7 +545,11 @@ export async function getNotificationCenterData(userId: string, filters: Notific
       source: "APPOINTMENT" as const,
       title: appointment.purpose,
       description: `${appointment.doctorName} • ${appointment.clinic}`,
-      priority: appointment.scheduledAt.getTime() - now.getTime() <= 3 * 24 * 60 * 60 * 1000 ? "medium" as const : "low" as const,
+      priority:
+        appointment.scheduledAt.getTime() - now.getTime() <=
+        3 * 24 * 60 * 60 * 1000
+          ? ("medium" as const)
+          : ("low" as const),
       tone: "info" as const,
       href: "/appointments",
       createdAt: appointment.createdAt,
@@ -296,13 +584,17 @@ export async function getNotificationCenterData(userId: string, filters: Notific
         description: needsLink
           ? `${document.fileName} is not linked to a record yet.`
           : `${document.fileName} needs stronger review notes.`,
-        priority: needsLink ? "medium" as const : "low" as const,
-        tone: needsLink ? "warning" as const : "neutral" as const,
-        href: needsLink ? "/documents?link=UNLINKED" : "/documents?quality=NEEDS_NOTES",
+        priority: needsLink ? ("medium" as const) : ("low" as const),
+        tone: needsLink ? ("warning" as const) : ("neutral" as const),
+        href: needsLink
+          ? "/documents?link=UNLINKED"
+          : "/documents?quality=NEEDS_NOTES",
         createdAt: document.createdAt,
         status: needsLink ? "UNLINKED" : needsNotes ? "NEEDS_NOTES" : "READY",
         meta: document.type,
-        actionHint: needsLink ? "Open document hub and link this file." : "Open document hub and add notes.",
+        actionHint: needsLink
+          ? "Open document hub and link this file."
+          : "Open document hub and add notes.",
       };
     }),
     ...careInvites.map((invite) => ({
@@ -311,7 +603,10 @@ export async function getNotificationCenterData(userId: string, filters: Notific
       source: "CARE" as const,
       title: `Pending invite for ${invite.email}`,
       description: `${invite.accessRole} access expires ${invite.expiresAt.toLocaleDateString()}`,
-      priority: invite.expiresAt.getTime() - now.getTime() <= 3 * 24 * 60 * 60 * 1000 ? "medium" as const : "low" as const,
+      priority:
+        invite.expiresAt.getTime() - now.getTime() <= 3 * 24 * 60 * 60 * 1000
+          ? ("medium" as const)
+          : ("low" as const),
       tone: "info" as const,
       href: "/care-team",
       createdAt: invite.createdAt,
@@ -325,28 +620,39 @@ export async function getNotificationCenterData(userId: string, filters: Notific
       sourceId: device.id,
       source: "DEVICE" as const,
       title: device.deviceLabel || `${device.platform} ${device.source}`,
-      description: device.lastError || `Last synced ${device.lastSyncedAt ? device.lastSyncedAt.toLocaleDateString() : "never"}`,
-      priority: device.status === DeviceConnectionStatus.ERROR ? "high" as const : "medium" as const,
-      tone: device.status === DeviceConnectionStatus.ERROR ? "danger" as const : "warning" as const,
+      description:
+        device.lastError ||
+        `Last synced ${device.lastSyncedAt ? device.lastSyncedAt.toLocaleDateString() : "never"}`,
+      priority:
+        device.status === DeviceConnectionStatus.ERROR
+          ? ("high" as const)
+          : ("medium" as const),
+      tone:
+        device.status === DeviceConnectionStatus.ERROR
+          ? ("danger" as const)
+          : ("warning" as const),
       href: "/device-connection",
       createdAt: device.updatedAt || device.createdAt,
       dueAt: device.lastSyncedAt,
       status: device.status,
       meta: `${device.source} • ${device.platform}`,
-      actionHint: "Open device connection review or create a sync follow-up reminder.",
+      actionHint:
+        "Open device connection review or create a sync follow-up reminder.",
     })),
   ];
 
-  const sortedItems = items
-    .sort((a, b) => {
-      const score = priorityScore(b.priority) - priorityScore(a.priority);
-      if (score !== 0) return score;
-      const aTime = (a.dueAt || a.createdAt).getTime();
-      const bTime = (b.dueAt || b.createdAt).getTime();
-      return bTime - aTime;
-    });
+  const sortedItems = items.sort((a, b) => {
+    const score = priorityScore(b.priority) - priorityScore(a.priority);
+    if (score !== 0) return score;
+    const aTime = (a.dueAt || a.createdAt).getTime();
+    const bTime = (b.dueAt || b.createdAt).getTime();
+    return bTime - aTime;
+  });
 
-  const filteredItems = sortedItems.filter((item) => matchesFilter(item, filters));
+  const filteredItems = sortedItems.filter((item) =>
+    matchesFilter(item, filters, now),
+  );
+  const reliability = buildNotificationReliabilitySummary(sortedItems, now);
 
   const counts = {
     total: sortedItems.length,
@@ -355,22 +661,42 @@ export async function getNotificationCenterData(userId: string, filters: Notific
     high: sortedItems.filter((item) => item.priority === "high").length,
     medium: sortedItems.filter((item) => item.priority === "medium").length,
     low: sortedItems.filter((item) => item.priority === "low").length,
-    bySource: (['ALERT', 'REMINDER', 'APPOINTMENT', 'LAB', 'DOCUMENT', 'CARE', 'DEVICE'] as NotificationSource[]).map((source) => ({
+    bySource: (
+      [
+        "ALERT",
+        "REMINDER",
+        "APPOINTMENT",
+        "LAB",
+        "DOCUMENT",
+        "CARE",
+        "DEVICE",
+      ] as NotificationSource[]
+    ).map((source) => ({
       source,
       count: sortedItems.filter((item) => item.source === source).length,
     })),
   };
 
   const nextActions = [
-    counts.critical || counts.high ? "Review high-priority alerts, abnormal labs, or device errors first." : "No high-risk items are waiting right now.",
-    counts.bySource.find((item) => item.source === "REMINDER")?.count ? "Clear due and overdue reminders to keep the care plan current." : "Reminder queue is clear for the current filter window.",
-    counts.bySource.find((item) => item.source === "DOCUMENT")?.count ? "Link uploaded documents to records so future summaries are more complete." : "Document hygiene looks good for now.",
+    reliability.urgent || counts.critical || counts.high
+      ? "Review urgent alerts, abnormal labs, or device errors first."
+      : "No urgent notification items are waiting right now.",
+    reliability.dueNow
+      ? "Clear due and overdue reminders to keep the care plan current."
+      : "Reminder queue is clear for the current filter window.",
+    reliability.cleanupCandidates
+      ? "Clean up stale or follow-up items so the inbox stays reviewer-ready."
+      : "No stale notification cleanup is needed right now.",
+    counts.bySource.find((item) => item.source === "DOCUMENT")?.count
+      ? "Link uploaded documents to records so future summaries are more complete."
+      : "Document hygiene looks good for now.",
   ];
 
   return {
     items: filteredItems,
     allItems: sortedItems,
     counts,
+    reliability,
     nextActions,
   };
 }

--- a/tests/notification-center.test.ts
+++ b/tests/notification-center.test.ts
@@ -7,6 +7,7 @@ import {
   LabFlag,
   ReminderState,
 } from "@prisma/client";
+import type { NotificationItem } from "@/lib/notification-center";
 
 const alertFindManyMock = vi.fn();
 const reminderFindManyMock = vi.fn();
@@ -27,6 +28,29 @@ vi.mock("@/lib/db", () => ({
     deviceConnection: { findMany: deviceConnectionFindManyMock },
   },
 }));
+
+function baseNotification(
+  overrides: Partial<NotificationItem> = {},
+): NotificationItem {
+  const now = new Date("2026-05-12T09:00:00.000Z");
+
+  return {
+    id: "notification_1",
+    sourceId: "source_1",
+    source: "REMINDER",
+    title: "Follow-up item",
+    description: "Review this workflow item.",
+    priority: "medium",
+    tone: "info",
+    href: "/notifications",
+    createdAt: now,
+    dueAt: now,
+    status: ReminderState.DUE,
+    meta: "GENERAL",
+    actionHint: "Review this item.",
+    ...overrides,
+  };
+}
 
 describe("notification center data", () => {
   beforeEach(() => {
@@ -123,10 +147,18 @@ describe("notification center data", () => {
       },
     ]);
 
-    const { getNotificationCenterData } = await import("@/lib/notification-center");
+    const { getNotificationCenterData } =
+      await import("@/lib/notification-center");
     const allData = await getNotificationCenterData("user_1");
-    const alertOnly = await getNotificationCenterData("user_1", { source: "ALERT" });
-    const highOnly = await getNotificationCenterData("user_1", { priority: "high" });
+    const alertOnly = await getNotificationCenterData("user_1", {
+      source: "ALERT",
+    });
+    const highOnly = await getNotificationCenterData("user_1", {
+      priority: "high",
+    });
+    const urgentOnly = await getNotificationCenterData("user_1", {
+      state: "urgent",
+    });
 
     expect(allData.counts.total).toBe(7);
     expect(allData.counts.critical).toBe(1);
@@ -135,7 +167,107 @@ describe("notification center data", () => {
     expect(alertOnly.items).toHaveLength(1);
     expect(alertOnly.items[0]?.source).toBe("ALERT");
     expect(highOnly.items.every((item) => item.priority === "high")).toBe(true);
-    expect(allData.counts.bySource.find((item) => item.source === "DEVICE")?.count).toBe(1);
-    expect(allData.nextActions).toContain("Review high-priority alerts, abnormal labs, or device errors first.");
+    expect(
+      urgentOnly.items.every(
+        (item) => item.priority === "critical" || item.source === "DEVICE",
+      ),
+    ).toBe(true);
+    expect(
+      allData.counts.bySource.find((item) => item.source === "DEVICE")?.count,
+    ).toBe(1);
+    expect(allData.reliability.urgent).toBeGreaterThanOrEqual(2);
+    expect(allData.reliability.dueNow).toBe(1);
+    expect(allData.reliability.actionable).toBeGreaterThan(0);
+    expect(allData.nextActions).toContain(
+      "Review urgent alerts, abnormal labs, or device errors first.",
+    );
+  });
+
+  it("classifies urgent, due-now, follow-up, stale, and scheduled notification signals", async () => {
+    const { buildNotificationReliabilitySummary, getNotificationItemSignal } =
+      await import("@/lib/notification-center");
+    const now = new Date("2026-05-12T09:00:00.000Z");
+    const thirtyDaysAgo = new Date("2026-04-12T09:00:00.000Z");
+    const tomorrow = new Date("2026-05-13T09:00:00.000Z");
+    const items: NotificationItem[] = [
+      baseNotification({
+        source: "ALERT",
+        priority: "critical",
+        status: AlertStatus.OPEN,
+        createdAt: now,
+        dueAt: null,
+      }),
+      baseNotification({
+        source: "REMINDER",
+        priority: "high",
+        status: ReminderState.OVERDUE,
+        createdAt: thirtyDaysAgo,
+        dueAt: thirtyDaysAgo,
+      }),
+      baseNotification({
+        source: "ALERT",
+        priority: "medium",
+        status: AlertStatus.ACKNOWLEDGED,
+        createdAt: now,
+        dueAt: null,
+      }),
+      baseNotification({
+        source: "DOCUMENT",
+        priority: "medium",
+        status: "UNLINKED",
+        createdAt: thirtyDaysAgo,
+        dueAt: null,
+      }),
+      baseNotification({
+        source: "APPOINTMENT",
+        priority: "low",
+        status: "UPCOMING",
+        createdAt: now,
+        dueAt: tomorrow,
+      }),
+    ];
+
+    expect(getNotificationItemSignal(items[0], now).state).toBe("urgent");
+    expect(getNotificationItemSignal(items[1], now).state).toBe("due_now");
+    expect(getNotificationItemSignal(items[2], now).state).toBe("follow_up");
+    expect(getNotificationItemSignal(items[3], now).state).toBe("stale");
+    expect(getNotificationItemSignal(items[4], now).state).toBe("scheduled");
+
+    const summary = buildNotificationReliabilitySummary(items, now);
+    expect(summary.urgent).toBe(1);
+    expect(summary.dueNow).toBe(1);
+    expect(summary.followUp).toBe(1);
+    expect(summary.stale).toBe(1);
+    expect(summary.scheduled).toBe(1);
+    expect(summary.cleanupCandidates).toBeGreaterThanOrEqual(2);
+  });
+
+  it("keeps action labels source-specific for notification cards", async () => {
+    const { getNotificationActionLabel } =
+      await import("@/lib/notification-center");
+
+    expect(
+      getNotificationActionLabel(
+        baseNotification({ source: "ALERT", status: AlertStatus.OPEN }),
+      ),
+    ).toBe("Acknowledge or resolve alert");
+    expect(
+      getNotificationActionLabel(
+        baseNotification({ source: "ALERT", status: AlertStatus.ACKNOWLEDGED }),
+      ),
+    ).toBe("Resolve acknowledged alert");
+    expect(
+      getNotificationActionLabel(
+        baseNotification({ source: "REMINDER", status: ReminderState.OVERDUE }),
+      ),
+    ).toBe("Complete, snooze, or skip overdue reminder");
+    expect(
+      getNotificationActionLabel(
+        baseNotification({
+          source: "DEVICE",
+          status: DeviceConnectionStatus.ERROR,
+        }),
+      ),
+    ).toBe("Review device sync health");
   });
 });


### PR DESCRIPTION
## Summary

This patch improves VitaVault's Notification Center with clearer workflow-state classification, action labels, stale cleanup signals, and reliability-focused tests.

## Changes

- Added notification reliability states for urgent, due-now, follow-up, stale, scheduled, and needs-review items
- Added reusable notification reliability helpers
- Added reliability summary counts to Notification Center data
- Added workflow-state filtering to `/notifications`
- Updated notification cards with action labels, cleanup guidance, and age labels
- Expanded notification-center test coverage
- Added Patch 67 documentation under `docs/`

## Safety

- No Prisma migration
- No schema changes
- No dependency changes
- No README changes
- No notification persistence model added
- Existing alert/reminder actions remain unchanged

## Checks

Run locally:

```powershell
npm install
npm run db:validate:ci
npm run actions:check
npm run actions:imports
npm run actions:shadow
npm run typecheck
npm run lint
npm run test:run