### PR TITLE
Harden deployment and demo readiness checks

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
-import { getDeploymentReadinessSummary } from "@/lib/deployment-readiness";
+import {
+  getDemoReadinessSummary,
+  getDeploymentReadinessSummary,
+} from "@/lib/deployment-readiness";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -14,45 +17,84 @@ type HealthCheckResult = {
 async function checkDatabase(): Promise<HealthCheckResult> {
   try {
     await db.$queryRaw`SELECT 1`;
-    return { name: "database", status: "ok", detail: "Prisma database ping succeeded." };
+    return {
+      name: "database",
+      status: "ok",
+      detail: "Prisma database ping succeeded.",
+    };
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Unknown database error";
+    const message =
+      error instanceof Error ? error.message : "Unknown database error";
     return { name: "database", status: "error", detail: message };
   }
 }
 
 function checkRedis(): HealthCheckResult {
   if (process.env.REDIS_URL?.trim()) {
-    return { name: "redis", status: "ok", detail: "REDIS_URL is configured for queue-backed workflows." };
+    return {
+      name: "redis",
+      status: "ok",
+      detail: "REDIS_URL is configured for queue-backed workflows.",
+    };
   }
-  return { name: "redis", status: "warning", detail: "REDIS_URL is not configured. Worker-backed jobs will be degraded." };
+  return {
+    name: "redis",
+    status: "warning",
+    detail: "REDIS_URL is not configured. Worker-backed jobs will be degraded.",
+  };
 }
 
 function checkEmail(): HealthCheckResult {
-  if (process.env.RESEND_API_KEY?.trim() && process.env.RESEND_FROM_EMAIL?.trim()) {
-    return { name: "email", status: "ok", detail: "Email delivery variables are configured." };
+  if (
+    process.env.RESEND_API_KEY?.trim() &&
+    process.env.RESEND_FROM_EMAIL?.trim()
+  ) {
+    return {
+      name: "email",
+      status: "ok",
+      detail: "Email delivery variables are configured.",
+    };
   }
-  return { name: "email", status: "warning", detail: "Email delivery is not fully configured." };
+  return {
+    name: "email",
+    status: "warning",
+    detail: "Email delivery is not fully configured.",
+  };
 }
 
 function checkAi(): HealthCheckResult {
   if (process.env.OPENAI_API_KEY?.trim()) {
-    return { name: "ai", status: "ok", detail: "AI insight generation key is configured." };
+    return {
+      name: "ai",
+      status: "ok",
+      detail: "AI insight generation key is configured.",
+    };
   }
-  return { name: "ai", status: "warning", detail: "OPENAI_API_KEY is missing. AI features should use fallback/demo behavior." };
+  return {
+    name: "ai",
+    status: "warning",
+    detail:
+      "OPENAI_API_KEY is missing. AI features should use fallback/demo behavior.",
+  };
 }
 
 export async function GET() {
   const readiness = getDeploymentReadinessSummary();
+  const demo = getDemoReadinessSummary();
   const checks = [await checkDatabase(), checkRedis(), checkEmail(), checkAi()];
-  const hasError = checks.some((check) => check.status === "error") || readiness.blockingIssues.length > 0;
-  const hasWarning = checks.some((check) => check.status === "warning") || readiness.warningIssues.length > 0;
+  const hasError =
+    checks.some((check) => check.status === "error") ||
+    readiness.blockingIssues.length > 0;
+  const hasWarning =
+    checks.some((check) => check.status === "warning") ||
+    readiness.warningIssues.length > 0;
 
   const body = {
     status: hasError ? "error" : hasWarning ? "warning" : "ok",
     service: "VitaVault",
     timestamp: new Date().toISOString(),
     readiness: {
+      mode: readiness.mode,
       score: readiness.score,
       requiredConfigured: readiness.requiredConfigured,
       requiredTotal: readiness.requiredTotal,
@@ -60,6 +102,13 @@ export async function GET() {
       recommendedTotal: readiness.recommendedTotal,
       blockingKeys: readiness.blockingIssues.map((issue) => issue.key),
       warningKeys: readiness.warningIssues.map((issue) => issue.key),
+      guidance: readiness.guidance,
+    },
+    demo: {
+      ready: demo.ready,
+      score: demo.score,
+      blockingKeys: demo.blocking.map((issue) => issue.key),
+      guidance: demo.guidance,
     },
     checks,
   };

--- a/docs/PATCH_76_DEPLOYMENT_DEMO_READINESS_HARDENING.md
+++ b/docs/PATCH_76_DEPLOYMENT_DEMO_READINESS_HARDENING.md
@@ -1,0 +1,54 @@
+# Patch 76 — Deployment and Demo Readiness Hardening
+
+## Summary
+
+This patch strengthens VitaVault's deployment validation layer so reviewers and maintainers can understand whether an environment is production-ready, review-ready, local-development ready, or blocked.
+
+## What changed
+
+- Added explicit deployment modes:
+  - `production-ready`
+  - `review-ready`
+  - `local-development`
+  - `blocked`
+- Added feature-area metadata for deployment checks.
+- Added sanitized environment readiness output so secrets are never rendered directly.
+- Added demo-readiness checks for:
+  - demo-mode fallback
+  - database minimum
+  - auth minimum
+  - static demo route availability
+- Added deployment guidance messages for blocking, degraded, and ready states.
+- Updated `/api/health` to expose readiness mode, guidance, and demo readiness summary.
+- Expanded deployment readiness tests.
+
+## Safety
+
+- No Prisma migration.
+- No schema changes.
+- No package changes.
+- No README changes.
+- No auth behavior changes.
+- No deployment secrets are exposed.
+- Demo readiness is informational and does not bypass production checks.
+
+## Validation
+
+Run:
+
+```powershell
+npm install
+npm run db:validate:ci
+npm run actions:check
+npm run actions:imports
+npm run actions:shadow
+npm run typecheck
+npm run lint
+npm run test:run
+```
+
+Targeted test:
+
+```powershell
+npm run test:run -- tests/deployment-readiness.test.ts
+```

--- a/docs/PATCH_76_HOTFIX_DEPLOYMENT_READINESS_TEST_TYPES.md
+++ b/docs/PATCH_76_HOTFIX_DEPLOYMENT_READINESS_TEST_TYPES.md
@@ -1,0 +1,30 @@
+# Patch 76 Hotfix — Deployment Readiness Test Types
+
+## Summary
+
+This hotfix resolves Patch 76 validation issues in the deployment-readiness test suite.
+
+## Fixes
+
+- Replaces direct `process.env.NODE_ENV` assignment with `vi.stubEnv("NODE_ENV", "production")` so the test remains compatible with TypeScript's readonly `NODE_ENV` typing.
+- Narrows the secret sanitization assertion to configured secret/key values only, avoiding false failures for optional secret-like variables that are intentionally not configured in the fixture.
+
+## Safety
+
+- No runtime code changes.
+- No Prisma migration.
+- No schema changes.
+- No package changes.
+- No README changes.
+- Test-only patch.
+
+## Validation
+
+Run:
+
+```powershell
+npm run typecheck
+npm run lint
+npm run test:run -- tests/deployment-readiness.test.ts
+npm run test:run
+```

--- a/lib/deployment-readiness.ts
+++ b/lib/deployment-readiness.ts
@@ -1,96 +1,440 @@
 export type DeploymentTone = "success" | "warning" | "danger" | "neutral";
 
+export type DeploymentCheckCategory = "required" | "recommended" | "optional";
+
 export type DeploymentCheck = {
   key: string;
   label: string;
-  category: "required" | "recommended" | "optional";
+  category: DeploymentCheckCategory;
   configured: boolean;
   tone: DeploymentTone;
   detail: string;
+  safeValue?: string;
+  requiredForDemo?: boolean;
+  featureArea:
+    | "core"
+    | "auth"
+    | "jobs"
+    | "email"
+    | "ai"
+    | "storage"
+    | "monitoring";
+};
+
+export type DeploymentMode =
+  | "production-ready"
+  | "review-ready"
+  | "local-development"
+  | "blocked";
+
+export type DeploymentReadinessSummary = {
+  mode: DeploymentMode;
+  score: number;
+  requiredTotal: number;
+  requiredConfigured: number;
+  recommendedTotal: number;
+  recommendedConfigured: number;
+  optionalTotal: number;
+  optionalConfigured: number;
+  blockingIssues: DeploymentCheck[];
+  warningIssues: DeploymentCheck[];
+  demoBlockingIssues: DeploymentCheck[];
+  checks: DeploymentCheck[];
+  guidance: string[];
+};
+
+export type DemoReadinessCheck = {
+  key: string;
+  label: string;
+  ready: boolean;
+  tone: DeploymentTone;
+  detail: string;
+};
+
+export type DemoReadinessSummary = {
+  ready: boolean;
+  score: number;
+  checks: DemoReadinessCheck[];
+  blocking: DemoReadinessCheck[];
+  guidance: string[];
 };
 
 function hasValue(value: string | undefined | null) {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+function normalizeEnvValue(value: string | undefined | null) {
+  return String(value ?? "").trim();
+}
+
 function isPlaceholder(value: string | undefined | null) {
   if (!hasValue(value)) return true;
-  const normalized = String(value).toLowerCase();
-  return normalized.includes("change-this") || normalized.includes("example.com") || normalized.includes("user:password") || normalized.includes("db_name");
+  const normalized = normalizeEnvValue(value).toLowerCase();
+  return (
+    normalized.includes("change-this") ||
+    normalized.includes("example.com") ||
+    normalized.includes("user:password") ||
+    normalized.includes("db_name") ||
+    normalized.includes("your-") ||
+    normalized.includes("replace-me") ||
+    normalized.includes("placeholder")
+  );
 }
 
-function checkRequired(key: string, label: string, detail: string): DeploymentCheck {
+function safeEnvValue(key: string, value: string | undefined | null) {
+  if (!hasValue(value)) return "Not configured";
+  if (isPlaceholder(value)) return "Placeholder value";
+
+  if (key.includes("SECRET") || key.includes("KEY") || key.includes("TOKEN")) {
+    return "Configured secret";
+  }
+
+  if (key === "DATABASE_URL") {
+    return "Configured database URL";
+  }
+
+  const trimmed = normalizeEnvValue(value);
+  if (trimmed.length <= 42) return trimmed;
+  return `${trimmed.slice(0, 24)}…${trimmed.slice(-10)}`;
+}
+
+function buildCheck(
+  category: DeploymentCheckCategory,
+  key: string,
+  label: string,
+  detail: string,
+  featureArea: DeploymentCheck["featureArea"],
+  requiredForDemo = false,
+): DeploymentCheck {
   const value = process.env[key];
   const configured = hasValue(value) && !isPlaceholder(value);
+  const missingDetail =
+    category === "required"
+      ? `${detail} This value is required before production deployment.`
+      : category === "recommended"
+        ? `${detail} The app can run without it, but the related feature will be degraded or disabled.`
+        : detail;
+
   return {
     key,
     label,
-    category: "required",
+    category,
     configured,
-    tone: configured ? "success" : "danger",
-    detail: configured ? detail : `${detail} This value is required before production deployment.`,
+    requiredForDemo,
+    featureArea,
+    tone: configured
+      ? "success"
+      : category === "required" || requiredForDemo
+        ? "danger"
+        : category === "recommended"
+          ? "warning"
+          : "neutral",
+    detail: configured ? detail : missingDetail,
+    safeValue: safeEnvValue(key, value),
   };
 }
 
-function checkRecommended(key: string, label: string, detail: string): DeploymentCheck {
-  const value = process.env[key];
-  const configured = hasValue(value) && !isPlaceholder(value);
-  return {
+function checkRequired(
+  key: string,
+  label: string,
+  detail: string,
+  featureArea: DeploymentCheck["featureArea"],
+  requiredForDemo = false,
+) {
+  return buildCheck(
+    "required",
     key,
     label,
-    category: "recommended",
-    configured,
-    tone: configured ? "success" : "warning",
-    detail: configured ? detail : `${detail} The app can run without it, but the related feature will be degraded or disabled.`,
-  };
-}
-
-function checkOptional(key: string, label: string, detail: string): DeploymentCheck {
-  const value = process.env[key];
-  const configured = hasValue(value) && !isPlaceholder(value);
-  return {
-    key,
-    label,
-    category: "optional",
-    configured,
-    tone: configured ? "success" : "neutral",
     detail,
-  };
+    featureArea,
+    requiredForDemo,
+  );
+}
+
+function checkRecommended(
+  key: string,
+  label: string,
+  detail: string,
+  featureArea: DeploymentCheck["featureArea"],
+) {
+  return buildCheck("recommended", key, label, detail, featureArea);
+}
+
+function checkOptional(
+  key: string,
+  label: string,
+  detail: string,
+  featureArea: DeploymentCheck["featureArea"],
+) {
+  return buildCheck("optional", key, label, detail, featureArea);
 }
 
 export function getDeploymentChecks(): DeploymentCheck[] {
   return [
-    checkRequired("DATABASE_URL", "Database URL", "PostgreSQL connection used by Prisma, records, auth, and reporting."),
-    checkRequired("AUTH_SECRET", "Auth secret", "Long random secret used by Auth.js session encryption and signing."),
-    checkRequired("NEXTAUTH_URL", "Public auth URL", "Canonical app URL used by Auth.js callbacks and redirects."),
-    checkRequired("APP_URL", "Application URL", "Base URL used by emails, links, and product-facing workflows."),
-    checkRecommended("REDIS_URL", "Redis URL", "Redis connection used by BullMQ workers, reminders, alerts, and queue-backed features."),
-    checkRecommended("INTERNAL_API_SECRET", "Internal API secret", "Secret used to protect internal job dispatch and worker-facing endpoints."),
-    checkRecommended("RESEND_API_KEY", "Resend API key", "Email delivery key used by verification, invites, and outbound notifications."),
-    checkRecommended("RESEND_FROM_EMAIL", "Email sender", "Verified sender identity for outbound email workflows."),
-    checkRecommended("OPENAI_API_KEY", "OpenAI API key", "Enables AI insight generation. Without it, AI pages should remain in fallback/demo mode."),
-    checkRecommended("DOCUMENT_STORAGE_MODE", "Document storage mode", "Selects the document storage provider. Local storage is fine for local development."),
-    checkRecommended("PRIVATE_UPLOAD_DIR", "Private upload directory", "Local private document upload path used by the default storage provider."),
-    checkOptional("HEALTHCHECK_URL", "Healthcheck URL", "Optional URL used by local scripts to check a running deployment."),
+    checkRequired(
+      "DATABASE_URL",
+      "Database URL",
+      "PostgreSQL connection used by Prisma, records, auth, and reporting.",
+      "core",
+      true,
+    ),
+    checkRequired(
+      "AUTH_SECRET",
+      "Auth secret",
+      "Long random secret used by Auth.js session encryption and signing.",
+      "auth",
+      true,
+    ),
+    checkRequired(
+      "NEXTAUTH_URL",
+      "Public auth URL",
+      "Canonical app URL used by Auth.js callbacks and redirects.",
+      "auth",
+    ),
+    checkRequired(
+      "APP_URL",
+      "Application URL",
+      "Base URL used by emails, links, and product-facing workflows.",
+      "core",
+    ),
+    checkRecommended(
+      "REDIS_URL",
+      "Redis URL",
+      "Redis connection used by BullMQ workers, reminders, alerts, and queue-backed features.",
+      "jobs",
+    ),
+    checkRecommended(
+      "INTERNAL_API_SECRET",
+      "Internal API secret",
+      "Secret used to protect internal job dispatch and worker-facing endpoints.",
+      "jobs",
+    ),
+    checkRecommended(
+      "RESEND_API_KEY",
+      "Resend API key",
+      "Email delivery key used by verification, invites, and outbound notifications.",
+      "email",
+    ),
+    checkRecommended(
+      "RESEND_FROM_EMAIL",
+      "Email sender",
+      "Verified sender identity for outbound email workflows.",
+      "email",
+    ),
+    checkRecommended(
+      "OPENAI_API_KEY",
+      "OpenAI API key",
+      "Enables AI insight generation. Without it, AI pages should remain in fallback/demo mode.",
+      "ai",
+    ),
+    checkRecommended(
+      "DOCUMENT_STORAGE_MODE",
+      "Document storage mode",
+      "Selects the document storage provider. Local storage is fine for local development.",
+      "storage",
+    ),
+    checkRecommended(
+      "PRIVATE_UPLOAD_DIR",
+      "Private upload directory",
+      "Local private document upload path used by the default storage provider.",
+      "storage",
+    ),
+    checkOptional(
+      "HEALTHCHECK_URL",
+      "Healthcheck URL",
+      "Optional URL used by local scripts to check a running deployment.",
+      "monitoring",
+    ),
   ];
 }
 
-export function getDeploymentReadinessSummary() {
+function getReadinessGuidance(
+  summary: Omit<DeploymentReadinessSummary, "guidance">,
+) {
+  if (summary.blockingIssues.length > 0) {
+    return [
+      "Configure required production environment variables before promoting this deployment.",
+      "Run `npm run db:validate:ci` and `npx prisma migrate deploy` against the intended database before launch.",
+      "Keep the public demo routes available for reviewers while production-only integrations are being configured.",
+    ];
+  }
+
+  if (summary.warningIssues.length > 0) {
+    return [
+      "Core app configuration is ready, but recommended integrations should be completed before a full production launch.",
+      "Features tied to missing recommended services should show fallback or degraded-mode messaging.",
+      "Run the full local check suite before opening a deployment PR.",
+    ];
+  }
+
+  return [
+    "Required and recommended deployment configuration is complete.",
+    "Run smoke tests against `/api/health`, `/demo`, `/login`, and the authenticated dashboard after deployment.",
+    "Rotate secrets and verify production database backups before handling real patient data.",
+  ];
+}
+
+function resolveDeploymentMode(
+  requiredConfigured: number,
+  requiredTotal: number,
+  recommendedConfigured: number,
+  recommendedTotal: number,
+  demoBlockingIssues: DeploymentCheck[],
+): DeploymentMode {
+  if (
+    requiredConfigured === requiredTotal &&
+    recommendedConfigured === recommendedTotal
+  )
+    return "production-ready";
+  if (requiredConfigured === requiredTotal) return "review-ready";
+  if (demoBlockingIssues.length === 0) return "local-development";
+  return "blocked";
+}
+
+export function getDeploymentReadinessSummary(): DeploymentReadinessSummary {
   const checks = getDeploymentChecks();
   const required = checks.filter((check) => check.category === "required");
-  const recommended = checks.filter((check) => check.category === "recommended");
-  const requiredConfigured = required.filter((check) => check.configured).length;
-  const recommendedConfigured = recommended.filter((check) => check.configured).length;
-  const score = Math.round(((requiredConfigured * 2 + recommendedConfigured) / Math.max(1, required.length * 2 + recommended.length)) * 100);
+  const recommended = checks.filter(
+    (check) => check.category === "recommended",
+  );
+  const optional = checks.filter((check) => check.category === "optional");
+  const requiredConfigured = required.filter(
+    (check) => check.configured,
+  ).length;
+  const recommendedConfigured = recommended.filter(
+    (check) => check.configured,
+  ).length;
+  const optionalConfigured = optional.filter(
+    (check) => check.configured,
+  ).length;
+  const blockingIssues = required.filter((check) => !check.configured);
+  const warningIssues = recommended.filter((check) => !check.configured);
+  const demoBlockingIssues = checks.filter(
+    (check) => check.requiredForDemo && !check.configured,
+  );
+  const score = Math.round(
+    ((requiredConfigured * 2 + recommendedConfigured) /
+      Math.max(1, required.length * 2 + recommended.length)) *
+      100,
+  );
 
-  return {
+  const summaryWithoutGuidance = {
+    mode: resolveDeploymentMode(
+      requiredConfigured,
+      required.length,
+      recommendedConfigured,
+      recommended.length,
+      demoBlockingIssues,
+    ),
     score,
     requiredTotal: required.length,
     requiredConfigured,
     recommendedTotal: recommended.length,
     recommendedConfigured,
-    blockingIssues: required.filter((check) => !check.configured),
-    warningIssues: recommended.filter((check) => !check.configured),
+    optionalTotal: optional.length,
+    optionalConfigured,
+    blockingIssues,
+    warningIssues,
+    demoBlockingIssues,
     checks,
   };
+
+  return {
+    ...summaryWithoutGuidance,
+    guidance: getReadinessGuidance(summaryWithoutGuidance),
+  };
+}
+
+function getBooleanEnv(key: string) {
+  const value = normalizeEnvValue(process.env[key]).toLowerCase();
+  return value === "1" || value === "true" || value === "yes" || value === "on";
+}
+
+export function getDemoReadinessSummary(): DemoReadinessSummary {
+  const deployment = getDeploymentReadinessSummary();
+  const demoModeEnabled =
+    getBooleanEnv("VITAVAULT_DEMO_MODE") ||
+    getBooleanEnv("NEXT_PUBLIC_DEMO_MODE") ||
+    process.env.NODE_ENV !== "production";
+
+  const checks: DemoReadinessCheck[] = [
+    {
+      key: "demo-mode",
+      label: "Demo mode fallback",
+      ready: demoModeEnabled,
+      tone: demoModeEnabled ? "success" : "warning",
+      detail: demoModeEnabled
+        ? "Demo-mode fallback is available for reviewer-friendly public routes."
+        : "Demo routes can still render static content, but explicit demo-mode fallback is not enabled.",
+    },
+    {
+      key: "database-minimum",
+      label: "Database minimum",
+      ready: deployment.demoBlockingIssues.every(
+        (issue) => issue.key !== "DATABASE_URL",
+      ),
+      tone: deployment.demoBlockingIssues.some(
+        (issue) => issue.key === "DATABASE_URL",
+      )
+        ? "danger"
+        : "success",
+      detail:
+        "A valid DATABASE_URL is needed for authenticated workflows, Prisma validation, and health checks.",
+    },
+    {
+      key: "auth-minimum",
+      label: "Auth minimum",
+      ready: deployment.demoBlockingIssues.every(
+        (issue) => issue.key !== "AUTH_SECRET",
+      ),
+      tone: deployment.demoBlockingIssues.some(
+        (issue) => issue.key === "AUTH_SECRET",
+      )
+        ? "danger"
+        : "success",
+      detail:
+        "A valid AUTH_SECRET prevents broken login/session behavior during reviewer testing.",
+    },
+    {
+      key: "static-demo-routes",
+      label: "Static demo routes",
+      ready: true,
+      tone: "success",
+      detail:
+        "The `/demo` route family is designed as read-only showcase content and should remain accessible without seeded patient accounts.",
+    },
+  ];
+
+  const blocking = checks.filter(
+    (check) => !check.ready && check.tone === "danger",
+  );
+  const readyCount = checks.filter((check) => check.ready).length;
+
+  return {
+    ready: blocking.length === 0,
+    score: Math.round((readyCount / checks.length) * 100),
+    checks,
+    blocking,
+    guidance:
+      blocking.length > 0
+        ? [
+            "Configure the minimum database and auth variables before asking reviewers to test authenticated workflows.",
+            "Use public `/demo` routes for portfolio review while production services are incomplete.",
+          ]
+        : [
+            "Reviewer demo readiness is acceptable.",
+            "Verify `/demo`, `/api/health`, and login redirects after each deployment.",
+          ],
+  };
+}
+
+export function getSanitizedDeploymentEnvironment() {
+  return getDeploymentChecks().map((check) => ({
+    key: check.key,
+    label: check.label,
+    category: check.category,
+    configured: check.configured,
+    safeValue: check.safeValue,
+    featureArea: check.featureArea,
+  }));
 }

--- a/tests/deployment-readiness.test.ts
+++ b/tests/deployment-readiness.test.ts
@@ -1,5 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { getDeploymentChecks, getDeploymentReadinessSummary } from "@/lib/deployment-readiness";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getDemoReadinessSummary,
+  getDeploymentChecks,
+  getDeploymentReadinessSummary,
+  getSanitizedDeploymentEnvironment,
+} from "@/lib/deployment-readiness";
 
 const trackedKeys = [
   "DATABASE_URL",
@@ -14,6 +19,9 @@ const trackedKeys = [
   "DOCUMENT_STORAGE_MODE",
   "PRIVATE_UPLOAD_DIR",
   "HEALTHCHECK_URL",
+  "VITAVAULT_DEMO_MODE",
+  "NEXT_PUBLIC_DEMO_MODE",
+  "NODE_ENV",
 ];
 
 const originalEnv = { ...process.env };
@@ -22,6 +30,23 @@ function clearTrackedEnv() {
   for (const key of trackedKeys) {
     delete process.env[key];
   }
+}
+
+function configureRequiredEnv() {
+  process.env.DATABASE_URL = "postgresql://demo:demo@localhost:5432/vitavault";
+  process.env.AUTH_SECRET = "super-long-random-secret-for-tests";
+  process.env.NEXTAUTH_URL = "http://localhost:3000";
+  process.env.APP_URL = "http://localhost:3000";
+}
+
+function configureRecommendedEnv() {
+  process.env.REDIS_URL = "redis://127.0.0.1:6379";
+  process.env.INTERNAL_API_SECRET = "internal-secret";
+  process.env.RESEND_API_KEY = "re_test_key";
+  process.env.RESEND_FROM_EMAIL = "VitaVault <noreply@example.test>";
+  process.env.OPENAI_API_KEY = "sk-test";
+  process.env.DOCUMENT_STORAGE_MODE = "private";
+  process.env.PRIVATE_UPLOAD_DIR = "./private-uploads";
 }
 
 describe("deployment readiness", () => {
@@ -36,16 +61,26 @@ describe("deployment readiness", () => {
   it("marks required environment variables as blocking when missing", () => {
     const summary = getDeploymentReadinessSummary();
 
+    expect(summary.mode).toBe("blocked");
     expect(summary.requiredTotal).toBeGreaterThanOrEqual(4);
     expect(summary.requiredConfigured).toBe(0);
     expect(summary.blockingIssues.map((item) => item.key)).toEqual(
-      expect.arrayContaining(["DATABASE_URL", "AUTH_SECRET", "NEXTAUTH_URL", "APP_URL"]),
+      expect.arrayContaining([
+        "DATABASE_URL",
+        "AUTH_SECRET",
+        "NEXTAUTH_URL",
+        "APP_URL",
+      ]),
     );
     expect(summary.score).toBe(0);
+    expect(summary.guidance[0]).toContain(
+      "Configure required production environment variables",
+    );
   });
 
   it("does not treat placeholder values as production-ready", () => {
-    process.env.DATABASE_URL = "postgresql://user:password@localhost:5432/db_name";
+    process.env.DATABASE_URL =
+      "postgresql://user:password@localhost:5432/db_name";
     process.env.AUTH_SECRET = "change-this-secret";
     process.env.NEXTAUTH_URL = "https://example.com";
     process.env.APP_URL = "https://example.com";
@@ -57,24 +92,78 @@ describe("deployment readiness", () => {
     expect(required.every((item) => item.tone === "danger")).toBe(true);
   });
 
-  it("calculates readiness when required and recommended services are configured", () => {
-    process.env.DATABASE_URL = "postgresql://demo:demo@localhost:5432/vitavault";
-    process.env.AUTH_SECRET = "super-long-random-secret-for-tests";
-    process.env.NEXTAUTH_URL = "http://localhost:3000";
-    process.env.APP_URL = "http://localhost:3000";
-    process.env.REDIS_URL = "redis://127.0.0.1:6379";
-    process.env.INTERNAL_API_SECRET = "internal-secret";
-    process.env.RESEND_API_KEY = "re_test_key";
-    process.env.RESEND_FROM_EMAIL = "VitaVault <noreply@example.test>";
-    process.env.OPENAI_API_KEY = "sk-test";
-    process.env.DOCUMENT_STORAGE_MODE = "private";
-    process.env.PRIVATE_UPLOAD_DIR = "./private-uploads";
+  it("calculates review-ready mode when required config exists but recommended services are missing", () => {
+    configureRequiredEnv();
 
     const summary = getDeploymentReadinessSummary();
 
+    expect(summary.mode).toBe("review-ready");
+    expect(summary.blockingIssues).toHaveLength(0);
+    expect(summary.warningIssues.length).toBeGreaterThan(0);
+    expect(summary.requiredConfigured).toBe(summary.requiredTotal);
+    expect(summary.recommendedConfigured).toBeLessThan(
+      summary.recommendedTotal,
+    );
+  });
+
+  it("calculates production readiness when required and recommended services are configured", () => {
+    configureRequiredEnv();
+    configureRecommendedEnv();
+
+    const summary = getDeploymentReadinessSummary();
+
+    expect(summary.mode).toBe("production-ready");
     expect(summary.blockingIssues).toHaveLength(0);
     expect(summary.requiredConfigured).toBe(summary.requiredTotal);
     expect(summary.recommendedConfigured).toBe(summary.recommendedTotal);
     expect(summary.score).toBe(100);
+  });
+
+  it("builds demo readiness guidance for reviewer-friendly validation", () => {
+    configureRequiredEnv();
+    process.env.VITAVAULT_DEMO_MODE = "true";
+    vi.stubEnv("NODE_ENV", "production");
+
+    const summary = getDemoReadinessSummary();
+
+    expect(summary.ready).toBe(true);
+    expect(summary.blocking).toHaveLength(0);
+    expect(summary.checks.map((check) => check.key)).toEqual(
+      expect.arrayContaining([
+        "demo-mode",
+        "database-minimum",
+        "auth-minimum",
+        "static-demo-routes",
+      ]),
+    );
+    expect(summary.guidance).toEqual(
+      expect.arrayContaining(["Reviewer demo readiness is acceptable."]),
+    );
+  });
+
+  it("sanitizes sensitive values before exposing environment readiness", () => {
+    configureRequiredEnv();
+    process.env.INTERNAL_API_SECRET = "secret-value-that-should-not-render";
+    process.env.OPENAI_API_KEY = "sk-real-looking-test-value";
+
+    const safeEnvironment = getSanitizedDeploymentEnvironment();
+    const configuredSecretValues = safeEnvironment.filter(
+      (item) =>
+        item.configured &&
+        (item.key.includes("SECRET") || item.key.includes("KEY")),
+    );
+
+    expect(configuredSecretValues.length).toBeGreaterThan(0);
+    expect(
+      configuredSecretValues.every(
+        (item) => item.safeValue === "Configured secret",
+      ),
+    ).toBe(true);
+    expect(JSON.stringify(safeEnvironment)).not.toContain(
+      "secret-value-that-should-not-render",
+    );
+    expect(JSON.stringify(safeEnvironment)).not.toContain(
+      "sk-real-looking-test-value",
+    );
   });
 });


### PR DESCRIPTION
## Summary

This patch improves VitaVault's deployment and demo readiness validation so reviewers and maintainers can quickly understand whether an environment is production-ready, review-ready, local-development ready, or blocked.

## Changes

- Added deployment readiness modes
- Added feature-area metadata to deployment checks
- Added sanitized environment readiness output
- Added demo-readiness checks for reviewer-friendly validation
- Added deployment guidance messages for blocked, degraded, and ready states
- Updated `/api/health` with readiness mode, guidance, and demo readiness data
- Expanded deployment readiness tests
- Added Patch 76 documentation under `docs/`

## Safety

- No Prisma migration
- No schema changes
- No dependency changes
- No README changes
- No auth/session behavior changes
- No deployment secrets are exposed
- Demo readiness is informational only and does not bypass production checks

## Checks

Run locally:

```powershell
npm install
npm run db:validate:ci
npm run actions:check
npm run actions:imports
npm run actions:shadow
npm run typecheck
npm run lint
npm run test:run