### PR TITLE
Add docs navigation and architecture map

### DIFF
--- a/docs/API_OVERVIEW.md
+++ b/docs/API_OVERVIEW.md
@@ -1,0 +1,137 @@
+# VitaVault API Overview
+
+This document summarizes VitaVault's API and route-handler surface at a reviewer level. For detailed mobile/device payloads, supported enum values, and generated exports, see [`MOBILE_DEVICE_API.md`](./MOBILE_DEVICE_API.md).
+
+## API route groups
+
+| Group | Routes | Purpose |
+|---|---|---|
+| Auth | `/api/auth/[...nextauth]` | Auth.js/NextAuth route handler. |
+| Health/readiness | `/api/health` | Deployment and demo readiness metadata. |
+| Documents | `/api/documents/[id]/download` | Protected document download behavior. |
+| Exports | `/exports/[type]` | Export packet download route for supported export types. |
+| Jobs | `/api/jobs/dispatch` | Admin-protected background job dispatch. |
+| Internal alert scans | `/api/internal/alerts/scan`, `/api/internal/alerts/evaluate` | Internal alert evaluation endpoints protected by internal API checks. |
+| Mobile auth | `/api/mobile/auth/login`, `/api/mobile/auth/me`, `/api/mobile/auth/logout` | Mobile session login, current user, and logout flow. |
+| Mobile devices | `/api/mobile/connections`, `/api/mobile/device-readings` | Device connection and reading ingestion APIs. |
+| Contract exports | `/api/mobile/openapi`, `/api/mobile/postman` | Machine-readable mobile API contract exports. |
+
+## Auth API
+
+### `/api/auth/[...nextauth]`
+
+Auth.js/NextAuth integration point for the web app. Authenticated server actions and protected pages rely on session helpers rather than calling this route directly.
+
+## Health and readiness API
+
+### `/api/health`
+
+Returns application health/readiness information suitable for deployment review.
+
+Current responsibilities include:
+
+- environment readiness mode
+- sanitized environment status
+- demo readiness guidance
+- deployment guidance
+- health-check metadata that avoids exposing secrets
+
+This route is designed to help identify missing configuration without leaking private values.
+
+## Document API
+
+### `/api/documents/[id]/download`
+
+Protected route for downloading a stored medical document. It should preserve authorization checks and avoid exposing private files without a valid session/access context.
+
+Related modules:
+
+- `lib/document-storage.ts`
+- `lib/storage/*`
+- `lib/document-hub.ts`
+
+## Export API
+
+### `/exports/[type]`
+
+Route handler for supported export types. Unknown export types should return structured JSON with supported types and safe response headers.
+
+Related modules:
+
+- `lib/export-center.ts`
+- `lib/export-definitions.ts`
+- `lib/export.ts`
+
+## Job and internal APIs
+
+### `/api/jobs/dispatch`
+
+Admin-protected endpoint for dispatching supported job operations.
+
+### `/api/internal/alerts/scan`
+
+Internal endpoint for scanning alert rules.
+
+### `/api/internal/alerts/evaluate`
+
+Internal endpoint for evaluating alert behavior.
+
+Internal APIs should not be treated as public client APIs. They should be protected by route policy and/or internal API authorization helpers.
+
+## Mobile API
+
+The mobile API provides a foundation for future native or React Native clients.
+
+| Route | Method intent | Purpose |
+|---|---|---|
+| `/api/mobile/auth/login` | Login | Create a mobile session token. |
+| `/api/mobile/auth/me` | Session check | Return the current mobile user/session context. |
+| `/api/mobile/auth/logout` | Logout | Revoke or end the mobile session. |
+| `/api/mobile/connections` | Connection management | Register or list device connections. |
+| `/api/mobile/device-readings` | Ingestion | Submit mobile/device readings. |
+| `/api/mobile/openapi` | Contract export | Return an OpenAPI-style contract. |
+| `/api/mobile/postman` | Contract export | Return a Postman collection. |
+
+Related modules:
+
+- `lib/mobile-auth.ts`
+- `lib/mobile-device-api.ts`
+- `lib/mobile-readings.ts`
+- `lib/mobile-api-security.ts`
+- `lib/mobile-api-contract-export.ts`
+- `lib/mobile-api-sdk-examples.ts`
+
+## Mobile contract values
+
+The current mobile/device contract is schema-backed and tested. Important value groups include:
+
+- `DevicePlatform`
+- `DeviceConnectionStatus`
+- `DeviceReadingType`
+- `ReadingSource`
+
+Do not add new values to SDK examples or docs unless the Prisma schema, API validators, OpenAPI/Postman exports, and tests are updated together.
+
+## API safety expectations
+
+When adding or changing API behavior:
+
+1. Keep response bodies web-compatible for Next.js route handlers.
+2. Avoid exposing raw secrets or private storage paths.
+3. Return structured errors for unknown or unsupported export/API types.
+4. Keep mobile API rate limits, payload size checks, and no-store headers intact.
+5. Add/update tests when contract values or route policies change.
+6. Avoid Prisma migrations unless the feature cannot be implemented with existing models.
+
+## API-related tests
+
+Relevant tests include:
+
+- `tests/mobile-device-api.test.ts`
+- `tests/mobile-api-security.test.ts`
+- `tests/mobile-api-contract-export.test.ts`
+- `tests/mobile-api-sdk-examples.test.ts`
+- `tests/internal-api-auth.test.ts`
+- `tests/document-download-route.test.ts`
+- `tests/exports-route.test.ts`
+- `tests/route-policy.test.ts`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,187 @@
+# VitaVault Architecture
+
+VitaVault is a full-stack personal health record platform built with the Next.js App Router, React, TypeScript, Prisma, PostgreSQL, Auth.js/NextAuth, Tailwind CSS, server actions, API routes, and Vitest tests.
+
+## System overview
+
+```text
+Browser / reviewer demo
+        |
+        v
+Next.js App Router
+        |
+        +-- Server components and protected pages
+        +-- Server actions for authenticated workflows
+        +-- API routes for health checks, mobile clients, exports, jobs, and internal scans
+        |
+        v
+Domain helpers in lib/
+        |
+        +-- clinical workflow helpers
+        +-- report/export builders
+        +-- notification/alert/reminder orchestration
+        +-- mobile/device contracts
+        +-- security/audit/admin helpers
+        |
+        v
+Prisma ORM
+        |
+        v
+PostgreSQL
+
+Optional side services:
+- Redis/BullMQ-style background job foundation
+- OpenAI-powered AI insights when configured
+- Email provider for account/invite workflows when configured
+- Local, S3, or R2-style document storage providers
+```
+
+## Runtime layers
+
+| Layer | Main folders | Responsibility |
+|---|---|---|
+| App routes | `app/` | Pages, layouts, route handlers, public demo surfaces, protected workflow screens. |
+| UI components | `components/` | Reusable cards, forms, shell, alerts, and shared interface elements. |
+| Domain logic | `lib/` | Business logic, data shaping, policy checks, review signals, export/report builders. |
+| Data model | `prisma/` | Prisma schema, migrations, and seed/demo seed foundations. |
+| Worker foundation | `worker/`, `lib/jobs/` | Background job contracts, queues, job run tracking, and job admin helpers. |
+| Tests | `tests/` | Vitest regression coverage for helpers, API behavior, route policies, and workflows. |
+| Docs | `docs/` | Product, API, deployment, migration, and patch documentation. |
+
+## App Router structure
+
+The app contains both authenticated product routes and public reviewer demo routes.
+
+### Authenticated product areas
+
+- `/dashboard`
+- `/health-profile`
+- `/medications`
+- `/appointments`
+- `/labs`
+- `/vitals`
+- `/symptoms`
+- `/documents`
+- `/care-team`
+- `/care-notes`
+- `/visit-prep`
+- `/care-plan`
+- `/notifications`
+- `/alerts`
+- `/summary`
+- `/report-builder`
+- `/exports`
+- `/ai-insights`
+- `/device-connection`
+- `/security`
+- `/audit-log`
+- `/admin`
+- `/ops`
+- `/jobs`
+
+### Public reviewer demo areas
+
+Public demo pages live under `/demo/*`. They let reviewers inspect major product surfaces without needing seeded credentials or a production database.
+
+## Domain helper pattern
+
+Most business logic is intentionally placed in `lib/` instead of directly inside pages. This keeps pages focused on composition and makes workflow logic easier to test.
+
+Examples:
+
+| Module | Helper responsibility |
+|---|---|
+| `lib/notification-center.ts` | Combines alerts, reminders, visits, devices, and review signals into notification items. |
+| `lib/export-center.ts` | Builds export packet readiness and supported export definitions. |
+| `lib/report-builder.ts` | Builds provider-ready report sections and print context. |
+| `lib/visit-prep.ts` | Computes visit readiness, appointment proximity, and prep timeline grouping. |
+| `lib/medication-safety.ts` | Classifies medication adherence and safety review states. |
+| `lib/lab-review.ts` | Interprets lab trends and follow-up signals. |
+| `lib/vitals-monitor.ts` | Classifies freshness, missing readings, and vital risk states. |
+| `lib/symptom-review.ts` | Groups symptoms into recurring, worsening, stale, resolved, and stable patterns. |
+| `lib/document-hub.ts` | Builds document intelligence review cards and readiness summaries. |
+| `lib/ai-insights-workspace.ts` | Builds AI insight review, source, and trust checklist signals. |
+
+## Data access pattern
+
+- Prisma is centralized through `lib/db.ts`.
+- Server actions and server routes call Prisma-backed helpers when data persistence is needed.
+- Pure helper functions are kept testable with partial mocks where practical.
+- Migration history is documented in `docs/PRISMA_MIGRATION_CHAIN.md`.
+
+## Auth and access control
+
+VitaVault uses Auth.js/NextAuth for authentication. Access control is split across:
+
+- session helpers in `lib/session.ts`
+- route policy helpers in `lib/route-policy.ts`
+- care-team access helpers in `lib/access.ts` and `lib/care-permissions.ts`
+- admin-only route and API policies for sensitive surfaces
+
+Admin and ops surfaces are hidden from non-admin navigation and should also be protected server-side.
+
+## Mobile and device architecture
+
+Mobile/device support is split across:
+
+| Area | Files/routes |
+|---|---|
+| Mobile auth | `/api/mobile/auth/login`, `/api/mobile/auth/me`, `/api/mobile/auth/logout` |
+| Device readings | `/api/mobile/device-readings` |
+| Device connections | `/api/mobile/connections`, `/device-connection`, `/device-connection/[id]` |
+| Contract exports | `/api/mobile/openapi`, `/api/mobile/postman` |
+| SDK examples | `examples/mobile-api/` |
+| Security helpers | `lib/mobile-api-security.ts` |
+| Provider abstractions | `lib/device-provider-connectors.ts` |
+
+The mobile API is contract-tested so SDK examples, OpenAPI/Postman exports, and schema-backed enum values stay aligned.
+
+## Background jobs architecture
+
+The jobs foundation includes:
+
+- queue constants and contracts
+- handler definitions
+- Redis connection helpers
+- job run tracking helpers
+- admin/job dashboard surfaces
+- device sync job visibility
+
+The application is designed so job foundations can run locally with Redis or degrade safely during build/reviewer flows when configured.
+
+## Reporting and export architecture
+
+Report and export workflows include:
+
+- patient summary packets
+- report builder presets
+- saved report history
+- print routes
+- export center readiness checks
+- CSV-style export routes
+- emergency card and handoff views
+
+These surfaces are designed for doctor visit prep, emergency handoff, and portable personal record sharing.
+
+## Testing strategy
+
+The project uses Vitest for broad helper and route regression coverage. Current test coverage focuses on:
+
+- server action export/import checks
+- route policy checks
+- mobile API contracts
+- workflow helper logic
+- report/export behavior
+- security/audit behavior
+- deployment readiness checks
+- public demo route coverage
+
+Future higher-value testing would include browser-based smoke tests for the public demo flow.
+
+## Design constraints
+
+- Avoid unnecessary Prisma migrations.
+- Keep README public-facing and avoid patch-history language there.
+- Keep patch docs under `docs/`.
+- Keep helper logic testable without requiring fully hydrated Prisma mocks.
+- Keep public demo pages usable without a fully configured production environment.

--- a/docs/FEATURE_MAP.md
+++ b/docs/FEATURE_MAP.md
@@ -1,0 +1,117 @@
+# VitaVault Feature Map
+
+This document maps VitaVault by product workflow instead of by implementation patch. Use it to understand what the platform currently does and where each capability fits in the health-record experience.
+
+## Product mission
+
+VitaVault is a personal health record platform focused on structured health data, provider handoff, care-team collaboration, mobile/device ingestion foundations, and production-minded operations surfaces.
+
+## Core health record modules
+
+| Module | Routes | Value |
+|---|---|---|
+| Dashboard | `/dashboard`, `/demo/dashboard` | Central health command center. |
+| Health profile | `/health-profile`, `/demo/health-profile` | Baseline patient context and identity-level health details. |
+| Medications | `/medications`, `/demo/medications` | Medication list, schedules, reminders, adherence context. |
+| Appointments | `/appointments`, `/demo/appointments` | Visit history and upcoming appointments. |
+| Doctors | `/doctors`, `/demo/doctors` | Provider directory and visit context. |
+| Labs | `/labs`, `/demo/labs` | Lab result record management. |
+| Vitals | `/vitals`, `/demo/vitals` | Vital-sign record management. |
+| Symptoms | `/symptoms`, `/demo/symptoms` | Symptom tracking and review context. |
+| Vaccinations | `/vaccinations`, `/demo/vaccinations` | Immunization record tracking. |
+| Documents | `/documents`, `/demo/documents` | Medical file metadata, notes, download links, and review states. |
+
+## Workflow and care coordination modules
+
+| Module | Routes | Value |
+|---|---|---|
+| Notifications | `/notifications`, `/demo/notifications` | Unified inbox for alerts, reminders, visits, devices, and review items. |
+| Reminders | `/reminders`, `/demo/reminders` | Follow-up and medication reminder workflows. |
+| Alerts | `/alerts`, `/alerts/[id]`, `/alerts/rules`, `/demo/alerts` | Health alert review and triage workflow. |
+| Care plan | `/care-plan`, `/demo/care-plan` | Action planning across records and next steps. |
+| Visit prep | `/visit-prep`, `/demo/visit-prep` | Provider-ready appointment preparation and timeline context. |
+| Review queue | `/review-queue`, `/demo/review-queue` | Aggregated review items across health workflows. |
+| Timeline | `/timeline`, `/demo/timeline` | Longitudinal health activity and care-note context. |
+
+## Clinical review modules
+
+| Module | Routes | Value |
+|---|---|---|
+| Health trends | `/trends`, `/demo/trends` | Cross-record trend interpretation and summary metrics. |
+| Medication safety | `/medication-safety`, `/demo/medication-safety` | Adherence, missed-dose, schedule, and medication review signals. |
+| Lab review | `/lab-review`, `/demo/lab-review` | Lab trend interpretation and follow-up guidance. |
+| Vitals monitor | `/vitals-monitor`, `/demo/vitals-monitor` | Vital freshness, missing-reading, and risk state detection. |
+| Symptom review | `/symptom-review`, `/demo/symptom-review` | Recurring, worsening, stale, resolved, and stable symptom pattern review. |
+| Data quality | `/data-quality`, `/demo/data-quality` | Data completeness, cleanup signals, and readiness scoring. |
+
+## Collaboration modules
+
+| Module | Routes | Value |
+|---|---|---|
+| Care team | `/care-team`, `/demo/care-team` | Invite-based sharing and permission management. |
+| Care notes | `/care-notes`, `/demo/care-notes` | Collaboration notes tied into timeline, reports, and exports. |
+| Shared patient workspace | `/patient/[ownerUserId]` | Caregiver/provider workspace for granted access. |
+
+## Reports, exports, and handoff modules
+
+| Module | Routes | Value |
+|---|---|---|
+| Patient summary | `/summary`, `/summary/print`, `/demo/summary` | Provider-ready patient context packet. |
+| Report builder | `/report-builder`, `/report-builder/print`, `/demo/report-builder` | Preset-driven report packets and saved report history. |
+| Export center | `/exports`, `/exports/[type]`, `/demo/exports` | Portable export packets and CSV-style downloads. |
+| Emergency card | `/emergency-card`, `/emergency-card/print`, `/demo/emergency-card` | Emergency profile and critical health context. |
+
+## AI and intelligence modules
+
+| Module | Routes | Value |
+|---|---|---|
+| AI insights | `/ai-insights`, `/demo/ai-insights` | Source-aware AI insight review, trust checklist, and fallback states. |
+| Document intelligence | `/documents`, `/demo/documents` | Document classification, review readiness, linked-record guidance. |
+| Data quality center | `/data-quality`, `/demo/data-quality` | Completeness and cleanup recommendations across records. |
+
+## Mobile and device modules
+
+| Module | Routes/APIs | Value |
+|---|---|---|
+| Device connection hub | `/device-connection`, `/device-connection/[id]`, `/demo/device-connection` | Device connection status, sync health, provider readiness. |
+| Device sync simulator | `/device-sync-simulator`, `/demo/device-sync-simulator` | QA/demo path for device ingestion. |
+| Mobile API docs | `/api-docs`, `/demo/api-docs` | Mobile API guide, OpenAPI/Postman links, and SDK examples. |
+| Mobile APIs | `/api/mobile/*` | Login, session, connections, device readings, OpenAPI, Postman. |
+
+## Admin, operations, and platform modules
+
+| Module | Routes/APIs | Value |
+|---|---|---|
+| Admin command center | `/admin`, `/demo/admin` | Admin account and operational visibility. |
+| Ops command center | `/ops`, `/demo/ops` | Operational status and platform health context. |
+| Jobs dashboard | `/jobs`, `/demo/jobs` | Background job visibility and job run management. |
+| Security center | `/security`, `/demo/security` | Account/session/mobile security review. |
+| Audit log | `/audit-log`, `/demo/audit-log` | Activity review and high-risk event detection. |
+| Deployment readiness | `/api/health` | Health and readiness information for deployed environments. |
+
+## Public demo experience
+
+The `/demo` route family exists so reviewers can inspect product depth without account setup. It should stay consistent with the authenticated app experience and should not depend on private secrets.
+
+Recommended public demo path:
+
+1. `/demo/walkthrough`
+2. `/demo/dashboard`
+3. `/demo/notifications`
+4. `/demo/care-plan`
+5. `/demo/visit-prep`
+6. `/demo/trends`
+7. `/demo/data-quality`
+8. `/demo/exports`
+9. `/demo/device-connection`
+10. `/demo/security`
+
+## Current strongest portfolio signals
+
+- Broad health-record coverage across core health data types.
+- Workflow layers that turn records into actions, review queues, and provider handoff packets.
+- Care-team sharing and collaboration foundations.
+- Mobile/device API and connector architecture beyond a basic CRUD app.
+- Admin, jobs, ops, audit, deployment, and security surfaces.
+- Public no-login demo experience.
+- Strong helper-level tests across regression-prone product logic.

--- a/docs/PATCH_79_DOCS_NAVIGATION_ARCHITECTURE_MAP.md
+++ b/docs/PATCH_79_DOCS_NAVIGATION_ARCHITECTURE_MAP.md
@@ -1,0 +1,41 @@
+# Patch 79: Docs Navigation and Architecture Map
+
+## Summary
+
+This patch adds a clean documentation entrypoint and high-level reviewer maps for VitaVault. The project already has many detailed patch notes, so this patch makes the docs folder easier to navigate without changing runtime code.
+
+## Files added
+
+- `docs/README.md`
+- `docs/ARCHITECTURE.md`
+- `docs/FEATURE_MAP.md`
+- `docs/API_OVERVIEW.md`
+
+## What changed
+
+- Added a documentation hub that points reviewers to the best starting documents.
+- Added a high-level architecture guide covering app layers, domain helpers, data access, mobile/device APIs, jobs, reports, and testing strategy.
+- Added a workflow-based feature map organized by product areas instead of patch history.
+- Added an API overview for route groups, mobile API surfaces, internal APIs, exports, and safety expectations.
+
+## Safety
+
+- No Prisma migration.
+- No schema changes.
+- No package changes.
+- No `package-lock.json` changes.
+- No runtime code changes.
+- No README changes.
+
+## Validation
+
+Recommended checks after applying:
+
+```powershell
+npm run db:validate:ci
+npm run typecheck
+npm run lint
+npm run test:run
+```
+
+Because this is docs-only, the main validation goal is making sure the project still passes the usual checks and the new docs link to intended existing project surfaces.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,67 @@
+# VitaVault Documentation Hub
+
+This folder contains the working documentation for VitaVault, a full-stack personal health record and health-tech portfolio platform. The goal of this hub is to make the project easier to review without forcing readers to scan every historical patch note.
+
+## Start here
+
+| Document | Purpose |
+|---|---|
+| [`ARCHITECTURE.md`](./ARCHITECTURE.md) | High-level architecture, runtime layers, data flow, and operational boundaries. |
+| [`FEATURE_MAP.md`](./FEATURE_MAP.md) | Product module map grouped by user workflow and reviewer value. |
+| [`API_OVERVIEW.md`](./API_OVERVIEW.md) | API route overview, mobile API surface, internal APIs, and export contracts. |
+| [`FEATURE_MATRIX.md`](./FEATURE_MATRIX.md) | Existing route-by-route matrix for authenticated and public demo surfaces. |
+| [`MOBILE_DEVICE_API.md`](./MOBILE_DEVICE_API.md) | Detailed mobile/device API guide, supported values, and contract exports. |
+| [`DEPLOYMENT_CHECKLIST.md`](./DEPLOYMENT_CHECKLIST.md) | Deployment validation checklist. |
+| [`KNOWN_LIMITATIONS.md`](./KNOWN_LIMITATIONS.md) | Honest limitations and reviewer context. |
+| [`PRISMA_MIGRATION_CHAIN.md`](./PRISMA_MIGRATION_CHAIN.md) | Prisma migration-chain notes and migration safety rules. |
+| [`ENVIRONMENT.md`](./ENVIRONMENT.md) | Environment variable setup for local, reviewer, and Vercel contexts. |
+
+## Reviewer paths
+
+### Product reviewer path
+
+1. Start with the public demo walkthrough.
+2. Review the product module map in [`FEATURE_MAP.md`](./FEATURE_MAP.md).
+3. Review the screenshots and public project narrative in the root `README.md`.
+4. Open the no-login demo routes and compare them with authenticated workflow coverage.
+
+### Technical reviewer path
+
+1. Read [`ARCHITECTURE.md`](./ARCHITECTURE.md).
+2. Review [`API_OVERVIEW.md`](./API_OVERVIEW.md) and [`MOBILE_DEVICE_API.md`](./MOBILE_DEVICE_API.md).
+3. Inspect `prisma/schema.prisma`, `lib/`, `app/`, and `tests/`.
+4. Run the standard local check commands from the patch instructions or deployment checklist.
+
+### Deployment reviewer path
+
+1. Read [`ENVIRONMENT.md`](./ENVIRONMENT.md).
+2. Confirm `.env.example` matches the target environment.
+3. Run `npm run db:validate:ci`, `npm run typecheck`, `npm run lint`, and `npm run test:run`.
+4. Check `/api/health` once deployed.
+
+## Documentation categories
+
+| Category | Files |
+|---|---|
+| Architecture and product | `ARCHITECTURE.md`, `FEATURE_MAP.md`, `FEATURE_MATRIX.md` |
+| API and integrations | `API_OVERVIEW.md`, `MOBILE_DEVICE_API.md`, mobile SDK examples under `examples/mobile-api/` |
+| Deployment and operations | `ENVIRONMENT.md`, `DEPLOYMENT_CHECKLIST.md`, `PRISMA_MIGRATION_CHAIN.md` |
+| Historical patch notes | `PATCH_*.md` files |
+| Known limits and QA | `KNOWN_LIMITATIONS.md`, demo and deployment checklists |
+
+## Notes on patch documentation
+
+The `PATCH_*.md` files are retained as implementation history. They are useful for understanding how the project evolved, but they are not the best starting point for reviewers. Prefer the overview documents above first, then use patch notes only when tracing a specific change.
+
+## Current high-level project shape
+
+VitaVault includes:
+
+- Health profile, medications, labs, vitals, symptoms, vaccinations, doctors, appointments, and documents.
+- Care-plan, visit-prep, notification, alert, reminder, and review-queue workflows.
+- Care-team sharing, care notes, and shared patient workspace foundations.
+- Report builder, saved report history, export center, emergency card, and print-ready packets.
+- AI insights workspace with source/trust review signals.
+- Mobile/device ingestion APIs, device connection management, provider connector abstractions, and SDK examples.
+- Admin, ops, jobs, security center, audit log, deployment readiness, and data quality surfaces.
+- Public no-login demo routes for reviewer-friendly inspection.


### PR DESCRIPTION
## Summary

This patch adds a clean documentation entrypoint and high-level reviewer maps for VitaVault.

## Changes

- Added `docs/README.md` as a documentation hub
- Added `docs/ARCHITECTURE.md` for system architecture, runtime layers, data flow, mobile/device APIs, jobs, reporting, and testing strategy
- Added `docs/FEATURE_MAP.md` to explain the product by workflow instead of patch history
- Added `docs/API_OVERVIEW.md` for route groups, mobile API surfaces, internal APIs, exports, and API safety expectations
- Added Patch 79 documentation under `docs/`

## Safety

- No Prisma migration
- No schema changes
- No dependency changes
- No runtime code changes
- No README changes

## Checks

Run locally:

```powershell
npm install
npm run db:validate:ci
npm run actions:check
npm run actions:imports
npm run actions:shadow
npm run typecheck
npm run lint
npm run test:run